### PR TITLE
Add notes new and new-todo commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: build test lint clean install
 
 BINARY := notes
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X github.com/dreikanter/notescli/internal/cli.Version=$(VERSION)
 
 build:
-	go build -o $(BINARY) ./cmd/notes
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/notes
 
 test:
 	go test ./...
@@ -15,4 +17,4 @@ clean:
 	rm -f $(BINARY)
 
 install:
-	go install ./cmd/notes
+	go install -ldflags "$(LDFLAGS)" ./cmd/notes

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+var (
+	newSlug        string
+	newTags        []string
+	newDescription string
+)
+
+var newCmd = &cobra.Command{
+	Use:   "new",
+	Short: "Create a new note",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+		today := time.Now().Format("20060102")
+
+		id, err := note.NextID(root)
+		if err != nil {
+			return err
+		}
+
+		filename := note.NoteFilename(today, id, newSlug)
+		dir := note.NoteDirPath(root, today)
+
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("cannot create directory %s: %w", dir, err)
+		}
+
+		fullPath := filepath.Join(dir, filename)
+
+		var content string
+
+		// Build frontmatter if tags or description provided
+		fm := note.BuildFrontmatter("", newTags, newDescription)
+		content = fm
+
+		// Read from stdin if piped
+		if !isTerminal(os.Stdin) {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("cannot read stdin: %w", err)
+			}
+			content += string(data)
+		}
+
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("cannot write note: %w", err)
+		}
+
+		fmt.Println(fullPath)
+		return nil
+	},
+}
+
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return true
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func init() {
+	newCmd.Flags().StringVar(&newSlug, "slug", "", "slug appended to filename")
+	newCmd.Flags().StringArrayVar(&newTags, "tag", nil, "tag for frontmatter (repeatable)")
+	newCmd.Flags().StringVar(&newDescription, "description", "", "description for frontmatter")
+	rootCmd.AddCommand(newCmd)
+}

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+var newTodoForce bool
+
+var newTodoCmd = &cobra.Command{
+	Use:   "new-todo",
+	Short: "Create today's todo from the previous todo",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+		today := time.Now().Format("20060102")
+
+		notes, err := note.Scan(root)
+		if err != nil {
+			return err
+		}
+
+		// Check if today's todo already exists
+		if !newTodoForce {
+			if existing := note.FindTodayTodo(root, notes, today); existing != nil {
+				fmt.Println(filepath.Join(root, existing.RelPath))
+				return nil
+			}
+		}
+
+		// Find the most recent previous todo
+		prev := note.FindLatestTodo(notes, today)
+		if prev == nil {
+			return fmt.Errorf("no previous todo found")
+		}
+
+		// Read previous todo content
+		prevPath := filepath.Join(root, prev.RelPath)
+		prevData, err := os.ReadFile(prevPath)
+		if err != nil {
+			return fmt.Errorf("cannot read previous todo: %w", err)
+		}
+		prevLines := strings.Split(string(prevData), "\n")
+
+		// Rollover tasks
+		result := note.RolloverTasks(prevLines, newTodoForce)
+
+		// Write back modified previous todo
+		if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
+			return fmt.Errorf("cannot update previous todo: %w", err)
+		}
+
+		// Allocate new ID and create new todo
+		id, err := note.NextID(root)
+		if err != nil {
+			return err
+		}
+
+		filename := note.NoteFilename(today, id, "todo")
+		dir := note.NoteDirPath(root, today)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("cannot create directory %s: %w", dir, err)
+		}
+
+		fullPath := filepath.Join(dir, filename)
+		content := note.FormatTodoContent(result.CarriedTasks)
+
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("cannot write todo: %w", err)
+		}
+
+		fmt.Println(fullPath)
+		return nil
+	},
+}
+
+func init() {
+	newTodoCmd.Flags().BoolVar(&newTodoForce, "force", false, "regenerate today's todo even if it exists, and carry over in-progress tasks")
+	rootCmd.AddCommand(newTodoCmd)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var notesPath string
+var (
+	notesPath string
+	Version   = "dev"
+)
 
 var rootCmd = &cobra.Command{
 	Use:          "notes",
@@ -18,6 +21,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.Version = Version
 	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes archive (overrides NOTES_PATH env var)")
 }
 

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -1,0 +1,25 @@
+package note
+
+import "strings"
+
+// BuildFrontmatter generates YAML frontmatter from the given fields.
+// Returns empty string if no fields are provided.
+func BuildFrontmatter(slug string, tags []string, description string) string {
+	var lines []string
+
+	if slug != "" {
+		lines = append(lines, "slug: "+slug)
+	}
+	if len(tags) > 0 {
+		lines = append(lines, "tags: ["+strings.Join(tags, ", ")+"]")
+	}
+	if description != "" {
+		lines = append(lines, "description: "+description)
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return "---\n" + strings.Join(lines, "\n") + "\n---\n\n"
+}

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -1,0 +1,54 @@
+package note
+
+import "testing"
+
+func TestBuildFrontmatter(t *testing.T) {
+	tests := []struct {
+		name        string
+		slug        string
+		tags        []string
+		description string
+		want        string
+	}{
+		{
+			name: "empty",
+			want: "",
+		},
+		{
+			name: "slug only",
+			slug: "todo",
+			want: "---\nslug: todo\n---\n\n",
+		},
+		{
+			name: "tags only",
+			tags: []string{"journal", "idea"},
+			want: "---\ntags: [journal, idea]\n---\n\n",
+		},
+		{
+			name:        "description only",
+			description: "Quick thought",
+			want:        "---\ndescription: Quick thought\n---\n\n",
+		},
+		{
+			name:        "all fields",
+			slug:        "weekly",
+			tags:        []string{"review"},
+			description: "Week 10",
+			want:        "---\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
+		},
+		{
+			name: "single tag",
+			tags: []string{"journal"},
+			want: "---\ntags: [journal]\n---\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildFrontmatter(tt.slug, tt.tags, tt.description)
+			if got != tt.want {
+				t.Errorf("BuildFrontmatter(%q, %v, %q) =\n%q\nwant:\n%q", tt.slug, tt.tags, tt.description, got, tt.want)
+			}
+		})
+	}
+}

--- a/note/id.go
+++ b/note/id.go
@@ -1,0 +1,69 @@
+package note
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// IDFile represents the id.json file that tracks the last allocated note ID.
+type IDFile struct {
+	LastID int `json:"last_id"`
+}
+
+// ReadID reads the current last_id from id.json in the archive root.
+func ReadID(root string) (IDFile, error) {
+	data, err := os.ReadFile(filepath.Join(root, "id.json"))
+	if err != nil {
+		return IDFile{}, fmt.Errorf("cannot read id.json: %w", err)
+	}
+	var idf IDFile
+	if err := json.Unmarshal(data, &idf); err != nil {
+		return IDFile{}, fmt.Errorf("cannot parse id.json: %w", err)
+	}
+	return idf, nil
+}
+
+// NextID reads id.json, increments last_id, writes it back atomically, and returns the new ID.
+func NextID(root string) (int, error) {
+	idf, err := ReadID(root)
+	if err != nil {
+		return 0, err
+	}
+	idf.LastID++
+	if err := WriteID(root, idf); err != nil {
+		return 0, err
+	}
+	return idf.LastID, nil
+}
+
+// WriteID atomically writes the IDFile to id.json using a temp file + rename.
+func WriteID(root string, idf IDFile) error {
+	data, err := json.Marshal(idf)
+	if err != nil {
+		return fmt.Errorf("cannot marshal id.json: %w", err)
+	}
+
+	target := filepath.Join(root, "id.json")
+	tmp, err := os.CreateTemp(root, "id-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("cannot create temp file for id.json: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("cannot write temp id.json: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("cannot close temp id.json: %w", err)
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("cannot rename temp id.json: %w", err)
+	}
+	return nil
+}

--- a/note/id_test.go
+++ b/note/id_test.go
@@ -1,0 +1,93 @@
+package note
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadID(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644)
+
+	idf, err := ReadID(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idf.LastID != 9218 {
+		t.Errorf("got LastID=%d, want 9218", idf.LastID)
+	}
+}
+
+func TestReadIDMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ReadID(dir)
+	if err == nil {
+		t.Fatal("expected error for missing id.json")
+	}
+}
+
+func TestReadIDInvalid(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`not json`), 0o644)
+
+	_, err := ReadID(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestNextID(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644)
+
+	id, err := NextID(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 9219 {
+		t.Errorf("got id=%d, want 9219", id)
+	}
+
+	// Verify file was updated
+	idf, err := ReadID(dir)
+	if err != nil {
+		t.Fatalf("unexpected error reading back: %v", err)
+	}
+	if idf.LastID != 9219 {
+		t.Errorf("got LastID=%d after write, want 9219", idf.LastID)
+	}
+}
+
+func TestNextIDConsecutive(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 100}`), 0o644)
+
+	id1, _ := NextID(dir)
+	id2, _ := NextID(dir)
+
+	if id1 != 101 {
+		t.Errorf("first call: got %d, want 101", id1)
+	}
+	if id2 != 102 {
+		t.Errorf("second call: got %d, want 102", id2)
+	}
+}
+
+func TestWriteIDAtomic(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 0}`), 0o644)
+
+	err := WriteID(dir, IDFile{LastID: 42})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No temp files should remain
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() != "id.json" {
+			t.Errorf("unexpected file left behind: %s", e.Name())
+		}
+	}
+}

--- a/note/todo.go
+++ b/note/todo.go
@@ -1,0 +1,157 @@
+package note
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// taskRe matches lines like "  - [ ] some task" or "[ ] some task" or "  [>] task".
+var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.?)(\].*)$`)
+
+// Task represents a parsed task line from a todo note.
+type Task struct {
+	Line       string // original full line
+	Prefix     string // everything before the marker character: e.g. "  - ["
+	Marker     string // single char marker: " ", ">", "+", etc.
+	Suffix     string // everything after marker: e.g. "] some task"
+	IsDaily    bool   // whether line contains [daily]
+	LineNumber int    // 0-based index in the source file lines
+}
+
+// ParseTask attempts to parse a line as a task. Returns nil if not a task line.
+func ParseTask(line string, lineNumber int) *Task {
+	m := taskRe.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+	return &Task{
+		Line:       line,
+		Prefix:     m[1],
+		Marker:     m[2],
+		Suffix:     m[3],
+		IsDaily:    strings.Contains(line, "[daily]"),
+		LineNumber: lineNumber,
+	}
+}
+
+// Reassembled returns the task line with a new marker.
+func (t *Task) Reassembled(marker string) string {
+	return t.Prefix + marker + t.Suffix
+}
+
+// ExtractTasks parses all task lines from a todo file's content lines.
+func ExtractTasks(lines []string) []Task {
+	var tasks []Task
+	for i, line := range lines {
+		if t := ParseTask(line, i); t != nil {
+			tasks = append(tasks, *t)
+		}
+	}
+	return tasks
+}
+
+// RolloverResult holds the output of a todo rollover operation.
+type RolloverResult struct {
+	CarriedTasks []Task   // tasks to include in the new todo
+	UpdatedLines []string // modified lines of the previous todo (with [ ] → [>])
+}
+
+// RolloverTasks determines which tasks to carry over and produces the modified previous todo.
+// If force is true, also carry over in-progress [>] tasks.
+func RolloverTasks(prevLines []string, force bool) RolloverResult {
+	tasks := ExtractTasks(prevLines)
+	updated := make([]string, len(prevLines))
+	copy(updated, prevLines)
+
+	seen := make(map[string]bool) // normalized task text to prevent duplicates
+	var carried []Task
+
+	addTask := func(t Task) {
+		// Normalize: strip leading whitespace, bullet, and marker for dedup
+		key := strings.TrimSpace(t.Suffix)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		carried = append(carried, t)
+	}
+
+	for _, t := range tasks {
+		switch {
+		case t.IsDaily:
+			// Daily tasks are always carried over regardless of marker
+			addTask(t)
+			// If the task was pending, mark as forwarded in previous
+			if t.Marker == " " {
+				updated[t.LineNumber] = t.Reassembled(">")
+			}
+		case t.Marker == " ":
+			// Pending tasks: carry over and mark as forwarded
+			addTask(t)
+			updated[t.LineNumber] = t.Reassembled(">")
+		case t.Marker == ">" && force:
+			// In-progress tasks: only carry over with --force
+			addTask(t)
+		}
+	}
+
+	return RolloverResult{
+		CarriedTasks: carried,
+		UpdatedLines: updated,
+	}
+}
+
+// FormatTodoContent formats carried tasks into the new todo file content.
+func FormatTodoContent(tasks []Task) string {
+	fm := BuildFrontmatter("todo", nil, "")
+
+	if len(tasks) == 0 {
+		return fm
+	}
+
+	var lines []string
+	for _, t := range tasks {
+		// Reset marker to pending [ ]
+		lines = append(lines, t.Reassembled(" "))
+	}
+
+	return fm + strings.Join(lines, "\n\n") + "\n"
+}
+
+// FindLatestTodo finds the most recent todo note strictly before the given date.
+func FindLatestTodo(notes []Note, beforeDate string) *Note {
+	// notes are sorted newest-first
+	for i := range notes {
+		if notes[i].Slug == "todo" && notes[i].Date < beforeDate {
+			return &notes[i]
+		}
+	}
+	return nil
+}
+
+// FindTodayTodo finds a todo note matching today's date.
+func FindTodayTodo(root string, notes []Note, today string) *Note {
+	for i := range notes {
+		if notes[i].Slug == "todo" && notes[i].Date == today {
+			return &notes[i]
+		}
+	}
+	return nil
+}
+
+// NoteFilename generates a note filename from date, id, and optional slug.
+func NoteFilename(date string, id int, slug string) string {
+	if slug != "" {
+		return fmt.Sprintf("%s_%d_%s.md", date, id, slug)
+	}
+	return fmt.Sprintf("%s_%d.md", date, id)
+}
+
+// NoteDirPath returns the YYYY/MM directory path for a given date string (YYYYMMDD).
+func NoteDirPath(root, date string) string {
+	year := date[:4]
+	month := date[4:6]
+	return filepath.Join(root, year, month)
+}

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -1,0 +1,276 @@
+package note
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTask(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantNil bool
+		marker  string
+		isDaily bool
+	}{
+		{"pending", "[ ] Buy milk", false, " ", false},
+		{"pending with bullet", "- [ ] Buy milk", false, " ", false},
+		{"pending indented", "  [ ] Buy milk", false, " ", false},
+		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false},
+		{"in progress", "[>] Working on it", false, ">", false},
+		{"completed", "[+] Done task", false, "+", false},
+		{"daily", "[ ] Standup [daily]", false, " ", true},
+		{"daily completed", "[+] Standup [daily]", false, "+", true},
+		{"not a task", "Just a regular line", true, "", false},
+		{"empty", "", true, "", false},
+		{"header", "# Todo", true, "", false},
+		{"frontmatter", "---", true, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := ParseTask(tt.line, 0)
+			if tt.wantNil {
+				if task != nil {
+					t.Errorf("expected nil for %q, got %+v", tt.line, task)
+				}
+				return
+			}
+			if task == nil {
+				t.Fatalf("expected non-nil for %q", tt.line)
+			}
+			if task.Marker != tt.marker {
+				t.Errorf("marker: got %q, want %q", task.Marker, tt.marker)
+			}
+			if task.IsDaily != tt.isDaily {
+				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)
+			}
+		})
+	}
+}
+
+func TestReassembled(t *testing.T) {
+	task := ParseTask("  - [ ] Some task", 0)
+	if task == nil {
+		t.Fatal("expected task")
+	}
+	got := task.Reassembled(">")
+	want := "  - [>] Some task"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRolloverTasks(t *testing.T) {
+	prev := strings.Split(`---
+slug: todo
+---
+
+[ ] Pending task one
+
+[ ] Pending task two
+
+[>] In progress task
+
+[+] Completed task
+
+[ ] Standup [daily]`, "\n")
+
+	result := RolloverTasks(prev, false)
+
+	// Should carry over: pending task one, pending task two, standup daily
+	if len(result.CarriedTasks) != 3 {
+		t.Fatalf("carried %d tasks, want 3", len(result.CarriedTasks))
+	}
+
+	// Verify previous todo was updated: pending tasks → [>]
+	for _, line := range result.UpdatedLines {
+		if strings.Contains(line, "Pending task one") && !strings.Contains(line, "[>]") {
+			t.Errorf("pending task one should be [>] in updated lines, got: %s", line)
+		}
+		if strings.Contains(line, "Pending task two") && !strings.Contains(line, "[>]") {
+			t.Errorf("pending task two should be [>] in updated lines, got: %s", line)
+		}
+	}
+
+	// In-progress task should NOT be modified in updated lines
+	for _, line := range result.UpdatedLines {
+		if strings.Contains(line, "In progress task") && !strings.Contains(line, "[>]") {
+			t.Errorf("in-progress task should remain [>], got: %s", line)
+		}
+	}
+}
+
+func TestRolloverTasksForce(t *testing.T) {
+	prev := strings.Split(`[ ] Pending task
+
+[>] In progress task
+
+[+] Completed task`, "\n")
+
+	result := RolloverTasks(prev, true)
+
+	// With force: carry pending + in-progress
+	if len(result.CarriedTasks) != 2 {
+		t.Fatalf("carried %d tasks, want 2", len(result.CarriedTasks))
+	}
+
+	markers := make(map[string]bool)
+	for _, task := range result.CarriedTasks {
+		if strings.Contains(task.Suffix, "Pending") {
+			markers["pending"] = true
+		}
+		if strings.Contains(task.Suffix, "In progress") {
+			markers["in-progress"] = true
+		}
+	}
+	if !markers["pending"] || !markers["in-progress"] {
+		t.Error("expected both pending and in-progress tasks to be carried over with force")
+	}
+}
+
+func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
+	prev := strings.Split(`[+] Standup [daily]
+
+[+] Completed other task`, "\n")
+
+	result := RolloverTasks(prev, false)
+
+	if len(result.CarriedTasks) != 1 {
+		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
+	}
+	if !strings.Contains(result.CarriedTasks[0].Suffix, "Standup") {
+		t.Error("expected daily task to be carried over")
+	}
+}
+
+func TestRolloverTasksNoDuplicates(t *testing.T) {
+	// A daily task that is also pending should appear only once
+	prev := strings.Split(`[ ] Standup [daily]`, "\n")
+
+	result := RolloverTasks(prev, false)
+
+	if len(result.CarriedTasks) != 1 {
+		t.Fatalf("carried %d tasks, want 1 (no duplicates)", len(result.CarriedTasks))
+	}
+}
+
+func TestRolloverTasksEmpty(t *testing.T) {
+	prev := strings.Split(`---
+slug: todo
+---
+
+[+] Everything done`, "\n")
+
+	result := RolloverTasks(prev, false)
+
+	if len(result.CarriedTasks) != 0 {
+		t.Errorf("carried %d tasks, want 0", len(result.CarriedTasks))
+	}
+}
+
+func TestFormatTodoContent(t *testing.T) {
+	tasks := []Task{
+		{Prefix: "[", Marker: " ", Suffix: "] Task one"},
+		{Prefix: "[", Marker: ">", Suffix: "] Task two"},
+	}
+
+	content := FormatTodoContent(tasks)
+
+	if !strings.HasPrefix(content, "---\nslug: todo\n---\n\n") {
+		t.Errorf("missing frontmatter, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[ ] Task one") {
+		t.Error("expected Task one with reset marker")
+	}
+	if !strings.Contains(content, "[ ] Task two") {
+		t.Error("expected Task two with reset marker")
+	}
+	// Tasks separated by blank lines
+	if !strings.Contains(content, "[ ] Task one\n\n[ ] Task two") {
+		t.Errorf("tasks should be separated by blank lines, got:\n%s", content)
+	}
+}
+
+func TestFormatTodoContentEmpty(t *testing.T) {
+	content := FormatTodoContent(nil)
+	want := "---\nslug: todo\n---\n\n"
+	if content != want {
+		t.Errorf("got:\n%q\nwant:\n%q", content, want)
+	}
+}
+
+func TestNoteFilename(t *testing.T) {
+	tests := []struct {
+		date string
+		id   int
+		slug string
+		want string
+	}{
+		{"20260312", 9219, "", "20260312_9219.md"},
+		{"20260312", 9219, "my-note", "20260312_9219_my-note.md"},
+		{"20260312", 9219, "todo", "20260312_9219_todo.md"},
+	}
+
+	for _, tt := range tests {
+		got := NoteFilename(tt.date, tt.id, tt.slug)
+		if got != tt.want {
+			t.Errorf("NoteFilename(%q, %d, %q) = %q, want %q", tt.date, tt.id, tt.slug, got, tt.want)
+		}
+	}
+}
+
+func TestNoteDirPath(t *testing.T) {
+	got := NoteDirPath("/archive", "20260312")
+	want := "/archive/2026/03"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFindLatestTodo(t *testing.T) {
+	notes := []Note{
+		{Date: "20260312", Slug: "todo", RelPath: "2026/03/20260312_100_todo.md"},
+		{Date: "20260311", Slug: "todo", RelPath: "2026/03/20260311_99_todo.md"},
+		{Date: "20260310", Slug: "", RelPath: "2026/03/20260310_98.md"},
+		{Date: "20260309", Slug: "todo", RelPath: "2026/03/20260309_97_todo.md"},
+	}
+
+	got := FindLatestTodo(notes, "20260312")
+	if got == nil {
+		t.Fatal("expected to find a todo")
+	}
+	if got.Date != "20260311" {
+		t.Errorf("got date %s, want 20260311", got.Date)
+	}
+}
+
+func TestFindLatestTodoNone(t *testing.T) {
+	notes := []Note{
+		{Date: "20260312", Slug: "todo"},
+	}
+	got := FindLatestTodo(notes, "20260312")
+	if got != nil {
+		t.Error("expected nil when no previous todo exists")
+	}
+}
+
+func TestFindTodayTodo(t *testing.T) {
+	notes := []Note{
+		{Date: "20260312", Slug: "todo", RelPath: "2026/03/20260312_100_todo.md"},
+		{Date: "20260311", Slug: "todo", RelPath: "2026/03/20260311_99_todo.md"},
+	}
+
+	got := FindTodayTodo("/archive", notes, "20260312")
+	if got == nil {
+		t.Fatal("expected to find today's todo")
+	}
+	if got.Date != "20260312" {
+		t.Errorf("got date %s, want 20260312", got.Date)
+	}
+
+	got = FindTodayTodo("/archive", notes, "20260313")
+	if got != nil {
+		t.Error("expected nil for future date")
+	}
+}


### PR DESCRIPTION
Implement note creation and daily todo management with task rollover.

**Changes:**
- `notes new` command: creates notes with auto-incremented IDs, optional slug/tags/description, handles piped stdin
- `notes new-todo` command: idempotent daily todo with automatic task rollover from previous day
- Task parsing with [daily] tag support for automatic carry-over
- Atomic id.json updates using temp file + rename pattern
- Version support via git tags and ldflags injection
- Comprehensive test coverage for ID management, frontmatter, and task rollover logic