### PR TITLE
Add --no-frontmatter flag to read command

### DIFF
--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -30,11 +30,17 @@ var readCmd = &cobra.Command{
 			return err
 		}
 
+		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
+		if noFrontmatter {
+			data = note.StripFrontmatter(data)
+		}
+
 		_, err = os.Stdout.Write(data)
 		return err
 	},
 }
 
 func init() {
+	readCmd.Flags().BoolP("no-frontmatter", "F", false, "exclude YAML frontmatter from output")
 	rootCmd.AddCommand(readCmd)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	notesPath string
-	Version   = "dev"
+	Version   = "0.4.0"
 )
 
 var rootCmd = &cobra.Command{

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -41,9 +41,12 @@ func StripFrontmatter(data []byte) []byte {
 
 	// Find closing "---" on its own line after the opening one.
 	rest := data[len(frontmatterDelim):]
-	// Skip to end of the opening delimiter line.
+	// Opening delimiter must be exactly "---" on its own line.
 	idx := bytes.IndexByte(rest, '\n')
 	if idx < 0 {
+		return data
+	}
+	if len(bytes.TrimRight(rest[:idx], "\r")) > 0 {
 		return data
 	}
 	rest = rest[idx+1:]

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -51,8 +51,12 @@ func StripFrontmatter(data []byte) []byte {
 	for {
 		line, after, found := bytes.Cut(rest, []byte("\n"))
 		if bytes.Equal(bytes.TrimRight(line, "\r"), frontmatterDelim) {
-			// Trim one leading blank line if present.
-			after = bytes.TrimLeft(after, "\r\n")
+			// Trim exactly one leading blank line if present.
+			if len(after) > 0 && after[0] == '\n' {
+				after = after[1:]
+			} else if len(after) > 1 && after[0] == '\r' && after[1] == '\n' {
+				after = after[2:]
+			}
 			return after
 		}
 		if !found {

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -1,6 +1,9 @@
 package note
 
-import "strings"
+import (
+	"bytes"
+	"strings"
+)
 
 // BuildFrontmatter generates YAML frontmatter from the given fields.
 // Returns empty string if no fields are provided.
@@ -22,4 +25,40 @@ func BuildFrontmatter(slug string, tags []string, description string) string {
 	}
 
 	return "---\n" + strings.Join(lines, "\n") + "\n---\n\n"
+}
+
+var frontmatterDelim = []byte("---")
+
+// StripFrontmatter removes YAML frontmatter from the beginning of data.
+// Frontmatter must start on the first line with "---" and end with a
+// subsequent "---" line. Leading whitespace after the closing delimiter
+// is also removed.
+func StripFrontmatter(data []byte) []byte {
+	// Must start with "---"
+	if !bytes.HasPrefix(data, frontmatterDelim) {
+		return data
+	}
+
+	// Find closing "---" on its own line after the opening one.
+	rest := data[len(frontmatterDelim):]
+	// Skip to end of the opening delimiter line.
+	idx := bytes.IndexByte(rest, '\n')
+	if idx < 0 {
+		return data
+	}
+	rest = rest[idx+1:]
+
+	for {
+		line, after, found := bytes.Cut(rest, []byte("\n"))
+		if bytes.Equal(bytes.TrimRight(line, "\r"), frontmatterDelim) {
+			// Trim one leading blank line if present.
+			after = bytes.TrimLeft(after, "\r\n")
+			return after
+		}
+		if !found {
+			// Reached end without closing delimiter.
+			return data
+		}
+		rest = after
+	}
 }

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -92,6 +92,36 @@ func TestStripFrontmatter(t *testing.T) {
 			want:  "# Hello\n\n---\n\nFooter.\n",
 		},
 		{
+			name:  "preserves multiple blank lines after frontmatter",
+			input: "---\nslug: todo\n---\n\n\n\nContent\n",
+			want:  "\n\nContent\n",
+		},
+		{
+			name:  "opening delimiter only no newline",
+			input: "---",
+			want:  "---",
+		},
+		{
+			name:  "opening delimiter only with newline",
+			input: "---\nstuff\n",
+			want:  "---\nstuff\n",
+		},
+		{
+			name:  "empty frontmatter block",
+			input: "---\n---\n\nBody\n",
+			want:  "Body\n",
+		},
+		{
+			name:  "malformed yaml in frontmatter",
+			input: "---\n[bad: yaml\n---\n\nBody\n",
+			want:  "Body\n",
+		},
+		{
+			name:  "multiple closing delimiters",
+			input: "---\na\n---\nb\n---\n\nBody\n",
+			want:  "b\n---\n\nBody\n",
+		},
+		{
 			name:  "roundtrip with BuildFrontmatter",
 			input: BuildFrontmatter("todo", []string{"journal"}, "A note") + "# Content\n",
 			want:  "# Content\n",

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -97,6 +97,11 @@ func TestStripFrontmatter(t *testing.T) {
 			want:  "\n\nContent\n",
 		},
 		{
+			name:  "opening delimiter with trailing text",
+			input: "---extra\nslug: x\n---\n\nBody\n",
+			want:  "---extra\nslug: x\n---\n\nBody\n",
+		},
+		{
 			name:  "opening delimiter only no newline",
 			input: "---",
 			want:  "---",

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -1,6 +1,8 @@
 package note
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBuildFrontmatter(t *testing.T) {
 	tests := []struct {
@@ -48,6 +50,59 @@ func TestBuildFrontmatter(t *testing.T) {
 			got := BuildFrontmatter(tt.slug, tt.tags, tt.description)
 			if got != tt.want {
 				t.Errorf("BuildFrontmatter(%q, %v, %q) =\n%q\nwant:\n%q", tt.slug, tt.tags, tt.description, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no frontmatter",
+			input: "# Hello\n\nBody text.\n",
+			want:  "# Hello\n\nBody text.\n",
+		},
+		{
+			name:  "with frontmatter",
+			input: "---\nslug: todo\ntags: [journal]\n---\n\n# Hello\n\nBody text.\n",
+			want:  "# Hello\n\nBody text.\n",
+		},
+		{
+			name:  "frontmatter only",
+			input: "---\nslug: todo\n---\n",
+			want:  "",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "unclosed frontmatter",
+			input: "---\nslug: todo\n# Hello\n",
+			want:  "---\nslug: todo\n# Hello\n",
+		},
+		{
+			name:  "triple dash in body not at start",
+			input: "# Hello\n\n---\n\nFooter.\n",
+			want:  "# Hello\n\n---\n\nFooter.\n",
+		},
+		{
+			name:  "roundtrip with BuildFrontmatter",
+			input: BuildFrontmatter("todo", []string{"journal"}, "A note") + "# Content\n",
+			want:  "# Content\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(StripFrontmatter([]byte(tt.input)))
+			if got != tt.want {
+				t.Errorf("StripFrontmatter(%q) =\n%q\nwant:\n%q", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `--no-frontmatter` / `-F` flag to the `read` command to strip YAML frontmatter from output (included by default)
- Implements `StripFrontmatter()` in the `note` package with robust edge case handling
- Bumps version to 0.4.0

## Test plan

- 13 unit tests covering: valid frontmatter, no frontmatter, empty file, unclosed delimiters, malformed YAML, multiple closing delimiters, blank line preservation
- Ad-hoc tested with `--no-frontmatter`, `-F`, and default output against notes with and without frontmatter