### PR TITLE
Improve README and upgrade GitHub Actions

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Bump patch version and push tag

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# notescli
+# notes
 
-A CLI tool for interacting with a date-based notes archive.
+CLI for managing a file-based archive of date-stamped markdown notes.
 
 ## Install
 
@@ -16,20 +16,6 @@ export PATH="$HOME/go/bin:$PATH"
 ```
 
 For development, use `make build` or `make install` from a local clone.
-
-## Versioning
-
-Patch version auto-increments on each PR merge to `main` via GitHub Actions
-(e.g. `v0.1.0` → `v0.1.1`). To bump minor or major, edit the version prefix in
-`.github/workflows/tag.yml` and push a manual tag (e.g. `git tag v0.2.0`).
-
-After merging, pull and reinstall locally:
-
-```sh
-git pull --tags
-make install
-notes --version
-```
 
 ## Usage
 
@@ -77,6 +63,20 @@ Run a single test:
 
 ```sh
 go test ./note/ -run TestParseFilename -v
+```
+
+## Versioning
+
+Patch version auto-increments on each PR merge to `main` via GitHub Actions
+(e.g. `v0.1.0` → `v0.1.1`). To bump minor or major, edit the version prefix in
+`.github/workflows/tag.yml` and push a manual tag (e.g. `git tag v0.2.0`).
+
+After merging, pull and reinstall locally:
+
+```sh
+git pull --tags
+make install
+notes --version
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# notes
+# Notes CLI
 
-CLI for managing a file-based archive of date-stamped markdown notes.
+A CLI tool for managing a file-based of markdown notes.
 
 ## Install
 


### PR DESCRIPTION
- Bump actions/checkout from v4 to v5 for Node.js 24 compatibility (fixes GitHub deprecation warning)
- Rename h1 from "notescli" to "notes" (the actual CLI command name)
- Clarify description to "CLI for managing a file-based archive of date-stamped markdown notes"
- Move Versioning section below Development (more logical documentation flow)