### PR TITLE
Generalize root command description

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,7 +17,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "notes",
 	Short:        "Interact with a notes archive",
-	Long:         "A CLI tool for reading, filtering, and listing notes in a date-based archive.",
+	Long:         "A CLI tool for managing Markdown notes on the local file system.",
 	SilenceUsage: true,
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,7 +17,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "notes",
 	Short:        "Interact with a notes archive",
-	Long:         "A CLI tool for managing Markdown notes on the local file system.",
+	Long:         "A command-line Markdown notes manager.",
 	SilenceUsage: true,
 }
 


### PR DESCRIPTION
Replace the verbose Long description with a concise one: "A command-line Markdown notes manager." Drops redundant details (specific operations, storage model) to keep it future-proof.