### PR TITLE
Add --title flag to new command

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -15,6 +15,7 @@ var (
 	newSlug        string
 	newTags        []string
 	newDescription string
+	newTitle       string
 )
 
 var newCmd = &cobra.Command{
@@ -42,7 +43,7 @@ var newCmd = &cobra.Command{
 		var content string
 
 		// Build frontmatter if tags or description provided
-		fm := note.BuildFrontmatter("", newTags, newDescription)
+		fm := note.BuildFrontmatter("", newTags, newDescription, newTitle)
 		content = fm
 
 		// Read from stdin if piped
@@ -75,5 +76,6 @@ func init() {
 	newCmd.Flags().StringVar(&newSlug, "slug", "", "slug appended to filename")
 	newCmd.Flags().StringArrayVar(&newTags, "tag", nil, "tag for frontmatter (repeatable)")
 	newCmd.Flags().StringVar(&newDescription, "description", "", "description for frontmatter")
+	newCmd.Flags().StringVar(&newTitle, "title", "", "title for frontmatter")
 	rootCmd.AddCommand(newCmd)
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -40,15 +40,11 @@ var newCmd = &cobra.Command{
 
 		fullPath := filepath.Join(dir, filename)
 
-		var content string
-
-		// Build frontmatter if tags or description provided
-		fm := note.BuildFrontmatter(note.FrontmatterFields{
+		content := note.BuildFrontmatter(note.FrontmatterFields{
 			Title:       newTitle,
 			Tags:        newTags,
 			Description: newDescription,
 		})
-		content = fm
 
 		// Read from stdin if piped
 		if !isTerminal(os.Stdin) {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -43,7 +43,11 @@ var newCmd = &cobra.Command{
 		var content string
 
 		// Build frontmatter if tags or description provided
-		fm := note.BuildFrontmatter("", newTags, newDescription, newTitle)
+		fm := note.BuildFrontmatter(note.FrontmatterFields{
+			Title:       newTitle,
+			Tags:        newTags,
+			Description: newDescription,
+		})
 		content = fm
 
 		// Read from stdin if piped

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -8,7 +8,6 @@ import (
 // FrontmatterFields holds optional fields for note frontmatter.
 type FrontmatterFields struct {
 	Title       string
-	Slug        string
 	Tags        []string
 	Description string
 }
@@ -20,9 +19,6 @@ func BuildFrontmatter(f FrontmatterFields) string {
 
 	if f.Title != "" {
 		lines = append(lines, "title: "+f.Title)
-	}
-	if f.Slug != "" {
-		lines = append(lines, "slug: "+f.Slug)
 	}
 	if len(f.Tags) > 0 {
 		lines = append(lines, "tags: ["+strings.Join(f.Tags, ", ")+"]")

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -7,9 +7,12 @@ import (
 
 // BuildFrontmatter generates YAML frontmatter from the given fields.
 // Returns empty string if no fields are provided.
-func BuildFrontmatter(slug string, tags []string, description string) string {
+func BuildFrontmatter(slug string, tags []string, description string, title string) string {
 	var lines []string
 
+	if title != "" {
+		lines = append(lines, "title: "+title)
+	}
 	if slug != "" {
 		lines = append(lines, "slug: "+slug)
 	}

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -5,22 +5,30 @@ import (
 	"strings"
 )
 
+// FrontmatterFields holds optional fields for note frontmatter.
+type FrontmatterFields struct {
+	Title       string
+	Slug        string
+	Tags        []string
+	Description string
+}
+
 // BuildFrontmatter generates YAML frontmatter from the given fields.
 // Returns empty string if no fields are provided.
-func BuildFrontmatter(slug string, tags []string, description string, title string) string {
+func BuildFrontmatter(f FrontmatterFields) string {
 	var lines []string
 
-	if title != "" {
-		lines = append(lines, "title: "+title)
+	if f.Title != "" {
+		lines = append(lines, "title: "+f.Title)
 	}
-	if slug != "" {
-		lines = append(lines, "slug: "+slug)
+	if f.Slug != "" {
+		lines = append(lines, "slug: "+f.Slug)
 	}
-	if len(tags) > 0 {
-		lines = append(lines, "tags: ["+strings.Join(tags, ", ")+"]")
+	if len(f.Tags) > 0 {
+		lines = append(lines, "tags: ["+strings.Join(f.Tags, ", ")+"]")
 	}
-	if description != "" {
-		lines = append(lines, "description: "+description)
+	if f.Description != "" {
+		lines = append(lines, "description: "+f.Description)
 	}
 
 	if len(lines) == 0 {

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -10,6 +10,7 @@ func TestBuildFrontmatter(t *testing.T) {
 		slug        string
 		tags        []string
 		description string
+		title       string
 		want        string
 	}{
 		{
@@ -36,20 +37,26 @@ func TestBuildFrontmatter(t *testing.T) {
 			slug:        "weekly",
 			tags:        []string{"review"},
 			description: "Week 10",
-			want:        "---\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
+			title:       "Weekly Review",
+			want:        "---\ntitle: Weekly Review\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
 		},
 		{
 			name: "single tag",
 			tags: []string{"journal"},
 			want: "---\ntags: [journal]\n---\n\n",
 		},
+		{
+			name:  "title only",
+			title: "My Note",
+			want:  "---\ntitle: My Note\n---\n\n",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildFrontmatter(tt.slug, tt.tags, tt.description)
+			got := BuildFrontmatter(tt.slug, tt.tags, tt.description, tt.title)
 			if got != tt.want {
-				t.Errorf("BuildFrontmatter(%q, %v, %q) =\n%q\nwant:\n%q", tt.slug, tt.tags, tt.description, got, tt.want)
+				t.Errorf("BuildFrontmatter(%q, %v, %q, %q) =\n%q\nwant:\n%q", tt.slug, tt.tags, tt.description, tt.title, got, tt.want)
 			}
 		})
 	}
@@ -128,7 +135,7 @@ func TestStripFrontmatter(t *testing.T) {
 		},
 		{
 			name:  "roundtrip with BuildFrontmatter",
-			input: BuildFrontmatter("todo", []string{"journal"}, "A note") + "# Content\n",
+			input: BuildFrontmatter("todo", []string{"journal"}, "A note", "") + "# Content\n",
 			want:  "# Content\n",
 		},
 	}

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -15,11 +15,6 @@ func TestBuildFrontmatter(t *testing.T) {
 			want: "",
 		},
 		{
-			name:   "slug only",
-			fields: FrontmatterFields{Slug: "todo"},
-			want:   "---\nslug: todo\n---\n\n",
-		},
-		{
 			name:   "tags only",
 			fields: FrontmatterFields{Tags: []string{"journal", "idea"}},
 			want:   "---\ntags: [journal, idea]\n---\n\n",
@@ -33,11 +28,10 @@ func TestBuildFrontmatter(t *testing.T) {
 			name: "all fields",
 			fields: FrontmatterFields{
 				Title:       "Weekly Review",
-				Slug:        "weekly",
 				Tags:        []string{"review"},
 				Description: "Week 10",
 			},
-			want: "---\ntitle: Weekly Review\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
+			want: "---\ntitle: Weekly Review\ntags: [review]\ndescription: Week 10\n---\n\n",
 		},
 		{
 			name:   "single tag",
@@ -134,7 +128,7 @@ func TestStripFrontmatter(t *testing.T) {
 		},
 		{
 			name:  "roundtrip with BuildFrontmatter",
-			input: BuildFrontmatter(FrontmatterFields{Slug: "todo", Tags: []string{"journal"}, Description: "A note"}) + "# Content\n",
+			input: BuildFrontmatter(FrontmatterFields{Tags: []string{"journal"}, Description: "A note"}) + "# Content\n",
 			want:  "# Content\n",
 		},
 	}

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -6,57 +6,56 @@ import (
 
 func TestBuildFrontmatter(t *testing.T) {
 	tests := []struct {
-		name        string
-		slug        string
-		tags        []string
-		description string
-		title       string
-		want        string
+		name   string
+		fields FrontmatterFields
+		want   string
 	}{
 		{
 			name: "empty",
 			want: "",
 		},
 		{
-			name: "slug only",
-			slug: "todo",
-			want: "---\nslug: todo\n---\n\n",
+			name:   "slug only",
+			fields: FrontmatterFields{Slug: "todo"},
+			want:   "---\nslug: todo\n---\n\n",
 		},
 		{
-			name: "tags only",
-			tags: []string{"journal", "idea"},
-			want: "---\ntags: [journal, idea]\n---\n\n",
+			name:   "tags only",
+			fields: FrontmatterFields{Tags: []string{"journal", "idea"}},
+			want:   "---\ntags: [journal, idea]\n---\n\n",
 		},
 		{
-			name:        "description only",
-			description: "Quick thought",
-			want:        "---\ndescription: Quick thought\n---\n\n",
+			name:   "description only",
+			fields: FrontmatterFields{Description: "Quick thought"},
+			want:   "---\ndescription: Quick thought\n---\n\n",
 		},
 		{
-			name:        "all fields",
-			slug:        "weekly",
-			tags:        []string{"review"},
-			description: "Week 10",
-			title:       "Weekly Review",
-			want:        "---\ntitle: Weekly Review\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
+			name: "all fields",
+			fields: FrontmatterFields{
+				Title:       "Weekly Review",
+				Slug:        "weekly",
+				Tags:        []string{"review"},
+				Description: "Week 10",
+			},
+			want: "---\ntitle: Weekly Review\nslug: weekly\ntags: [review]\ndescription: Week 10\n---\n\n",
 		},
 		{
-			name: "single tag",
-			tags: []string{"journal"},
-			want: "---\ntags: [journal]\n---\n\n",
+			name:   "single tag",
+			fields: FrontmatterFields{Tags: []string{"journal"}},
+			want:   "---\ntags: [journal]\n---\n\n",
 		},
 		{
-			name:  "title only",
-			title: "My Note",
-			want:  "---\ntitle: My Note\n---\n\n",
+			name:   "title only",
+			fields: FrontmatterFields{Title: "My Note"},
+			want:   "---\ntitle: My Note\n---\n\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildFrontmatter(tt.slug, tt.tags, tt.description, tt.title)
+			got := BuildFrontmatter(tt.fields)
 			if got != tt.want {
-				t.Errorf("BuildFrontmatter(%q, %v, %q, %q) =\n%q\nwant:\n%q", tt.slug, tt.tags, tt.description, tt.title, got, tt.want)
+				t.Errorf("BuildFrontmatter(%+v) =\n%q\nwant:\n%q", tt.fields, got, tt.want)
 			}
 		})
 	}
@@ -135,7 +134,7 @@ func TestStripFrontmatter(t *testing.T) {
 		},
 		{
 			name:  "roundtrip with BuildFrontmatter",
-			input: BuildFrontmatter("todo", []string{"journal"}, "A note", "") + "# Content\n",
+			input: BuildFrontmatter(FrontmatterFields{Slug: "todo", Tags: []string{"journal"}, Description: "A note"}) + "# Content\n",
 			want:  "# Content\n",
 		},
 	}

--- a/note/todo.go
+++ b/note/todo.go
@@ -105,7 +105,7 @@ func RolloverTasks(prevLines []string, force bool) RolloverResult {
 
 // FormatTodoContent formats carried tasks into the new todo file content.
 func FormatTodoContent(tasks []Task) string {
-	fm := BuildFrontmatter(FrontmatterFields{Slug: "todo"})
+	fm := BuildFrontmatter(FrontmatterFields{})
 
 	if len(tasks) == 0 {
 		return fm

--- a/note/todo.go
+++ b/note/todo.go
@@ -105,7 +105,7 @@ func RolloverTasks(prevLines []string, force bool) RolloverResult {
 
 // FormatTodoContent formats carried tasks into the new todo file content.
 func FormatTodoContent(tasks []Task) string {
-	fm := BuildFrontmatter("todo", nil, "")
+	fm := BuildFrontmatter("todo", nil, "", "")
 
 	if len(tasks) == 0 {
 		return fm

--- a/note/todo.go
+++ b/note/todo.go
@@ -105,7 +105,7 @@ func RolloverTasks(prevLines []string, force bool) RolloverResult {
 
 // FormatTodoContent formats carried tasks into the new todo file content.
 func FormatTodoContent(tasks []Task) string {
-	fm := BuildFrontmatter("todo", nil, "", "")
+	fm := BuildFrontmatter(FrontmatterFields{Slug: "todo"})
 
 	if len(tasks) == 0 {
 		return fm

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -177,8 +177,8 @@ func TestFormatTodoContent(t *testing.T) {
 
 	content := FormatTodoContent(tasks)
 
-	if !strings.HasPrefix(content, "---\nslug: todo\n---\n\n") {
-		t.Errorf("missing frontmatter, got:\n%s", content)
+	if strings.HasPrefix(content, "---") {
+		t.Errorf("unexpected frontmatter, got:\n%s", content)
 	}
 	if !strings.Contains(content, "[ ] Task one") {
 		t.Error("expected Task one with reset marker")
@@ -194,9 +194,8 @@ func TestFormatTodoContent(t *testing.T) {
 
 func TestFormatTodoContentEmpty(t *testing.T) {
 	content := FormatTodoContent(nil)
-	want := "---\nslug: todo\n---\n\n"
-	if content != want {
-		t.Errorf("got:\n%q\nwant:\n%q", content, want)
+	if content != "" {
+		t.Errorf("got:\n%q\nwant empty string", content)
 	}
 }
 


### PR DESCRIPTION
Add support for setting title in note frontmatter via the --title flag on the new command. Title is placed first in the frontmatter block when provided. Updates BuildFrontmatter to accept the title parameter and updates all call sites and tests.