### PR TITLE
Remove redundant Long description from root command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,7 +17,6 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "notes",
 	Short:        "Interact with a notes archive",
-	Long:         "A command-line Markdown notes manager.",
 	SilenceUsage: true,
 }
 


### PR DESCRIPTION
Removed the redundant Long description field from the root command. The Short description is sufficient and will be used by Cobra for all help output.