### PR TITLE
Add bin/update script for convenient local updates

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "Pulling latest changes..."
+git checkout main
+git pull --tags
+
+echo "Building and installing..."
+make install
+
+echo "Installed: $(notes --version)"


### PR DESCRIPTION
Adds a small convenience script that pulls the latest changes from origin/main and rebuilds the tool locally. Combines git pull --tags and make install into a single command.