### PR TITLE
Add latest command to print absolute path to most recent note

### DIFF
--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/dreikanter/notescli/note"
@@ -26,14 +25,12 @@ var latestCmd = &cobra.Command{
 
 		if len(notes) == 0 {
 			if len(args) > 0 {
-				fmt.Fprintf(os.Stderr, "no notes found with type %q\n", args[0])
-			} else {
-				fmt.Fprintln(os.Stderr, "no notes found")
+				return fmt.Errorf("no notes found with type %q", args[0])
 			}
-			os.Exit(1)
+			return fmt.Errorf("no notes found")
 		}
 
-		fmt.Println(filepath.Join(root, notes[0].RelPath))
+		cmd.Println(filepath.Join(root, notes[0].RelPath))
 		return nil
 	},
 }

--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+var latestCmd = &cobra.Command{
+	Use:   "latest [type]",
+	Short: "Print absolute path to the most recent note, optionally filtered by type",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+		notes, err := note.Scan(root)
+		if err != nil {
+			return err
+		}
+
+		if len(args) > 0 {
+			notes = note.FilterBySlug(notes, args[0])
+		}
+
+		if len(notes) == 0 {
+			if len(args) > 0 {
+				fmt.Fprintf(os.Stderr, "no notes found with type %q\n", args[0])
+			} else {
+				fmt.Fprintln(os.Stderr, "no notes found")
+			}
+			os.Exit(1)
+		}
+
+		fmt.Println(filepath.Join(root, notes[0].RelPath))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(latestCmd)
+}

--- a/internal/cli/latest_test.go
+++ b/internal/cli/latest_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testdataPath(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("../../testdata")
+	if err != nil {
+		t.Fatalf("cannot resolve testdata path: %v", err)
+	}
+	return abs
+}
+
+func runLatest(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := testdataPath(t)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"latest", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func TestLatestNoArgs(t *testing.T) {
+	out, err := runLatest(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestLatestWithType(t *testing.T) {
+	out, err := runLatest(t, "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260102_8814_todo.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestLatestNotFound(t *testing.T) {
+	_, err := runLatest(t, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent type, got nil")
+	}
+}


### PR DESCRIPTION
Adds a new `latest` command that prints the absolute path to the most recent note. Optionally filters by type (slug) when an argument is provided. Returns exit code 1 if no matching note is found.

This command simplifies shell script usage by handling path construction internally, eliminating the need for NOTES_PATH variable management in scripts.