### PR TITLE
Add path command to print notes archive location

### DIFF
--- a/internal/cli/path.go
+++ b/internal/cli/path.go
@@ -1,0 +1,17 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+var pathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the notes archive path",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.Println(mustNotesPath())
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pathCmd)
+}

--- a/internal/cli/path_test.go
+++ b/internal/cli/path_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	root := testdataPath(t)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"path", "--path", root})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != root {
+		t.Errorf("got %q, want %q", got, root)
+	}
+}


### PR DESCRIPTION
Implements `notes path` command that prints the configured notes archive path, resolving from --path flag, NOTES_PATH env var, or default ~/Dropbox/Notes. Useful for agents and scripts that need to discover the notes location.