### PR TITLE
Add grep command for searching note contents

### DIFF
--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var grepCmd = &cobra.Command{
+	Use:                "grep [flags] <pattern>",
+	Short:              "Search note contents using grep",
+	DisableFlagParsing: true,
+	SilenceErrors:      true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+		grepArgs := append([]string{"-r"}, args...)
+		grepArgs = append(grepArgs, root)
+
+		grep := exec.Command("grep", grepArgs...)
+		grep.Stdout = os.Stdout
+		grep.Stderr = os.Stderr
+
+		return grep.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(grepCmd)
+}

--- a/internal/cli/grep_test.go
+++ b/internal/cli/grep_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func runGrep(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := testdataPath(t)
+
+	// Set notesPath directly since DisableFlagParsing prevents
+	// --path from being parsed when passed after "grep".
+	origPath := notesPath
+	notesPath = root
+	t.Cleanup(func() { notesPath = origPath })
+
+	// Capture stdout since grep writes to os.Stdout directly.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	rootCmd.SetArgs(append([]string{"grep"}, args...))
+	execErr := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	r.Close()
+
+	return strings.TrimSpace(string(buf[:n])), execErr
+}
+
+func TestGrepFindsMatch(t *testing.T) {
+	out, err := runGrep(t, "-rl", "Todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "20260102_8814_todo.md") {
+		t.Errorf("expected output to contain todo note, got %q", out)
+	}
+}
+
+func TestGrepNoMatch(t *testing.T) {
+	_, err := runGrep(t, "-rl", "zzz_no_match_zzz")
+	if err == nil {
+		t.Fatal("expected error for no matches, got nil")
+	}
+}
+
+func TestGrepCaseInsensitive(t *testing.T) {
+	out, err := runGrep(t, "-ril", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "20260102_8814_todo.md") {
+		t.Errorf("expected output to contain todo note, got %q", out)
+	}
+}


### PR DESCRIPTION
Implements `notes grep` command that wraps the system grep tool with automatic notes archive root injection.

The command runs `grep -r <args> $NOTES_PATH`, eliminating the need to remember or reference the archive path manually. All grep flags and options pass through unchanged.

Tests cover basic matching, case-insensitive search, and proper handling of no-match cases.