### PR TITLE
Make 'notes path' return absolute path

### DIFF
--- a/internal/cli/path_test.go
+++ b/internal/cli/path_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -20,6 +21,29 @@ func TestPath(t *testing.T) {
 	}
 
 	got := strings.TrimSpace(buf.String())
+	if got != root {
+		t.Errorf("got %q, want %q", got, root)
+	}
+}
+
+func TestPathRelative(t *testing.T) {
+	root := testdataPath(t)
+	rel := "../../testdata"
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"path", "--path", rel})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if !filepath.IsAbs(got) {
+		t.Errorf("expected absolute path, got %q", got)
+	}
 	if got != root {
 		t.Errorf("got %q, want %q", got, root)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,6 +57,12 @@ func mustNotesPath() string {
 		os.Exit(1)
 	}
 
+	p, err = filepath.Abs(p)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	info, err := os.Stat(p)
 	if err != nil || !info.IsDir() {
 		fmt.Fprintf(os.Stderr, "notes path does not exist or is not a directory: %s\n", p)


### PR DESCRIPTION
Ensure the path command always returns an absolute path, even when given a relative path via --path flag or NOTES_PATH environment variable. Uses filepath.Abs() to normalize the resolved path before validation. Adds TestPathRelative to verify relative paths are converted to absolute.