### PR TITLE
Change default notes path to ~/notes and document all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ notes read todo
 # Read a note by filename
 notes read 20260106_8823.md
 
+# Create a new note
+notes new
+notes new --title "Meeting notes" --slug meeting --tag work
+
+# Create today's todo from the previous todo
+notes new-todo
+
 # Filter notes by fragment
 notes filter todo
 notes filter 2026
@@ -41,6 +48,16 @@ notes ls
 notes ls --limit 10
 notes ls --type todo
 
+# Search note contents
+notes grep "search pattern"
+
+# Print path to most recent note
+notes latest
+notes latest --type todo
+
+# Print the notes archive path
+notes path
+
 # Override notes archive path
 notes --path /path/to/notes read 8823
 ```
@@ -49,7 +66,7 @@ The notes archive path is resolved in this order:
 
 1. `--path` flag
 2. `NOTES_PATH` environment variable
-3. `~/Dropbox/Notes` (default)
+3. `~/notes` (default)
 
 ## Development
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,7 +47,7 @@ func resolveNotesPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, "Dropbox", "Notes"), nil
+	return filepath.Join(home, "notes"), nil
 }
 
 func mustNotesPath() string {


### PR DESCRIPTION
Change default notes archive fallback from ~/Dropbox/Notes to ~/notes. Update README with complete command examples including new, new-todo, grep, latest, and path commands that were previously undocumented.