### PR TITLE
Fix path and latest output going to stderr

### DIFF
--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -30,7 +30,7 @@ var latestCmd = &cobra.Command{
 			return fmt.Errorf("no notes found")
 		}
 
-		cmd.Println(filepath.Join(root, notes[0].RelPath))
+		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, notes[0].RelPath))
 		return nil
 	},
 }

--- a/internal/cli/path.go
+++ b/internal/cli/path.go
@@ -1,13 +1,17 @@
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 var pathCmd = &cobra.Command{
 	Use:   "path",
 	Short: "Print the notes archive path",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.Println(mustNotesPath())
+		fmt.Fprintln(cmd.OutOrStdout(), mustNotesPath())
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary

- Cobra's `cmd.Println` defaults to `OutOrStderr()`, so `notes path` and `notes latest` wrote to stderr instead of stdout
- This broke shell captures like `file=$(notes latest)` — the variable ended up empty
- Switched both commands to `fmt.Fprintln(cmd.OutOrStdout(), ...)` which writes to stdout by default while remaining testable via cobra's `SetOut`

## Test plan

- [x] `make test` passes
- [x] Verify `notes path` and `notes latest` output is capturable: `path=$(notes path) && echo "$path"`