### PR TITLE
Add --tag flag to ls command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ notes ls
 notes ls --limit 10
 notes ls --type todo
 notes ls --tag work
+notes ls --tag work --tag meeting
 notes ls --tag work --type todo
 
 # Search note contents

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ notes filter 2026
 notes ls
 notes ls --limit 10
 notes ls --type todo
+notes ls --tag work
+notes ls --tag work --type todo
 
 # Search note contents
 notes grep "search pattern"

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -10,7 +10,7 @@ import (
 var (
 	lsLimit int
 	lsType  string
-	lsTag   string
+	lsTags  []string
 )
 
 var lsCmd = &cobra.Command{
@@ -28,8 +28,8 @@ var lsCmd = &cobra.Command{
 			notes = note.FilterBySlug(notes, lsType)
 		}
 
-		if lsTag != "" {
-			notes, err = note.FilterByTag(notes, root, lsTag)
+		if len(lsTags) > 0 {
+			notes, err = note.FilterByTags(notes, root, lsTags)
 			if err != nil {
 				return err
 			}
@@ -49,6 +49,6 @@ var lsCmd = &cobra.Command{
 func init() {
 	lsCmd.Flags().IntVar(&lsLimit, "limit", 20, "maximum number of notes to list")
 	lsCmd.Flags().StringVar(&lsType, "type", "", "filter by note type (slug), e.g. todo, backlog, weekly")
-	lsCmd.Flags().StringVar(&lsTag, "tag", "", "filter by frontmatter tag")
+	lsCmd.Flags().StringSliceVar(&lsTags, "tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	rootCmd.AddCommand(lsCmd)
 }

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -10,6 +10,7 @@ import (
 var (
 	lsLimit int
 	lsType  string
+	lsTag   string
 )
 
 var lsCmd = &cobra.Command{
@@ -27,12 +28,19 @@ var lsCmd = &cobra.Command{
 			notes = note.FilterBySlug(notes, lsType)
 		}
 
+		if lsTag != "" {
+			notes, err = note.FilterByTag(notes, root, lsTag)
+			if err != nil {
+				return err
+			}
+		}
+
 		if lsLimit > 0 && len(notes) > lsLimit {
 			notes = notes[:lsLimit]
 		}
 
 		for _, n := range notes {
-			fmt.Println(n.RelPath)
+			fmt.Fprintln(cmd.OutOrStdout(), n.RelPath)
 		}
 		return nil
 	},
@@ -41,5 +49,6 @@ var lsCmd = &cobra.Command{
 func init() {
 	lsCmd.Flags().IntVar(&lsLimit, "limit", 20, "maximum number of notes to list")
 	lsCmd.Flags().StringVar(&lsType, "type", "", "filter by note type (slug), e.g. todo, backlog, weekly")
+	lsCmd.Flags().StringVar(&lsTag, "tag", "", "filter by frontmatter tag")
 	rootCmd.AddCommand(lsCmd)
 }

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -4,16 +4,24 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func runLs(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 
 	root := testdataPath(t)
+	lsTags = nil
+	lsType = ""
+	lsLimit = 20
+	lsCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
+	lsCmd.SetOut(buf)
+	lsCmd.SetErr(buf)
 	rootCmd.SetArgs(append([]string{"ls", "--path", root}, args...))
 
 	err := rootCmd.Execute()
@@ -79,6 +87,36 @@ func TestLsTagAndLimit(t *testing.T) {
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {
 		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+}
+
+func TestLsMultipleTags(t *testing.T) {
+	out, err := runLs(t, "--tag", "work", "--tag", "planning")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1 (only todo has both work+planning):\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "todo") {
+		t.Errorf("expected todo note, got %q", lines[0])
+	}
+}
+
+func TestLsMultipleTagsCommaSeparated(t *testing.T) {
+	out, err := runLs(t, "--tag", "work,meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1 (only meeting note has both work+meeting):\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "meeting") {
+		t.Errorf("expected meeting note, got %q", lines[0])
 	}
 }
 

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func runLs(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := testdataPath(t)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"ls", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func TestLsNoArgs(t *testing.T) {
+	out, err := runLs(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4:\n%s", len(lines), out)
+	}
+}
+
+func TestLsWithTag(t *testing.T) {
+	out, err := runLs(t, "--tag", "work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), out)
+	}
+}
+
+func TestLsTagNoMatch(t *testing.T) {
+	out, err := runLs(t, "--tag", "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestLsTagAndType(t *testing.T) {
+	out, err := runLs(t, "--tag", "work", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "todo") {
+		t.Errorf("expected todo note, got %q", lines[0])
+	}
+}
+
+func TestLsTagAndLimit(t *testing.T) {
+	out, err := runLs(t, "--tag", "work", "--limit", "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+}
+
+func TestLsTagAndTypeNoOverlap(t *testing.T) {
+	out, err := runLs(t, "--tag", "meeting", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != "" {
+		t.Errorf("expected empty output (no todo with meeting tag), got %q", out)
+	}
+}

--- a/note/archive.go
+++ b/note/archive.go
@@ -91,22 +91,33 @@ func Filter(notes []Note, fragment string) []Note {
 	return results
 }
 
-// FilterByTag returns notes that contain the given tag in their frontmatter.
-func FilterByTag(notes []Note, root string, tag string) ([]Note, error) {
+// FilterByTags returns notes that contain all of the given tags in their frontmatter.
+func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 	var results []Note
 	for _, n := range notes {
 		data, err := os.ReadFile(filepath.Join(root, n.RelPath))
 		if err != nil {
 			return nil, err
 		}
-		for _, t := range ParseTags(data) {
-			if t == tag {
-				results = append(results, n)
-				break
-			}
+		noteTags := ParseTags(data)
+		if hasAllTags(noteTags, tags) {
+			results = append(results, n)
 		}
 	}
 	return results, nil
+}
+
+func hasAllTags(noteTags []string, required []string) bool {
+	set := make(map[string]struct{}, len(noteTags))
+	for _, t := range noteTags {
+		set[t] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := set[r]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // FilterBySlug returns notes with an exact slug match.

--- a/note/archive.go
+++ b/note/archive.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -88,6 +89,24 @@ func Filter(notes []Note, fragment string) []Note {
 		}
 	}
 	return results
+}
+
+// FilterByTag returns notes that contain the given tag in their frontmatter.
+func FilterByTag(notes []Note, root string, tag string) ([]Note, error) {
+	var results []Note
+	for _, n := range notes {
+		data, err := os.ReadFile(filepath.Join(root, n.RelPath))
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range ParseTags(data) {
+			if t == tag {
+				results = append(results, n)
+				break
+			}
+		}
+	}
+	return results, nil
 }
 
 // FilterBySlug returns notes with an exact slug match.

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -21,19 +21,22 @@ func TestScan(t *testing.T) {
 		t.Fatalf("Scan(%q) error: %v", root, err)
 	}
 
-	if len(notes) != 3 {
-		t.Fatalf("Scan returned %d notes, want 3", len(notes))
+	if len(notes) != 4 {
+		t.Fatalf("Scan returned %d notes, want 4", len(notes))
 	}
 
 	// Should be sorted newest first (descending RelPath)
 	if notes[0].ID != "8823" {
 		t.Errorf("notes[0].ID = %q, want 8823 (newest)", notes[0].ID)
 	}
-	if notes[1].ID != "8814" {
-		t.Errorf("notes[1].ID = %q, want 8814", notes[1].ID)
+	if notes[1].ID != "8818" {
+		t.Errorf("notes[1].ID = %q, want 8818", notes[1].ID)
 	}
-	if notes[2].ID != "6973" {
-		t.Errorf("notes[2].ID = %q, want 6973 (oldest)", notes[2].ID)
+	if notes[2].ID != "8814" {
+		t.Errorf("notes[2].ID = %q, want 8814", notes[2].ID)
+	}
+	if notes[3].ID != "6973" {
+		t.Errorf("notes[3].ID = %q, want 6973 (oldest)", notes[3].ID)
 	}
 }
 
@@ -117,6 +120,43 @@ func TestFilter(t *testing.T) {
 			got := Filter(notes, tt.fragment)
 			if len(got) != tt.wantLen {
 				t.Errorf("Filter(%q) returned %d results, want %d", tt.fragment, len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestFilterByTag(t *testing.T) {
+	root := testdataPath(t)
+	notes, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		tag     string
+		wantLen int
+		wantIDs []string
+	}{
+		{"shared tag", "work", 3, []string{"8823", "8818", "8814"}},
+		{"unique tag", "meeting", 1, []string{"8818"}},
+		{"planning tag", "planning", 1, []string{"8814"}},
+		{"no match", "nonexistent", 0, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterByTag(notes, root, tt.tag)
+			if err != nil {
+				t.Fatalf("FilterByTag(%q) error: %v", tt.tag, err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("FilterByTag(%q) returned %d notes, want %d", tt.tag, len(got), tt.wantLen)
+			}
+			for i, wantID := range tt.wantIDs {
+				if got[i].ID != wantID {
+					t.Errorf("FilterByTag(%q)[%d].ID = %q, want %q", tt.tag, i, got[i].ID, wantID)
+				}
 			}
 		})
 	}

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -125,7 +125,7 @@ func TestFilter(t *testing.T) {
 	}
 }
 
-func TestFilterByTag(t *testing.T) {
+func TestFilterByTags(t *testing.T) {
 	root := testdataPath(t)
 	notes, err := Scan(root)
 	if err != nil {
@@ -134,28 +134,30 @@ func TestFilterByTag(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		tag     string
+		tags    []string
 		wantLen int
 		wantIDs []string
 	}{
-		{"shared tag", "work", 3, []string{"8823", "8818", "8814"}},
-		{"unique tag", "meeting", 1, []string{"8818"}},
-		{"planning tag", "planning", 1, []string{"8814"}},
-		{"no match", "nonexistent", 0, nil},
+		{"single shared tag", []string{"work"}, 3, []string{"8823", "8818", "8814"}},
+		{"single unique tag", []string{"meeting"}, 1, []string{"8818"}},
+		{"two tags AND", []string{"work", "planning"}, 1, []string{"8814"}},
+		{"two tags AND meeting", []string{"work", "meeting"}, 1, []string{"8818"}},
+		{"no match", []string{"nonexistent"}, 0, nil},
+		{"one matching one not", []string{"work", "nonexistent"}, 0, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FilterByTag(notes, root, tt.tag)
+			got, err := FilterByTags(notes, root, tt.tags)
 			if err != nil {
-				t.Fatalf("FilterByTag(%q) error: %v", tt.tag, err)
+				t.Fatalf("FilterByTags(%v) error: %v", tt.tags, err)
 			}
 			if len(got) != tt.wantLen {
-				t.Fatalf("FilterByTag(%q) returned %d notes, want %d", tt.tag, len(got), tt.wantLen)
+				t.Fatalf("FilterByTags(%v) returned %d notes, want %d", tt.tags, len(got), tt.wantLen)
 			}
 			for i, wantID := range tt.wantIDs {
 				if got[i].ID != wantID {
-					t.Errorf("FilterByTag(%q)[%d].ID = %q, want %q", tt.tag, i, got[i].ID, wantID)
+					t.Errorf("FilterByTags(%v)[%d].ID = %q, want %q", tt.tags, i, got[i].ID, wantID)
 				}
 			}
 		})

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -34,6 +34,52 @@ func BuildFrontmatter(f FrontmatterFields) string {
 	return "---\n" + strings.Join(lines, "\n") + "\n---\n\n"
 }
 
+// ParseTags extracts tags from YAML frontmatter in data.
+// Returns nil if no tags are found.
+func ParseTags(data []byte) []string {
+	// Must start with "---"
+	if !bytes.HasPrefix(data, frontmatterDelim) {
+		return nil
+	}
+
+	rest := data[len(frontmatterDelim):]
+	idx := bytes.IndexByte(rest, '\n')
+	if idx < 0 {
+		return nil
+	}
+	if len(bytes.TrimRight(rest[:idx], "\r")) > 0 {
+		return nil
+	}
+	rest = rest[idx+1:]
+
+	var tagsLine []byte
+	for {
+		line, after, found := bytes.Cut(rest, []byte("\n"))
+		trimmed := bytes.TrimRight(line, "\r")
+
+		if bytes.Equal(trimmed, frontmatterDelim) {
+			// Found closing delimiter — return any tags we collected.
+			if tagsLine == nil {
+				return nil
+			}
+			inner := tagsLine[len("tags: [") : len(tagsLine)-1]
+			if len(inner) == 0 {
+				return nil
+			}
+			return strings.Split(string(inner), ", ")
+		}
+
+		if bytes.HasPrefix(trimmed, []byte("tags: [")) && bytes.HasSuffix(trimmed, []byte("]")) {
+			tagsLine = trimmed
+		}
+
+		if !found {
+			return nil
+		}
+		rest = after
+	}
+}
+
 var frontmatterDelim = []byte("---")
 
 // StripFrontmatter removes YAML frontmatter from the beginning of data.

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -55,6 +55,80 @@ func TestBuildFrontmatter(t *testing.T) {
 	}
 }
 
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want []string
+	}{
+		{
+			name:  "multiple tags",
+			input: "---\ntags: [work, planning]\n---\n\n# Note\n",
+			want:  []string{"work", "planning"},
+		},
+		{
+			name:  "single tag",
+			input: "---\ntags: [journal]\n---\n\n# Note\n",
+			want:  []string{"journal"},
+		},
+		{
+			name:  "no frontmatter",
+			input: "# Hello\n\nBody text.\n",
+			want:  nil,
+		},
+		{
+			name:  "frontmatter without tags",
+			input: "---\ntitle: My Note\n---\n\n# Note\n",
+			want:  nil,
+		},
+		{
+			name:  "empty tags",
+			input: "---\ntags: []\n---\n\n# Note\n",
+			want:  nil,
+		},
+		{
+			name:  "tags with other fields",
+			input: "---\ntitle: Weekly Review\ntags: [review, work]\ndescription: Week 10\n---\n\n# Note\n",
+			want:  []string{"review", "work"},
+		},
+		{
+			name:  "roundtrip with BuildFrontmatter",
+			input: BuildFrontmatter(FrontmatterFields{Tags: []string{"x", "y"}}) + "# Content\n",
+			want:  []string{"x", "y"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "unclosed frontmatter",
+			input: "---\ntags: [a]\n# Hello\n",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTags([]byte(tt.input))
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("ParseTags(%q) = %v, want nil", tt.input, got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseTags(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseTags(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestStripFrontmatter(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/testdata/2026/01/20260102_8814_todo.md
+++ b/testdata/2026/01/20260102_8814_todo.md
@@ -1,3 +1,7 @@
+---
+tags: [work, planning]
+---
+
 # Todo
 
 - [ ] Task one

--- a/testdata/2026/01/20260104_8818_meeting.md
+++ b/testdata/2026/01/20260104_8818_meeting.md
@@ -1,0 +1,7 @@
+---
+tags: [work, meeting]
+---
+
+# Standup notes
+
+Discussion items.

--- a/testdata/2026/01/20260106_8823.md
+++ b/testdata/2026/01/20260106_8823.md
@@ -1,3 +1,7 @@
+---
+tags: [work]
+---
+
 # Plain note
 
 Some content here.


### PR DESCRIPTION
## Summary

- Adds `--tag` flag to `notes ls` for filtering notes by frontmatter tags (e.g. `notes ls --tag work`)
- Composes with existing `--type` and `--limit` flags — slug filter runs first to minimize file I/O, then tag filter, then limit truncation
- Also fixes `ls` to use `cmd.OutOrStdout()` instead of `fmt.Println` for testability

## Test plan

- [x] `TestParseTags` — 9 cases: multiple/single/empty tags, no frontmatter, unclosed frontmatter, roundtrip with `BuildFrontmatter`
- [x] `TestFilterByTag` — shared tag, unique tag, no match
- [x] `TestLsWithTag` — tag-only filtering
- [x] `TestLsTagAndType` — `--tag` + `--type` composability (intersection)
- [x] `TestLsTagAndTypeNoOverlap` — disjoint `--tag` + `--type` returns empty
- [x] `TestLsTagAndLimit` — `--tag` + `--limit` composability
- [x] `TestLsTagNoMatch` — nonexistent tag returns empty