### PR TITLE
Fix linter errors

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	notesPath string
-	Version = "dev"
+	Version   = "dev"
 )
 
 var rootCmd = &cobra.Command{

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -57,9 +57,9 @@ func TestBuildFrontmatter(t *testing.T) {
 
 func TestParseTags(t *testing.T) {
 	tests := []struct {
-		name string
+		name  string
 		input string
-		want []string
+		want  []string
 	}{
 		{
 			name:  "multiple tags",

--- a/note/id_test.go
+++ b/note/id_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestReadID(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	idf, err := ReadID(dir)
 	if err != nil {
@@ -29,7 +31,9 @@ func TestReadIDMissing(t *testing.T) {
 
 func TestReadIDInvalid(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`not json`), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`not json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := ReadID(dir)
 	if err == nil {
@@ -39,7 +43,9 @@ func TestReadIDInvalid(t *testing.T) {
 
 func TestNextID(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 9218}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	id, err := NextID(dir)
 	if err != nil {
@@ -61,7 +67,9 @@ func TestNextID(t *testing.T) {
 
 func TestNextIDConsecutive(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 100}`), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 100}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	id1, _ := NextID(dir)
 	id2, _ := NextID(dir)
@@ -76,7 +84,9 @@ func TestNextIDConsecutive(t *testing.T) {
 
 func TestWriteIDAtomic(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 0}`), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	err := WriteID(dir, IDFile{LastID: 42})
 	if err != nil {


### PR DESCRIPTION
Resolve golangci-lint violations in test code and formatting.

- Check return values from os.WriteFile calls in id_test.go
- Fix gofmt alignment in root.go and frontmatter_test.go