### PR TITLE
Refactor: move misplaced helpers, drop unused parameter

### DIFF
--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -28,7 +28,7 @@ var newTodoCmd = &cobra.Command{
 
 		// Check if today's todo already exists
 		if !newTodoForce {
-			if existing := note.FindTodayTodo(root, notes, today); existing != nil {
+			if existing := note.FindTodayTodo(notes, today); existing != nil {
 				fmt.Println(filepath.Join(root, existing.RelPath))
 				return nil
 			}

--- a/note/note.go
+++ b/note/note.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -43,6 +44,21 @@ func ParseFilename(baseName string) (Note, error) {
 		Slug:     slug,
 		BaseName: baseName,
 	}, nil
+}
+
+// NoteFilename generates a note filename from date, id, and optional slug.
+func NoteFilename(date string, id int, slug string) string {
+	if slug != "" {
+		return fmt.Sprintf("%s_%d_%s.md", date, id, slug)
+	}
+	return fmt.Sprintf("%s_%d.md", date, id)
+}
+
+// NoteDirPath returns the YYYY/MM directory path for a given date string (YYYYMMDD).
+func NoteDirPath(root, date string) string {
+	year := date[:4]
+	month := date[4:6]
+	return filepath.Join(root, year, month)
 }
 
 func isDigits(s string) bool {

--- a/note/todo.go
+++ b/note/todo.go
@@ -1,8 +1,6 @@
 package note
 
 import (
-	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -132,26 +130,11 @@ func FindLatestTodo(notes []Note, beforeDate string) *Note {
 }
 
 // FindTodayTodo finds a todo note matching today's date.
-func FindTodayTodo(root string, notes []Note, today string) *Note {
+func FindTodayTodo(notes []Note, today string) *Note {
 	for i := range notes {
 		if notes[i].Slug == "todo" && notes[i].Date == today {
 			return &notes[i]
 		}
 	}
 	return nil
-}
-
-// NoteFilename generates a note filename from date, id, and optional slug.
-func NoteFilename(date string, id int, slug string) string {
-	if slug != "" {
-		return fmt.Sprintf("%s_%d_%s.md", date, id, slug)
-	}
-	return fmt.Sprintf("%s_%d.md", date, id)
-}
-
-// NoteDirPath returns the YYYY/MM directory path for a given date string (YYYYMMDD).
-func NoteDirPath(root, date string) string {
-	year := date[:4]
-	month := date[4:6]
-	return filepath.Join(root, year, month)
 }

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -260,7 +260,7 @@ func TestFindTodayTodo(t *testing.T) {
 		{Date: "20260311", Slug: "todo", RelPath: "2026/03/20260311_99_todo.md"},
 	}
 
-	got := FindTodayTodo("/archive", notes, "20260312")
+	got := FindTodayTodo(notes, "20260312")
 	if got == nil {
 		t.Fatal("expected to find today's todo")
 	}
@@ -268,7 +268,7 @@ func TestFindTodayTodo(t *testing.T) {
 		t.Errorf("got date %s, want 20260312", got.Date)
 	}
 
-	got = FindTodayTodo("/archive", notes, "20260313")
+	got = FindTodayTodo(notes, "20260313")
 	if got != nil {
 		t.Error("expected nil for future date")
 	}


### PR DESCRIPTION
## Summary

Minor refactoring based on a code structure review of the `note` package.

- Move `NoteFilename()` and `NoteDirPath()` from `todo.go` to `note.go` — these are general-purpose note utilities used by `new.go` for any note type, not just todos
- Drop unused `root` parameter from `FindTodayTodo()` — the function only iterates the `notes` slice and never references `root`

## Code Structure Review

```
cmd/notes/main.go          → entry point
internal/cli/              → cobra commands (CLI layer)
note/                      → domain/library package
  note.go                  → Note struct + filename parsing
  archive.go               → scan, resolve, filter operations
  id.go                    → sequential ID allocation (id.json)
  frontmatter.go           → YAML frontmatter build/parse/strip
  todo.go                  → task parsing + rollover logic
```

### Verdict: The design is sound

Two-layer architecture (CLI → domain) is the right call for a small personal CLI. The `note` package owns the domain concepts, CLI commands are thin wrappers. No unnecessary abstractions. A few things stood out:

#### 1. Misplaced helpers in `todo.go` ✅ Fixed

`NoteFilename()` and `NoteDirPath()` (todo.go:145-157) are general-purpose note utilities — `new.go` uses them for any note, not just todos. They belong in `note.go` alongside `ParseFilename` and the `Note` struct. A reader looking at todo.go would assume these are todo-specific.

#### 2. Unused parameter ✅ Fixed

`FindTodayTodo(root string, notes []Note, today string)` takes `root` but never uses it. The function only iterates the `notes` slice. Dropped the parameter and updated the call site.

#### 3. Type = Slug conflation (no action needed) ✅ Fixed in #22

`--type todo` works because it calls `FilterBySlug(notes, "todo")`. This is pragmatic — "types" like `todo`, `backlog`, `weekly` are exactly the slugs. But conceptually "type" and "slug" are different ideas (a note slug "meeting-with-bob" isn't a "type"). Works fine today because the only types you care about happen to be slugs. Worth being aware of if types and slugs ever need to diverge, but not worth refactoring preemptively.

#### 4. No Archive struct — and that's fine

Every command independently calls `mustNotesPath()` + `note.Scan(root)`. An `Archive{root, notes}` struct could reduce this, but for 7 commands this is not worth the abstraction tax yet.

### Things done well

- **Atomic ID writes** (temp file + rename in id.go) — correct approach
- **Clean separation**: CLI layer handles cobra wiring + I/O, `note` package is pure logic
- **Pragmatic `grep` command** — shelling out to system grep is the right call
- **Flat `note` package** — no premature sub-packaging

## Test plan

- [x] `make test` passes
- [x] `make lint` passes