### PR TITLE
Rename "archive" to "store" in all user-facing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ notes grep "search pattern"
 notes latest
 notes latest --type todo
 
-# Print the notes archive path
+# Print the notes store path
 notes path
 
-# Override notes archive path
+# Override notes store path
 notes --path /path/to/notes read 8823
 ```
 
-The notes archive path is resolved in this order:
+The notes store path is resolved in this order:
 
 1. `--path` flag
 2. `NOTES_PATH` environment variable

--- a/internal/cli/path.go
+++ b/internal/cli/path.go
@@ -8,7 +8,7 @@ import (
 
 var pathCmd = &cobra.Command{
 	Use:   "path",
-	Short: "Print the notes archive path",
+	Short: "Print the notes store path",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(cmd.OutOrStdout(), mustNotesPath())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,7 +16,7 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:          "notes",
-	Short:        "Interact with a notes archive",
+	Short:        "Interact with a notes store",
 	SilenceUsage: true,
 }
 
@@ -27,7 +27,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
-	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes archive (overrides NOTES_PATH env var)")
+	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (overrides NOTES_PATH env var)")
 }
 
 func Execute() {

--- a/note/id.go
+++ b/note/id.go
@@ -12,7 +12,7 @@ type IDFile struct {
 	LastID int `json:"last_id"`
 }
 
-// ReadID reads the current last_id from id.json in the archive root.
+// ReadID reads the current last_id from id.json in the store root.
 func ReadID(root string) (IDFile, error) {
 	data, err := os.ReadFile(filepath.Join(root, "id.json"))
 	if err != nil {

--- a/note/note.go
+++ b/note/note.go
@@ -19,9 +19,9 @@ func IsKnownType(s string) bool {
 	return false
 }
 
-// Note represents a single note file in the archive.
+// Note represents a single note file in the store.
 type Note struct {
-	RelPath  string // relative path from archive root, e.g. "2026/01/20260106_8823.md"
+	RelPath  string // relative path from store root, e.g. "2026/01/20260106_8823.md"
 	Date     string // "20260106"
 	ID       string // "8823"
 	Slug     string // descriptive slug, e.g. "api-redesign", or ""

--- a/note/store.go
+++ b/note/store.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Scan walks the archive directory and returns all valid notes, sorted newest first.
+// Scan walks the store directory and returns all valid notes, sorted newest first.
 func Scan(root string) ([]Note, error) {
 	var notes []Note
 


### PR DESCRIPTION
## Summary

The term "archive" implies notes are put away and forgotten. After researching how other knowledge management tools name their top-level collections, "store" was chosen as the most neutral, shortest term that works as both noun and verb with no inherited connotations.

### Research: terminology across note-taking and PKM tools

| Term | Used by |
|------|---------|
| **Workspace** | Notion, Coda, Slite, Nuclino, Slab, Almanac, Tana, Heptabase, Mem, ClickUp, Dendron (as container of vaults) |
| **Notebook** | OneNote, Evernote, Joplin, Zoho Notebook, `nb` CLI |
| **Space** | Confluence, Anytype, Capacities, Craft, Evernote (newer) |
| **Vault** | Obsidian, Dendron, Notesnook |
| **Graph** | Roam Research, Logseq, Athens Research |
| **Book** | Dnote CLI |
| **No term (flat)** | Bear, Simplenote, Standard Notes, Google Keep, Apple Notes |

Key observations:
- **Workspace** is the most common but implies collaboration — too heavy for a personal CLI tool.
- **Notebook** collides with the concept of a single note.
- **Vault** connotes encryption/privacy.
- **Graph** implies linked/networked notes.
- **No existing tool uses "store," "library," or "base"** — "store" is a fresh term with zero baggage in the notes space.

### Changes

- Replaced "archive" → "store" in all help strings, comments, and documentation
- Renamed `note/archive.go` → `note/store.go`
- No variable/function names changed (none used the word "archive")

## Test plan

- [x] `make lint` passes
- [x] `make test` passes