### PR TITLE
Support variable-length year in date format

### DIFF
--- a/note/note.go
+++ b/note/note.go
@@ -22,7 +22,7 @@ func IsKnownType(s string) bool {
 // Note represents a single note file in the store.
 type Note struct {
 	RelPath  string // relative path from store root, e.g. "2026/01/20260106_8823.md"
-	Date     string // "20260106"
+	Date     string // date as Y...YMMDD, e.g. "20260106"
 	ID       string // "8823"
 	Slug     string // descriptive slug, e.g. "api-redesign", or ""
 	Type     string // known type from file extension, e.g. "todo", "backlog", or ""
@@ -30,7 +30,7 @@ type Note struct {
 }
 
 // ParseFilename parses a note base filename (without .md extension) into its components.
-// Expected format: Y...YMMDD_ID[_slug][.TYPE]
+// Expected format: Y...YMMDD_ID[_slug][.TYPE], where MM and DD are zero-padded.
 // If the base name ends with a known type suffix (e.g. ".todo"), it is extracted as the Type.
 func ParseFilename(baseName string) (Note, error) {
 	noteType := ""
@@ -87,7 +87,8 @@ func NoteFilename(date string, id int, slug, noteType string) string {
 	return base + ".md"
 }
 
-// NoteDirPath returns the year/month directory path for a given date string (Y...YMMDD).
+// NoteDirPath returns the year/month directory path for a given date string (Y...YMMDD),
+// where MM and DD are zero-padded.
 func NoteDirPath(root, date string) string {
 	year := date[:len(date)-4]
 	month := date[len(date)-4 : len(date)-2]

--- a/note/note.go
+++ b/note/note.go
@@ -30,7 +30,7 @@ type Note struct {
 }
 
 // ParseFilename parses a note base filename (without .md extension) into its components.
-// Expected format: YYYYMMDD_ID[_slug][.TYPE]
+// Expected format: Y...YMMDD_ID[_slug][.TYPE]
 // If the base name ends with a known type suffix (e.g. ".todo"), it is extracted as the Type.
 func ParseFilename(baseName string) (Note, error) {
 	noteType := ""
@@ -51,7 +51,7 @@ func ParseFilename(baseName string) (Note, error) {
 	}
 
 	date := parts[0]
-	if len(date) != 8 || !isDigits(date) {
+	if len(date) < 5 || !isDigits(date) {
 		return Note{}, fmt.Errorf("invalid date in filename: %s", baseName)
 	}
 
@@ -87,10 +87,10 @@ func NoteFilename(date string, id int, slug, noteType string) string {
 	return base + ".md"
 }
 
-// NoteDirPath returns the YYYY/MM directory path for a given date string (YYYYMMDD).
+// NoteDirPath returns the year/month directory path for a given date string (Y...YMMDD).
 func NoteDirPath(root, date string) string {
-	year := date[:4]
-	month := date[4:6]
+	year := date[:len(date)-4]
+	month := date[len(date)-4 : len(date)-2]
 	return filepath.Join(root, year, month)
 }
 

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -89,8 +89,17 @@ func TestParseFilename(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "short date",
-			input:   "2026010_1234",
+			name:         "short year in date",
+			input:        "2026010_1234",
+			wantDate:     "2026010",
+			wantID:       "1234",
+			wantSlug:     "",
+			wantType:     "",
+			wantBaseName: "2026010_1234",
+		},
+		{
+			name:    "date too short for MMDD",
+			input:   "2601_1234",
 			wantErr: true,
 		},
 		{

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -98,6 +98,15 @@ func TestParseFilename(t *testing.T) {
 			wantBaseName: "2026010_1234",
 		},
 		{
+			name:         "distant future date",
+			input:        "120260106_8823",
+			wantDate:     "120260106",
+			wantID:       "8823",
+			wantSlug:     "",
+			wantType:     "",
+			wantBaseName: "120260106_8823",
+		},
+		{
 			name:    "date too short for MMDD",
 			input:   "2601_1234",
 			wantErr: true,


### PR DESCRIPTION
Allow date parsing to accept any year length (e.g., 1, 2, 3, 4, 5+ digits) instead of requiring exactly 4 digits. The year is now inferred as everything before the final 4 characters (MMDD) in the date string.

Changes:
- ParseFilename relaxed from exactly 8-digit dates to minimum 5 digits (Y...YMMDD)
- NoteDirPath updated to extract year/month using string indices relative to the end
- Test case updated to validate 7-digit dates; added error case for 4-digit dates