### PR TITLE
Limit grep to .md files and exclude .git directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ notes ls --tag work
 notes ls --tag work --tag meeting
 notes ls --tag work --type todo
 
-# Search note contents
+# Search note contents (only .md files, .git excluded)
 notes grep "search pattern"
 
 # Print path to most recent note

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -10,11 +10,12 @@ import (
 var grepCmd = &cobra.Command{
 	Use:                "grep [flags] <pattern>",
 	Short:              "Search note contents using grep",
+	Long:               "Search note contents using grep. Only .md files are searched; .git directories are excluded.",
 	DisableFlagParsing: true,
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
-		grepArgs := append([]string{"-r"}, args...)
+		grepArgs := append([]string{"-r", "--include=*.md", "--exclude-dir=.git"}, args...)
 		grepArgs = append(grepArgs, root)
 
 		grep := exec.Command("grep", grepArgs...)

--- a/internal/cli/grep_test.go
+++ b/internal/cli/grep_test.go
@@ -56,6 +56,13 @@ func TestGrepNoMatch(t *testing.T) {
 	}
 }
 
+func TestGrepExcludesNonMarkdown(t *testing.T) {
+	out, err := runGrep(t, "-rl", "skipped")
+	if err == nil {
+		t.Fatalf("expected no matches, got output: %q", out)
+	}
+}
+
 func TestGrepCaseInsensitive(t *testing.T) {
 	out, err := runGrep(t, "-ril", "todo")
 	if err != nil {


### PR DESCRIPTION
## Summary

- `notes grep` now only searches `.md` files (`--include=*.md`) and excludes `.git` directories (`--exclude-dir=.git`) by default
- Added `Long` description to the grep command documenting the filtering behavior
- Updated README usage comment to mention the scope
- Added test verifying non-markdown files are excluded from results