### PR TITLE
Add notes rg subcommand for ripgrep integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Add `rg` command for searching note contents using ripgrep ([#27])
+
 ## [0.1.19] - 2026-03-23
 
 ### Fixed
@@ -115,3 +121,4 @@
 [#23]: https://github.com/dreikanter/notescli/pull/23
 [#24]: https://github.com/dreikanter/notescli/pull/24
 [#25]: https://github.com/dreikanter/notescli/pull/25
+[#27]: https://github.com/dreikanter/notescli/pull/27

--- a/internal/cli/rg.go
+++ b/internal/cli/rg.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var rgCmd = &cobra.Command{
+	Use:                "rg [flags] <pattern>",
+	Short:              "Search note contents using ripgrep",
+	Long:               "Search note contents using ripgrep (rg). Only .md files are searched.",
+	DisableFlagParsing: true,
+	SilenceErrors:      true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := exec.LookPath("rg"); err != nil {
+			return fmt.Errorf("ripgrep (rg) is not installed; install it from https://github.com/BurntSushi/ripgrep")
+		}
+
+		root := mustNotesPath()
+		rgArgs := append([]string{"--glob", "*.md"}, args...)
+		rgArgs = append(rgArgs, root)
+
+		rg := exec.Command("rg", rgArgs...)
+		rg.Stdout = os.Stdout
+		rg.Stderr = os.Stderr
+
+		return rg.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rgCmd)
+}

--- a/internal/cli/rg_test.go
+++ b/internal/cli/rg_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func requireRg(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed, skipping")
+	}
+}
+
+func runRg(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	root := testdataPath(t)
+
+	origPath := notesPath
+	notesPath = root
+	t.Cleanup(func() { notesPath = origPath })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create pipe: %v", err)
+	}
+
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	rootCmd.SetArgs(append([]string{"rg"}, args...))
+	execErr := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	r.Close()
+
+	return strings.TrimSpace(string(buf[:n])), execErr
+}
+
+func TestRgFindsMatch(t *testing.T) {
+	requireRg(t)
+	out, err := runRg(t, "-l", "Todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "20260102_8814.todo.md") {
+		t.Errorf("expected output to contain todo note, got %q", out)
+	}
+}
+
+func TestRgNoMatch(t *testing.T) {
+	requireRg(t)
+	_, err := runRg(t, "-l", "zzz_no_match_zzz")
+	if err == nil {
+		t.Fatal("expected error for no matches, got nil")
+	}
+}
+
+func TestRgExcludesNonMarkdown(t *testing.T) {
+	requireRg(t)
+	out, err := runRg(t, "-l", "skipped")
+	if err == nil {
+		t.Fatalf("expected no matches, got output: %q", out)
+	}
+	_ = out
+}
+
+func TestRgCaseInsensitive(t *testing.T) {
+	requireRg(t)
+	out, err := runRg(t, "-il", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "20260102_8814.todo.md") {
+		t.Errorf("expected output to contain todo note, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `notes rg` subcommand that wraps ripgrep (`rg`) with `--glob *.md` scoping, mirroring the existing `notes grep` pattern
- Shows an informative error with install link if `rg` is not found in PATH
- Includes tests for match, no-match, non-markdown exclusion, and case-insensitive search (skipped when `rg` is not installed)