### PR TITLE
Add default options for rg and grep subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `rg` command for searching note contents using ripgrep ([#27])
+- Add default options for `rg` and `grep` subcommands ([#28])
 
 ## [0.1.19] - 2026-03-23
 
@@ -122,3 +123,4 @@
 [#24]: https://github.com/dreikanter/notescli/pull/24
 [#25]: https://github.com/dreikanter/notescli/pull/25
 [#27]: https://github.com/dreikanter/notescli/pull/27
+[#28]: https://github.com/dreikanter/notescli/pull/28

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -15,7 +15,7 @@ var grepCmd = &cobra.Command{
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
-		grepArgs := append([]string{"-r", "--include=*.md", "--exclude-dir=.git"}, args...)
+		grepArgs := append([]string{"-r", "-i", "--include=*.md", "--exclude-dir=.git"}, args...)
 		grepArgs = append(grepArgs, root)
 
 		grep := exec.Command("grep", grepArgs...)

--- a/internal/cli/rg.go
+++ b/internal/cli/rg.go
@@ -20,7 +20,13 @@ var rgCmd = &cobra.Command{
 		}
 
 		root := mustNotesPath()
-		rgArgs := append([]string{"--glob", "*.md"}, args...)
+		rgArgs := append([]string{
+			"--glob", "*.md",
+			"--sortr", "path",
+			"--heading",
+			"--no-line-number",
+			"--ignore-case",
+		}, args...)
 		rgArgs = append(rgArgs, root)
 
 		rg := exec.Command("rg", rgArgs...)


### PR DESCRIPTION
## Summary

- Add default options for `notes rg`: `--sortr path`, `--heading`, `--no-line-number`, `--ignore-case` for better readability out of the box.
- Add `--ignore-case` (`-i`) default for `notes grep`.
- Defaults are prepended before user args, so they can be overridden.