### PR TITLE
Add --type, --slug, --tag filter flags to latest command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add `rg` command for searching note contents using ripgrep ([#27])
 - Add default options for `rg` and `grep` subcommands ([#28])
 
+### Changed
+
+- Replace positional `[type]` argument in `latest` with `--type`, `--slug`, and `--tag` flags
+
 ## [0.1.19] - 2026-03-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.1.23] - 2026-03-24
+
 ### Added
 
 - Add `rg` command for searching note contents using ripgrep ([#27])
@@ -96,6 +98,7 @@
 - Add `new` and `new-todo` commands ([#2])
 - Add `--no-frontmatter` flag to `read` command ([#3], [#4])
 
+[0.1.23]: https://github.com/dreikanter/notescli/releases/tag/v0.1.23
 [0.1.19]: https://github.com/dreikanter/notescli/releases/tag/v0.1.19
 [0.1.18]: https://github.com/dreikanter/notescli/releases/tag/v0.1.18
 [0.1.17]: https://github.com/dreikanter/notescli/releases/tag/v0.1.17

--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -9,9 +9,9 @@ import (
 )
 
 var latestCmd = &cobra.Command{
-	Use:   "latest [type]",
-	Short: "Print absolute path to the most recent note, optionally filtered by type",
-	Args:  cobra.MaximumNArgs(1),
+	Use:   "latest",
+	Short: "Print absolute path to the most recent note, optionally filtered by type, slug, or tag",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
 		notes, err := note.Scan(root)
@@ -19,13 +19,28 @@ var latestCmd = &cobra.Command{
 			return err
 		}
 
-		if len(args) > 0 {
-			notes = note.FilterByType(notes, args[0])
+		types, _ := cmd.Flags().GetStringSlice("type")
+		slugs, _ := cmd.Flags().GetStringSlice("slug")
+		tags, _ := cmd.Flags().GetStringSlice("tag")
+
+		if len(types) > 0 {
+			notes = note.FilterByTypes(notes, types)
+		}
+
+		if len(slugs) > 0 {
+			notes = note.FilterBySlugs(notes, slugs)
+		}
+
+		if len(tags) > 0 {
+			notes, err = note.FilterByTags(notes, root, tags)
+			if err != nil {
+				return err
+			}
 		}
 
 		if len(notes) == 0 {
-			if len(args) > 0 {
-				return fmt.Errorf("no notes found with type %q", args[0])
+			if len(types) > 0 || len(slugs) > 0 || len(tags) > 0 {
+				return fmt.Errorf("no notes found matching the given criteria")
 			}
 			return fmt.Errorf("no notes found")
 		}
@@ -36,5 +51,8 @@ var latestCmd = &cobra.Command{
 }
 
 func init() {
+	latestCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	latestCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	latestCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	rootCmd.AddCommand(latestCmd)
 }

--- a/internal/cli/latest_test.go
+++ b/internal/cli/latest_test.go
@@ -75,6 +75,32 @@ func TestLatestWithSlug(t *testing.T) {
 	}
 }
 
+func TestLatestWithTag(t *testing.T) {
+	out, err := runLatest(t, "--tag", "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestLatestCombinedFilters(t *testing.T) {
+	out, err := runLatest(t, "--tag", "work", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260102_8814.todo.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
 func TestLatestSlugNotFound(t *testing.T) {
 	_, err := runLatest(t, "--slug", "nonexistent")
 	if err == nil {

--- a/internal/cli/latest_test.go
+++ b/internal/cli/latest_test.go
@@ -21,6 +21,12 @@ func runLatest(t *testing.T, args ...string) (string, error) {
 
 	root := testdataPath(t)
 
+	// Reset flags to avoid state leaking between tests.
+	latestCmd.ResetFlags()
+	latestCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	latestCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	latestCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
@@ -44,7 +50,7 @@ func TestLatestNoArgs(t *testing.T) {
 }
 
 func TestLatestWithType(t *testing.T) {
-	out, err := runLatest(t, "todo")
+	out, err := runLatest(t, "--type", "todo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,8 +62,28 @@ func TestLatestWithType(t *testing.T) {
 	}
 }
 
-func TestLatestNotFound(t *testing.T) {
-	_, err := runLatest(t, "nonexistent")
+func TestLatestWithSlug(t *testing.T) {
+	out, err := runLatest(t, "--slug", "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestLatestSlugNotFound(t *testing.T) {
+	_, err := runLatest(t, "--slug", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent slug, got nil")
+	}
+}
+
+func TestLatestTypeNotFound(t *testing.T) {
+	_, err := runLatest(t, "--type", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent type, got nil")
 	}

--- a/note/store.go
+++ b/note/store.go
@@ -130,9 +130,15 @@ func hasAllTags(noteTags []string, required []string) bool {
 
 // FilterBySlug returns notes with an exact slug match.
 func FilterBySlug(notes []Note, slug string) []Note {
+	return FilterBySlugs(notes, []string{slug})
+}
+
+// FilterBySlugs returns notes whose slug matches any of the given values.
+func FilterBySlugs(notes []Note, slugs []string) []Note {
+	set := toSet(slugs)
 	var results []Note
 	for _, n := range notes {
-		if n.Slug == slug {
+		if _, ok := set[n.Slug]; ok {
 			results = append(results, n)
 		}
 	}
@@ -141,11 +147,25 @@ func FilterBySlug(notes []Note, slug string) []Note {
 
 // FilterByType returns notes with an exact type match.
 func FilterByType(notes []Note, noteType string) []Note {
+	return FilterByTypes(notes, []string{noteType})
+}
+
+// FilterByTypes returns notes whose type matches any of the given values.
+func FilterByTypes(notes []Note, types []string) []Note {
+	set := toSet(types)
 	var results []Note
 	for _, n := range notes {
-		if n.Type == noteType {
+		if _, ok := set[n.Type]; ok {
 			results = append(results, n)
 		}
 	}
 	return results
+}
+
+func toSet(vals []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(vals))
+	for _, v := range vals {
+		m[v] = struct{}{}
+	}
+	return m
 }


### PR DESCRIPTION
Replace the positional `[type]` argument in `notes latest` with composable `--type`, `--slug`, and `--tag` flags. All flags are repeatable (`StringSlice`) and can be combined, e.g. `notes latest --type todo --tag work`. Also adds `FilterByTypes` and `FilterBySlugs` multi-value variants in `note/store.go`.