### PR TITLE
Add append subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `append` command for appending stdin text to existing notes ([#30])
+
 ## [0.1.23] - 2026-03-24
 
 ### Added
@@ -131,3 +135,4 @@
 [#25]: https://github.com/dreikanter/notescli/pull/25
 [#27]: https://github.com/dreikanter/notescli/pull/27
 [#28]: https://github.com/dreikanter/notescli/pull/28
+[#30]: https://github.com/dreikanter/notescli/pull/30

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+var appendCmd = &cobra.Command{
+	Use:   "append [<id|slug|filename|path>]",
+	Short: "Append text from stdin to an existing note",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+
+		// Check stdin is piped
+		if isTerminal(os.Stdin) {
+			return fmt.Errorf("no input: pipe text to stdin (e.g. echo 'text' | notes append <target>)")
+		}
+
+		// Read and trim stdin
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("cannot read stdin: %w", err)
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			return nil
+		}
+
+		types, _ := cmd.Flags().GetStringSlice("type")
+		slugs, _ := cmd.Flags().GetStringSlice("slug")
+		tags, _ := cmd.Flags().GetStringSlice("tag")
+		hasFilters := len(types) > 0 || len(slugs) > 0 || len(tags) > 0
+
+		var targetPath string
+
+		if len(args) == 1 {
+			if hasFilters {
+				return fmt.Errorf("cannot combine positional argument with filter flags")
+			}
+
+			if strings.Contains(args[0], "/") {
+				// Treat as file path
+				targetPath, err = resolveFilePath(args[0], root)
+				if err != nil {
+					return err
+				}
+			} else {
+				// Resolve by ID/slug/filename
+				notes, scanErr := note.Scan(root)
+				if scanErr != nil {
+					return scanErr
+				}
+				n := note.Resolve(notes, args[0])
+				if n == nil {
+					return fmt.Errorf("note not found: %s", args[0])
+				}
+				targetPath = filepath.Join(root, n.RelPath)
+			}
+		} else if hasFilters {
+			notes, scanErr := note.Scan(root)
+			if scanErr != nil {
+				return scanErr
+			}
+
+			if len(types) > 0 {
+				notes = note.FilterByTypes(notes, types)
+			}
+			if len(slugs) > 0 {
+				notes = note.FilterBySlugs(notes, slugs)
+			}
+			if len(tags) > 0 {
+				notes, err = note.FilterByTags(notes, root, tags)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(notes) == 0 {
+				return fmt.Errorf("no notes found matching the given criteria")
+			}
+			targetPath = filepath.Join(root, notes[0].RelPath)
+		} else {
+			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag)")
+		}
+
+		// Read existing file
+		existing, err := os.ReadFile(targetPath)
+		if err != nil {
+			return fmt.Errorf("cannot read note: %w", err)
+		}
+
+		// Append: ensure existing ends with \n, then \n + content + \n
+		existingStr := string(existing)
+		if len(existingStr) > 0 && !strings.HasSuffix(existingStr, "\n") {
+			existingStr += "\n"
+		}
+		result := existingStr + "\n" + content + "\n"
+
+		if err := os.WriteFile(targetPath, []byte(result), 0o644); err != nil {
+			return fmt.Errorf("cannot write note: %w", err)
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), targetPath)
+		return nil
+	},
+}
+
+func resolveFilePath(arg, root string) (string, error) {
+	absPath, err := filepath.Abs(arg)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve path: %w", err)
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve path: %w", err)
+	}
+
+	absRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve notes path: %w", err)
+	}
+
+	if !strings.HasPrefix(absPath, absRoot+"/") {
+		return "", fmt.Errorf("path is outside notes directory: %s", arg)
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		return "", fmt.Errorf("note not found: %s", arg)
+	}
+
+	return absPath, nil
+}
+
+func init() {
+	appendCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	appendCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+	rootCmd.AddCommand(appendCmd)
+}

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -64,28 +64,11 @@ var appendCmd = &cobra.Command{
 				targetPath = filepath.Join(root, n.RelPath)
 			}
 		} else if hasFilters {
-			notes, scanErr := note.Scan(root)
-			if scanErr != nil {
-				return scanErr
+			n, filterErr := scanAndFilter(cmd, root)
+			if filterErr != nil {
+				return filterErr
 			}
-
-			if len(types) > 0 {
-				notes = note.FilterByTypes(notes, types)
-			}
-			if len(slugs) > 0 {
-				notes = note.FilterBySlugs(notes, slugs)
-			}
-			if len(tags) > 0 {
-				notes, err = note.FilterByTags(notes, root, tags)
-				if err != nil {
-					return err
-				}
-			}
-
-			if len(notes) == 0 {
-				return fmt.Errorf("no notes found matching the given criteria")
-			}
-			targetPath = filepath.Join(root, notes[0].RelPath)
+			targetPath = filepath.Join(root, n.RelPath)
 		} else {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag)")
 		}
@@ -119,7 +102,7 @@ func resolveFilePath(arg, root string) (string, error) {
 	}
 	absPath, err = filepath.EvalSymlinks(absPath)
 	if err != nil {
-		return "", fmt.Errorf("cannot resolve path: %w", err)
+		return "", fmt.Errorf("note not found: %s", arg)
 	}
 
 	absRoot, err := filepath.EvalSymlinks(root)
@@ -129,10 +112,6 @@ func resolveFilePath(arg, root string) (string, error) {
 
 	if !strings.HasPrefix(absPath, absRoot+"/") {
 		return "", fmt.Errorf("path is outside notes directory: %s", arg)
-	}
-
-	if _, err := os.Stat(absPath); err != nil {
-		return "", fmt.Errorf("note not found: %s", arg)
 	}
 
 	return absPath, nil

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// copyTestdata copies testdata into a temporary directory so append tests
+// can modify files without affecting other tests.
+func copyTestdata(t *testing.T) string {
+	t.Helper()
+	src := testdataPath(t)
+	dst := t.TempDir()
+
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, path)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+	if err != nil {
+		t.Fatalf("cannot copy testdata: %v", err)
+	}
+	return dst
+}
+
+func runAppend(t *testing.T, root string, stdin string, args ...string) (string, error) {
+	t.Helper()
+
+	appendCmd.ResetFlags()
+	appendCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	appendCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"append", "--path", root}, args...))
+
+	// Replace stdin
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create pipe: %v", err)
+	}
+	os.Stdin = r
+
+	go func() {
+		_, _ = io.WriteString(w, stdin)
+		w.Close()
+	}()
+
+	execErr := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), execErr
+}
+
+func TestAppendByID(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "appended text", "8823")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	if out != want {
+		t.Errorf("got output %q, want %q", out, want)
+	}
+
+	data, _ := os.ReadFile(want)
+	if !strings.Contains(string(data), "appended text") {
+		t.Error("appended text not found in file")
+	}
+}
+
+func TestAppendByAbsolutePath(t *testing.T) {
+	root := copyTestdata(t)
+	target := filepath.Join(root, "2026/01/20260106_8823.md")
+	out, err := runAppend(t, root, "path append", target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// EvalSymlinks may resolve /var → /private/var on macOS
+	resolved, _ := filepath.EvalSymlinks(target)
+	if out != resolved {
+		t.Errorf("got output %q, want %q", out, resolved)
+	}
+
+	data, _ := os.ReadFile(target)
+	if !strings.Contains(string(data), "path append") {
+		t.Error("appended text not found in file")
+	}
+}
+
+func TestAppendByRelativePath(t *testing.T) {
+	root := copyTestdata(t)
+	target := filepath.Join(root, "2026/01/20260106_8823.md")
+
+	out, err := runAppend(t, root, "rel append", target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resolved, _ := filepath.EvalSymlinks(target)
+	if out != resolved {
+		t.Errorf("got output %q, want %q", out, resolved)
+	}
+}
+
+func TestAppendByTagFilter(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "tag append", "--tag", "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out != want {
+		t.Errorf("got output %q, want %q", out, want)
+	}
+
+	data, _ := os.ReadFile(want)
+	if !strings.Contains(string(data), "tag append") {
+		t.Error("appended text not found in file")
+	}
+}
+
+func TestAppendBySlugFilter(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "slug append", "--slug", "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out != want {
+		t.Errorf("got output %q, want %q", out, want)
+	}
+}
+
+func TestAppendByTypeFilter(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "type append", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260102_8814.todo.md")
+	if out != want {
+		t.Errorf("got output %q, want %q", out, want)
+	}
+}
+
+func TestAppendPathOutsideRoot(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "escape attempt", "/tmp/evil.md")
+	if err == nil {
+		t.Fatal("expected error for path outside notes directory, got nil")
+	}
+}
+
+func TestAppendNonExistentNote(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "9999")
+	if err == nil {
+		t.Fatal("expected error for non-existent note, got nil")
+	}
+}
+
+func TestAppendEmptyStdin(t *testing.T) {
+	root := copyTestdata(t)
+	target := filepath.Join(root, "2026/01/20260106_8823.md")
+	before, _ := os.ReadFile(target)
+
+	_, err := runAppend(t, root, "", "8823")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	after, _ := os.ReadFile(target)
+	if string(before) != string(after) {
+		t.Error("file should not have changed with empty stdin")
+	}
+}
+
+func TestAppendWhitespaceOnlyStdin(t *testing.T) {
+	root := copyTestdata(t)
+	target := filepath.Join(root, "2026/01/20260106_8823.md")
+	before, _ := os.ReadFile(target)
+
+	_, err := runAppend(t, root, "   \n\n  \t  ", "8823")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	after, _ := os.ReadFile(target)
+	if string(before) != string(after) {
+		t.Error("file should not have changed with whitespace-only stdin")
+	}
+}
+
+func TestAppendMultipleProducesSeparation(t *testing.T) {
+	root := copyTestdata(t)
+
+	_, _ = runAppend(t, root, "first fragment", "8823")
+	_, _ = runAppend(t, root, "second fragment", "8823")
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/01/20260106_8823.md"))
+	content := string(data)
+
+	if !strings.Contains(content, "first fragment") {
+		t.Error("first fragment not found")
+	}
+	if !strings.Contains(content, "second fragment") {
+		t.Error("second fragment not found")
+	}
+
+	// Fragments should be separated by a blank line
+	idx1 := strings.Index(content, "first fragment")
+	idx2 := strings.Index(content, "second fragment")
+	between := content[idx1+len("first fragment") : idx2]
+	if !strings.Contains(between, "\n\n") {
+		t.Errorf("fragments not separated by blank line, got between: %q", between)
+	}
+}
+
+func TestAppendPositionalArgWithFilterErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "8823", "--type", "todo")
+	if err == nil {
+		t.Fatal("expected error when combining positional arg and filter flags, got nil")
+	}
+}
+
+func TestAppendNoTargetErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text")
+	if err == nil {
+		t.Fatal("expected error when no target specified, got nil")
+	}
+}

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -109,16 +109,30 @@ func TestAppendByAbsolutePath(t *testing.T) {
 
 func TestAppendByRelativePath(t *testing.T) {
 	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260106_8823.md")
 
-	out, err := runAppend(t, root, "rel append", target)
+	// chdir into the temp root so a relative path containing "/" works
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get working directory: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("cannot chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	out, err := runAppend(t, root, "rel append", "2026/01/20260106_8823.md")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, _ := filepath.EvalSymlinks(target)
+	resolved, _ := filepath.EvalSymlinks(filepath.Join(root, "2026/01/20260106_8823.md"))
 	if out != resolved {
 		t.Errorf("got output %q, want %q", out, resolved)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/01/20260106_8823.md"))
+	if !strings.Contains(string(data), "rel append") {
+		t.Error("appended text not found in file")
 	}
 }
 

--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -14,40 +14,51 @@ var latestCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
-		notes, err := note.Scan(root)
+		n, err := scanAndFilter(cmd, root)
 		if err != nil {
 			return err
 		}
 
-		types, _ := cmd.Flags().GetStringSlice("type")
-		slugs, _ := cmd.Flags().GetStringSlice("slug")
-		tags, _ := cmd.Flags().GetStringSlice("tag")
-
-		if len(types) > 0 {
-			notes = note.FilterByTypes(notes, types)
-		}
-
-		if len(slugs) > 0 {
-			notes = note.FilterBySlugs(notes, slugs)
-		}
-
-		if len(tags) > 0 {
-			notes, err = note.FilterByTags(notes, root, tags)
-			if err != nil {
-				return err
-			}
-		}
-
-		if len(notes) == 0 {
-			if len(types) > 0 || len(slugs) > 0 || len(tags) > 0 {
-				return fmt.Errorf("no notes found matching the given criteria")
-			}
-			return fmt.Errorf("no notes found")
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, notes[0].RelPath))
+		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
 		return nil
 	},
+}
+
+// scanAndFilter scans notes and applies --type, --slug, --tag filter flags,
+// returning the most recent match.
+func scanAndFilter(cmd *cobra.Command, root string) (*note.Note, error) {
+	notes, err := note.Scan(root)
+	if err != nil {
+		return nil, err
+	}
+
+	types, _ := cmd.Flags().GetStringSlice("type")
+	slugs, _ := cmd.Flags().GetStringSlice("slug")
+	tags, _ := cmd.Flags().GetStringSlice("tag")
+
+	if len(types) > 0 {
+		notes = note.FilterByTypes(notes, types)
+	}
+
+	if len(slugs) > 0 {
+		notes = note.FilterBySlugs(notes, slugs)
+	}
+
+	if len(tags) > 0 {
+		notes, err = note.FilterByTags(notes, root, tags)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(notes) == 0 {
+		if len(types) > 0 || len(slugs) > 0 || len(tags) > 0 {
+			return nil, fmt.Errorf("no notes found matching the given criteria")
+		}
+		return nil, fmt.Errorf("no notes found")
+	}
+
+	return &notes[0], nil
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- Add `notes append` subcommand to append stdin text to existing notes
- Supports target resolution by positional arg (ID, slug, filename, or file path) or filter flags (`--type`, `--slug`, `--tag`)
- Stdin-only input with empty/whitespace-only silent exit; fragments separated by `\n\n`

## Spec

### Target resolution — two mutually exclusive modes:
- **Positional arg**: `notes append <id|slug|filename|path>` — if arg contains `/`, treat as file path (resolved via `filepath.Abs` + `filepath.EvalSymlinks`, validated to be within notes root); otherwise resolved via `note.Resolve()` (ID → slug → type → basename)
- **Filter flags**: `--type`, `--slug`, `--tag` — scan + filter, take most recent match

Error if both positional arg and filter flags are provided. Error if neither.

### Content input
Stdin only. Error if stdin is a terminal (not piped). If stdin is empty or whitespace-only after `TrimSpace`, exit silently with no changes.

### Fragment separation
`\n\n` between existing content and new fragment. Existing content is ensured to end with `\n`, then `\n` + trimmed content + `\n` is appended.

### Output
Print absolute path to stdout (consistent with `new`).

### Path safety
File path arguments are resolved via `filepath.EvalSymlinks` on both the candidate and root to prevent symlink escape, then validated with `strings.HasPrefix`.

## Test plan

- [x] Append to note by ID
- [x] Append to note by absolute file path
- [x] Append to note by relative file path
- [x] Append via `--tag`, `--slug`, `--type` filters
- [x] Path outside NOTES_PATH → error
- [x] Non-existent note → error
- [x] Empty stdin → silent exit, no file changes
- [x] Whitespace-only stdin → silent exit, no file changes
- [x] Multiple appends produce `\n\n`-separated fragments
- [x] Positional arg + filter flags → error
- [x] No target specified → error
- [x] `make test` and `make lint` pass