### PR TITLE
Replace [>] forwarded state with (moved) tag in todo rollover

### DIFF
--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -49,7 +49,7 @@ var newTodoCmd = &cobra.Command{
 		prevLines := strings.Split(string(prevData), "\n")
 
 		// Rollover tasks
-		result := note.RolloverTasks(prevLines, newTodoForce)
+		result := note.RolloverTasks(prevLines)
 
 		// Write back modified previous todo
 		if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
@@ -81,6 +81,6 @@ var newTodoCmd = &cobra.Command{
 }
 
 func init() {
-	newTodoCmd.Flags().BoolVar(&newTodoForce, "force", false, "regenerate today's todo even if it exists, and carry over in-progress tasks")
+	newTodoCmd.Flags().BoolVar(&newTodoForce, "force", false, "regenerate today's todo even if it exists")
 	rootCmd.AddCommand(newTodoCmd)
 }

--- a/note/todo.go
+++ b/note/todo.go
@@ -12,9 +12,10 @@ var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.?)(\].*)$`)
 type Task struct {
 	Line       string // original full line
 	Prefix     string // everything before the marker character: e.g. "  - ["
-	Marker     string // single char marker: " ", ">", "+", etc.
+	Marker     string // single char marker: " ", "x", "+", etc.
 	Suffix     string // everything after marker: e.g. "] some task"
 	IsDaily    bool   // whether line contains [daily]
+	IsMoved    bool   // whether line contains (moved)
 	LineNumber int    // 0-based index in the source file lines
 }
 
@@ -30,6 +31,7 @@ func ParseTask(line string, lineNumber int) *Task {
 		Marker:     m[2],
 		Suffix:     m[3],
 		IsDaily:    strings.Contains(line, "[daily]"),
+		IsMoved:    strings.Contains(line, "(moved)"),
 		LineNumber: lineNumber,
 	}
 }
@@ -82,6 +84,8 @@ func RolloverTasks(prevLines []string) RolloverResult {
 	var carried []Task
 
 	addTask := func(t Task) {
+		// Strip (moved) from suffix so carried tasks are clean
+		t.Suffix = strings.Replace(t.Suffix, "(moved) ", "", 1)
 		// Normalize: strip leading whitespace, bullet, and marker for dedup
 		key := strings.TrimSpace(t.Suffix)
 		if seen[key] {
@@ -96,10 +100,10 @@ func RolloverTasks(prevLines []string) RolloverResult {
 		case t.IsDaily:
 			// Daily tasks are always carried over regardless of marker
 			addTask(t)
-			if t.Marker == " " {
+			if t.Marker == " " && !t.IsMoved {
 				updated[t.LineNumber] = t.WithTag("moved")
 			}
-		case t.Marker == " ":
+		case t.Marker == " " && !t.IsMoved:
 			// Pending tasks: carry over and tag as moved in previous
 			addTask(t)
 			updated[t.LineNumber] = t.WithTag("moved")

--- a/note/todo.go
+++ b/note/todo.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// taskRe matches lines like "  - [ ] some task" or "[ ] some task" or "  [>] task".
+// taskRe matches lines like "  - [ ] some task" or "[ ] some task".
 var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.?)(\].*)$`)
 
 // Task represents a parsed task line from a todo note.
@@ -39,6 +39,17 @@ func (t *Task) Reassembled(marker string) string {
 	return t.Prefix + marker + t.Suffix
 }
 
+// WithTag returns the task line with a tag inserted after the marker bracket.
+// E.g. "- [ ] Do thing" with tag "moved" becomes "- [ ] (moved) Do thing".
+func (t *Task) WithTag(tag string) string {
+	// Suffix starts with "] ", insert tag after the "] "
+	if len(t.Suffix) >= 2 && t.Suffix[:2] == "] " {
+		return t.Prefix + t.Marker + "] (" + tag + ") " + t.Suffix[2:]
+	}
+	// Suffix is just "]" with no text
+	return t.Prefix + t.Marker + "] (" + tag + ")" + t.Suffix[1:]
+}
+
 // ExtractTasks parses all task lines from a todo file's content lines.
 func ExtractTasks(lines []string) []Task {
 	var tasks []Task
@@ -53,12 +64,11 @@ func ExtractTasks(lines []string) []Task {
 // RolloverResult holds the output of a todo rollover operation.
 type RolloverResult struct {
 	CarriedTasks []Task   // tasks to include in the new todo
-	UpdatedLines []string // modified lines of the previous todo (with [ ] → [>])
+	UpdatedLines []string // modified lines of the previous todo (with (moved) tag added)
 }
 
 // RolloverTasks determines which tasks to carry over and produces the modified previous todo.
-// If force is true, also carry over in-progress [>] tasks.
-func RolloverTasks(prevLines []string, force bool) RolloverResult {
+func RolloverTasks(prevLines []string) RolloverResult {
 	tasks := ExtractTasks(prevLines)
 	updated := make([]string, len(prevLines))
 	copy(updated, prevLines)
@@ -81,17 +91,13 @@ func RolloverTasks(prevLines []string, force bool) RolloverResult {
 		case t.IsDaily:
 			// Daily tasks are always carried over regardless of marker
 			addTask(t)
-			// If the task was pending, mark as forwarded in previous
 			if t.Marker == " " {
-				updated[t.LineNumber] = t.Reassembled(">")
+				updated[t.LineNumber] = t.WithTag("moved")
 			}
 		case t.Marker == " ":
-			// Pending tasks: carry over and mark as forwarded
+			// Pending tasks: carry over and tag as moved in previous
 			addTask(t)
-			updated[t.LineNumber] = t.Reassembled(">")
-		case t.Marker == ">" && force:
-			// In-progress tasks: only carry over with --force
-			addTask(t)
+			updated[t.LineNumber] = t.WithTag("moved")
 		}
 	}
 

--- a/note/todo.go
+++ b/note/todo.go
@@ -41,13 +41,18 @@ func (t *Task) Reassembled(marker string) string {
 
 // WithTag returns the task line with a tag inserted after the marker bracket.
 // E.g. "- [ ] Do thing" with tag "moved" becomes "- [ ] (moved) Do thing".
+// Returns the line unchanged if the tag is already present.
 func (t *Task) WithTag(tag string) string {
+	tagStr := "(" + tag + ")"
+	if strings.Contains(t.Suffix, tagStr) {
+		return t.Line
+	}
 	// Suffix starts with "] ", insert tag after the "] "
 	if len(t.Suffix) >= 2 && t.Suffix[:2] == "] " {
-		return t.Prefix + t.Marker + "] (" + tag + ") " + t.Suffix[2:]
+		return t.Prefix + t.Marker + "] " + tagStr + " " + t.Suffix[2:]
 	}
 	// Suffix is just "]" with no text
-	return t.Prefix + t.Marker + "] (" + tag + ")" + t.Suffix[1:]
+	return t.Prefix + t.Marker + "] " + tagStr + t.Suffix[1:]
 }
 
 // ExtractTasks parses all task lines from a todo file's content lines.

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -17,7 +17,7 @@ func TestParseTask(t *testing.T) {
 		{"pending with bullet", "- [ ] Buy milk", false, " ", false},
 		{"pending indented", "  [ ] Buy milk", false, " ", false},
 		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false},
-		{"in progress", "[>] Working on it", false, ">", false},
+		{"unknown marker", "[>] Working on it", false, ">", false},
 		{"completed", "[+] Done task", false, "+", false},
 		{"daily", "[ ] Standup [daily]", false, " ", true},
 		{"daily completed", "[+] Standup [daily]", false, "+", true},
@@ -54,10 +54,36 @@ func TestReassembled(t *testing.T) {
 	if task == nil {
 		t.Fatal("expected task")
 	}
-	got := task.Reassembled(">")
-	want := "  - [>] Some task"
+	got := task.Reassembled("+")
+	want := "  - [+] Some task"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWithTag(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		tag  string
+		want string
+	}{
+		{"simple", "- [ ] Do the thing", "moved", "- [ ] (moved) Do the thing"},
+		{"with existing tag", "- [ ] (private) Do the thing", "moved", "- [ ] (moved) (private) Do the thing"},
+		{"no bullet", "[ ] Do the thing", "moved", "[ ] (moved) Do the thing"},
+		{"indented", "  - [ ] Do the thing", "moved", "  - [ ] (moved) Do the thing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := ParseTask(tt.line, 0)
+			if task == nil {
+				t.Fatalf("expected task for %q", tt.line)
+			}
+			got := task.WithTag(tt.tag)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -70,62 +96,62 @@ slug: todo
 
 [ ] Pending task two
 
-[>] In progress task
-
 [+] Completed task
 
 [ ] Standup [daily]`, "\n")
 
-	result := RolloverTasks(prev, false)
+	result := RolloverTasks(prev)
 
 	// Should carry over: pending task one, pending task two, standup daily
 	if len(result.CarriedTasks) != 3 {
 		t.Fatalf("carried %d tasks, want 3", len(result.CarriedTasks))
 	}
 
-	// Verify previous todo was updated: pending tasks → [>]
+	// Verify previous todo was updated: pending tasks tagged (moved)
 	for _, line := range result.UpdatedLines {
-		if strings.Contains(line, "Pending task one") && !strings.Contains(line, "[>]") {
-			t.Errorf("pending task one should be [>] in updated lines, got: %s", line)
+		if strings.Contains(line, "Pending task one") && !strings.Contains(line, "(moved)") {
+			t.Errorf("pending task one should have (moved) tag, got: %s", line)
 		}
-		if strings.Contains(line, "Pending task two") && !strings.Contains(line, "[>]") {
-			t.Errorf("pending task two should be [>] in updated lines, got: %s", line)
+		if strings.Contains(line, "Pending task two") && !strings.Contains(line, "(moved)") {
+			t.Errorf("pending task two should have (moved) tag, got: %s", line)
 		}
 	}
 
-	// In-progress task should NOT be modified in updated lines
+	// Verify moved tasks still have [ ] marker
 	for _, line := range result.UpdatedLines {
-		if strings.Contains(line, "In progress task") && !strings.Contains(line, "[>]") {
-			t.Errorf("in-progress task should remain [>], got: %s", line)
+		if strings.Contains(line, "(moved)") && !strings.Contains(line, "[ ]") {
+			t.Errorf("moved task should keep [ ] marker, got: %s", line)
 		}
 	}
 }
 
-func TestRolloverTasksForce(t *testing.T) {
-	prev := strings.Split(`[ ] Pending task
+func TestRolloverTasksMovedFormat(t *testing.T) {
+	prev := strings.Split(`[ ] Buy milk
 
-[>] In progress task
+[ ] (private) Secret task
 
 [+] Completed task`, "\n")
 
-	result := RolloverTasks(prev, true)
+	result := RolloverTasks(prev)
 
-	// With force: carry pending + in-progress
 	if len(result.CarriedTasks) != 2 {
 		t.Fatalf("carried %d tasks, want 2", len(result.CarriedTasks))
 	}
 
-	markers := make(map[string]bool)
-	for _, task := range result.CarriedTasks {
-		if strings.Contains(task.Suffix, "Pending") {
-			markers["pending"] = true
+	// Verify (moved) is inserted before existing tags
+	for _, line := range result.UpdatedLines {
+		if strings.Contains(line, "Buy milk") && strings.Contains(line, "(moved)") {
+			want := "[ ] (moved) Buy milk"
+			if line != want {
+				t.Errorf("got %q, want %q", line, want)
+			}
 		}
-		if strings.Contains(task.Suffix, "In progress") {
-			markers["in-progress"] = true
+		if strings.Contains(line, "Secret task") && strings.Contains(line, "(moved)") {
+			want := "[ ] (moved) (private) Secret task"
+			if line != want {
+				t.Errorf("got %q, want %q", line, want)
+			}
 		}
-	}
-	if !markers["pending"] || !markers["in-progress"] {
-		t.Error("expected both pending and in-progress tasks to be carried over with force")
 	}
 }
 
@@ -134,7 +160,7 @@ func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
 
 [+] Completed other task`, "\n")
 
-	result := RolloverTasks(prev, false)
+	result := RolloverTasks(prev)
 
 	if len(result.CarriedTasks) != 1 {
 		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
@@ -148,7 +174,7 @@ func TestRolloverTasksNoDuplicates(t *testing.T) {
 	// A daily task that is also pending should appear only once
 	prev := strings.Split(`[ ] Standup [daily]`, "\n")
 
-	result := RolloverTasks(prev, false)
+	result := RolloverTasks(prev)
 
 	if len(result.CarriedTasks) != 1 {
 		t.Fatalf("carried %d tasks, want 1 (no duplicates)", len(result.CarriedTasks))
@@ -162,7 +188,7 @@ slug: todo
 
 [+] Everything done`, "\n")
 
-	result := RolloverTasks(prev, false)
+	result := RolloverTasks(prev)
 
 	if len(result.CarriedTasks) != 0 {
 		t.Errorf("carried %d tasks, want 0", len(result.CarriedTasks))
@@ -172,7 +198,7 @@ slug: todo
 func TestFormatTodoContent(t *testing.T) {
 	tasks := []Task{
 		{Prefix: "[", Marker: " ", Suffix: "] Task one"},
-		{Prefix: "[", Marker: ">", Suffix: "] Task two"},
+		{Prefix: "[", Marker: " ", Suffix: "] Task two"},
 	}
 
 	content := FormatTodoContent(tasks)

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -12,18 +12,21 @@ func TestParseTask(t *testing.T) {
 		wantNil bool
 		marker  string
 		isDaily bool
+		isMoved bool
 	}{
-		{"pending", "[ ] Buy milk", false, " ", false},
-		{"pending with bullet", "- [ ] Buy milk", false, " ", false},
-		{"pending indented", "  [ ] Buy milk", false, " ", false},
-		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false},
-		{"completed", "[+] Done task", false, "+", false},
-		{"daily", "[ ] Standup [daily]", false, " ", true},
-		{"daily completed", "[+] Standup [daily]", false, "+", true},
-		{"not a task", "Just a regular line", true, "", false},
-		{"empty", "", true, "", false},
-		{"header", "# Todo", true, "", false},
-		{"frontmatter", "---", true, "", false},
+		{"pending", "[ ] Buy milk", false, " ", false, false},
+		{"pending with bullet", "- [ ] Buy milk", false, " ", false, false},
+		{"pending indented", "  [ ] Buy milk", false, " ", false, false},
+		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false, false},
+		{"completed", "[+] Done task", false, "+", false, false},
+		{"daily", "[ ] Standup [daily]", false, " ", true, false},
+		{"daily completed", "[+] Standup [daily]", false, "+", true, false},
+		{"moved", "- [ ] (moved) Buy milk", false, " ", false, true},
+		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, " ", false, true},
+		{"not a task", "Just a regular line", true, "", false, false},
+		{"empty", "", true, "", false, false},
+		{"header", "# Todo", true, "", false, false},
+		{"frontmatter", "---", true, "", false, false},
 	}
 
 	for _, tt := range tests {
@@ -43,6 +46,9 @@ func TestParseTask(t *testing.T) {
 			}
 			if task.IsDaily != tt.isDaily {
 				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)
+			}
+			if task.IsMoved != tt.isMoved {
+				t.Errorf("isMoved: got %v, want %v", task.IsMoved, tt.isMoved)
 			}
 		})
 	}
@@ -152,6 +158,30 @@ func TestRolloverTasksMovedFormat(t *testing.T) {
 			if line != want {
 				t.Errorf("got %q, want %q", line, want)
 			}
+		}
+	}
+}
+
+func TestRolloverTasksSkipsMoved(t *testing.T) {
+	prev := strings.Split(`[ ] (moved) Already moved task
+
+[ ] Fresh task
+
+[x] Done task`, "\n")
+
+	result := RolloverTasks(prev)
+
+	if len(result.CarriedTasks) != 1 {
+		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
+	}
+	if !strings.Contains(result.CarriedTasks[0].Suffix, "Fresh task") {
+		t.Errorf("expected Fresh task, got: %s", result.CarriedTasks[0].Suffix)
+	}
+
+	// Already-moved task should not be re-tagged
+	for _, line := range result.UpdatedLines {
+		if strings.Contains(line, "Already moved") && line != "[ ] (moved) Already moved task" {
+			t.Errorf("moved task should be unchanged, got: %s", line)
 		}
 	}
 }

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -71,6 +71,8 @@ func TestWithTag(t *testing.T) {
 		{"with existing tag", "- [ ] (private) Do the thing", "moved", "- [ ] (moved) (private) Do the thing"},
 		{"no bullet", "[ ] Do the thing", "moved", "[ ] (moved) Do the thing"},
 		{"indented", "  - [ ] Do the thing", "moved", "  - [ ] (moved) Do the thing"},
+		{"already tagged", "- [ ] (moved) Do the thing", "moved", "- [ ] (moved) Do the thing"},
+		{"already tagged with other", "- [ ] (moved) (private) Do the thing", "moved", "- [ ] (moved) (private) Do the thing"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -17,7 +17,6 @@ func TestParseTask(t *testing.T) {
 		{"pending with bullet", "- [ ] Buy milk", false, " ", false},
 		{"pending indented", "  [ ] Buy milk", false, " ", false},
 		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false},
-		{"unknown marker", "[>] Working on it", false, ">", false},
 		{"completed", "[+] Done task", false, "+", false},
 		{"daily", "[ ] Standup [daily]", false, " ", true},
 		{"daily completed", "[+] Standup [daily]", false, "+", true},

--- a/testdata/2026/01/20260102_8814.todo.md
+++ b/testdata/2026/01/20260102_8814.todo.md
@@ -5,4 +5,4 @@ tags: [work, planning]
 # Todo
 
 - [ ] Task one
-- [>] Task two
+- [ ] (moved) Task two


### PR DESCRIPTION
During todo rollover, incomplete tasks carried to the new todo are now tagged with `(moved)` in the previous todo instead of having their marker changed to `[>]`. The `(moved)` tag is inserted first, before any existing tags. The `--force` flag on `new-todo` is retained for regenerating today's todo but no longer affects which tasks are carried over, since the in-progress `[>]` state no longer exists.