### PR TITLE
Add --name flag to ls for filename substring search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `append` command for appending stdin text to existing notes ([#30])
 - Add `update` command for updating frontmatter and renaming notes ([#34])
+- Add `--name` flag to `ls` for case-insensitive substring search on note filenames
 
 ## [0.1.23] - 2026-03-24
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -12,6 +12,7 @@ var (
 	lsType  string
 	lsSlug  string
 	lsTags  []string
+	lsName  string
 )
 
 var lsCmd = &cobra.Command{
@@ -23,6 +24,10 @@ var lsCmd = &cobra.Command{
 		notes, err := note.Scan(root)
 		if err != nil {
 			return err
+		}
+
+		if lsName != "" {
+			notes = note.Filter(notes, lsName)
 		}
 
 		if lsType != "" {
@@ -56,5 +61,6 @@ func init() {
 	lsCmd.Flags().StringVar(&lsType, "type", "", "filter by note type, e.g. todo, backlog, weekly")
 	lsCmd.Flags().StringVar(&lsSlug, "slug", "", "filter by descriptive slug")
 	lsCmd.Flags().StringSliceVar(&lsTags, "tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
+	lsCmd.Flags().StringVar(&lsName, "name", "", "filter by filename fragment (case-insensitive substring)")
 	rootCmd.AddCommand(lsCmd)
 }

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -15,6 +15,7 @@ func runLs(t *testing.T, args ...string) (string, error) {
 	lsTags = nil
 	lsType = ""
 	lsSlug = ""
+	lsName = ""
 	lsLimit = 20
 	lsCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
 
@@ -129,5 +130,46 @@ func TestLsTagAndTypeNoOverlap(t *testing.T) {
 
 	if out != "" {
 		t.Errorf("expected empty output (no todo with meeting tag), got %q", out)
+	}
+}
+
+func TestLsWithName(t *testing.T) {
+	out, err := runLs(t, "--name", "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "meeting") {
+		t.Errorf("expected meeting note, got %q", lines[0])
+	}
+}
+
+func TestLsNameNoMatch(t *testing.T) {
+	out, err := runLs(t, "--name", "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestLsNameAndType(t *testing.T) {
+	out, err := runLs(t, "--name", "8814", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "8814") {
+		t.Errorf("expected note 8814, got %q", lines[0])
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--name <fragment>` flag to the `ls` command for case-insensitive substring search on note filenames
- Reuses the existing `note.Filter()` function (same logic as the `filter` command)
- Composable with existing `--type`, `--slug`, `--tag`, and `--limit` flags

## Test Plan

- [ ] `notes ls --name meeting` returns notes with "meeting" in filename
- [ ] `notes ls --name nonexistent` returns empty output
- [ ] `notes ls --name 8814 --type todo` returns the matching note