### PR TITLE
Refactor CLI commands to read flags via GetString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@
 
 - Add `append` command for appending stdin text to existing notes ([#30])
 - Add `update` command for updating frontmatter and renaming notes ([#34])
-- Add `--name` flag to `ls` for case-insensitive substring search on note filenames
+- Add `--name` flag to `ls` for case-insensitive substring search on note filenames ([#36])
 
 ### Changed
 
-- Migrate `new`, `ls`, `new-todo`, and `update` flag bindings from package-level vars to `GetString`/`GetBool` (Pattern B) for cleaner test isolation ([#35])
+- Migrate `new`, `ls`, `new-todo`, and `update` flag bindings from package-level vars to `GetString`/`GetBool` (Pattern B) for cleaner test isolation ([#39])
 
 ### Removed
 
-- Remove `filter` command (superseded by `ls --name`)
+- Remove `filter` command (superseded by `ls --name`) ([#38])
 
 ## [0.1.23] - 2026-03-24
 
@@ -147,3 +147,6 @@
 [#28]: https://github.com/dreikanter/notescli/pull/28
 [#30]: https://github.com/dreikanter/notescli/pull/30
 [#34]: https://github.com/dreikanter/notescli/pull/34
+[#36]: https://github.com/dreikanter/notescli/pull/36
+[#38]: https://github.com/dreikanter/notescli/pull/38
+[#39]: https://github.com/dreikanter/notescli/pull/39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add `update` command for updating frontmatter and renaming notes ([#34])
 - Add `--name` flag to `ls` for case-insensitive substring search on note filenames
 
+### Changed
+
+- Migrate `new`, `ls`, `new-todo`, and `update` flag bindings from package-level vars to `GetString`/`GetBool` (Pattern B) for cleaner test isolation ([#35])
+
 ### Removed
 
 - Remove `filter` command (superseded by `ls --name`)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ notes ls --limit 10
 notes ls --type todo
 notes ls --slug meeting
 notes ls --tag work
-notes ls --tag work --tag meeting
+notes ls --tag work --tag meeting  # multiple --tag flags are ANDed; all flags compose
 notes ls --tag work --type todo
 notes ls --name 2026
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Notes CLI
 
-A CLI tool for managing a file-based of markdown notes.
+A CLI tool for managing a file-based store of markdown notes.
 
 ## Install
 
@@ -20,18 +20,6 @@ For development, use `make build` or `make install` from a local clone.
 ## Usage
 
 ```sh
-# Show help
-notes --help
-
-# Read a note by ID
-notes read 8823
-
-# Read a note by slug
-notes read todo
-
-# Read a note by filename
-notes read 20260106_8823.md
-
 # Create a new note
 notes new
 notes new --title "Meeting notes" --slug meeting --tag work
@@ -39,30 +27,47 @@ notes new --title "Meeting notes" --slug meeting --tag work
 # Create today's todo from the previous todo
 notes new-todo
 
-# Filter notes by filename fragment
-notes ls --name todo
-notes ls --name 2026
-
 # List recent notes
 notes ls
 notes ls --limit 10
 notes ls --type todo
+notes ls --slug meeting
 notes ls --tag work
 notes ls --tag work --tag meeting
 notes ls --tag work --type todo
+notes ls --name 2026
 
-# Search note contents (only .md files, .git excluded)
-notes grep "search pattern"
+# Read a note by ID, slug, or filename
+notes read 8823
+notes read meeting
+notes read 20260106_8823.md
+
+# Append stdin text to a note
+echo "text" | notes append 8823
+echo "text" | notes append --type todo
+echo "text" | notes append --type weekly --create
+
+# Update frontmatter and rename a note
+notes update 8823 --title "New Title"
+notes update 8823 --tag work --tag planning
+notes update 8823 --slug meeting
+notes update 8823 --no-slug
+notes update 8823 --type todo
+notes update 8823 --no-type
+notes update 8823 --no-tags
 
 # Print path to most recent note
 notes latest
 notes latest --type todo
+notes latest --slug meeting
+notes latest --tag work
+
+# Search note contents
+notes grep "search pattern"
+notes rg "search pattern"
 
 # Print the notes store path
 notes path
-
-# Override notes store path
-notes --path /path/to/notes read 8823
 ```
 
 The notes store path is resolved in this order:
@@ -74,6 +79,8 @@ The notes store path is resolved in this order:
 ## Development
 
 ```sh
+make build       # build local ./notes binary
+make install     # build and install to ~/go/bin/notes
 make test        # run all tests
 make lint        # run golangci-lint
 make clean       # remove built binary

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ notes ls --tag work --tag meeting  # multiple --tag flags are ANDed; all flags c
 notes ls --tag work --type todo
 notes ls --name 2026
 
-# Read a note by ID, slug, or filename
+# Note references: any command accepting a note ref resolves by ID, slug, basename, or full path
 notes read 8823
 notes read meeting
 notes read 20260106_8823.md

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -7,19 +7,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	lsLimit int
-	lsType  string
-	lsSlug  string
-	lsTags  []string
-	lsName  string
-)
-
 var lsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List recent notes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		lsLimit, _ := cmd.Flags().GetInt("limit")
+		lsType, _ := cmd.Flags().GetString("type")
+		lsSlug, _ := cmd.Flags().GetString("slug")
+		lsTags, _ := cmd.Flags().GetStringSlice("tag")
+		lsName, _ := cmd.Flags().GetString("name")
+
 		root := mustNotesPath()
 		notes, err := note.Scan(root)
 		if err != nil {
@@ -57,10 +55,10 @@ var lsCmd = &cobra.Command{
 }
 
 func init() {
-	lsCmd.Flags().IntVar(&lsLimit, "limit", 20, "maximum number of notes to list")
-	lsCmd.Flags().StringVar(&lsType, "type", "", "filter by note type, e.g. todo, backlog, weekly")
-	lsCmd.Flags().StringVar(&lsSlug, "slug", "", "filter by descriptive slug")
-	lsCmd.Flags().StringSliceVar(&lsTags, "tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
-	lsCmd.Flags().StringVar(&lsName, "name", "", "filter by filename fragment (case-insensitive substring)")
+	lsCmd.Flags().Int("limit", 20, "maximum number of notes to list")
+	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
+	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
+	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
+	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 	rootCmd.AddCommand(lsCmd)
 }

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -20,8 +20,6 @@ func runLs(t *testing.T, args ...string) (string, error) {
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	lsCmd.SetOut(buf)
-	lsCmd.SetErr(buf)
 	rootCmd.SetArgs(append([]string{"ls", "--path", root}, args...))
 
 	err := rootCmd.Execute()

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -4,20 +4,18 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-
-	"github.com/spf13/pflag"
 )
 
 func runLs(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 
 	root := testdataPath(t)
-	lsTags = nil
-	lsType = ""
-	lsSlug = ""
-	lsName = ""
-	lsLimit = 20
-	lsCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	lsCmd.ResetFlags()
+	lsCmd.Flags().Int("limit", 20, "maximum number of notes to list")
+	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
+	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
+	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
+	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -10,21 +10,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	newSlug        string
-	newType        string
-	newTags        []string
-	newDescription string
-	newTitle       string
-)
-
 var newCmd = &cobra.Command{
 	Use:   "new",
 	Short: "Create a new note",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if newType != "" && !note.IsKnownType(newType) {
-			return fmt.Errorf("unknown note type %q (valid types: %s)", newType, strings.Join(note.KnownTypes, ", "))
+		slug, _ := cmd.Flags().GetString("slug")
+		noteType, _ := cmd.Flags().GetString("type")
+		tags, _ := cmd.Flags().GetStringArray("tag")
+		description, _ := cmd.Flags().GetString("description")
+		title, _ := cmd.Flags().GetString("title")
+
+		if noteType != "" && !note.IsKnownType(noteType) {
+			return fmt.Errorf("unknown note type %q (valid types: %s)", noteType, strings.Join(note.KnownTypes, ", "))
 		}
 
 		root := mustNotesPath()
@@ -40,11 +38,11 @@ var newCmd = &cobra.Command{
 
 		fullPath, err := createNote(createNoteParams{
 			Root:        root,
-			Slug:        newSlug,
-			Type:        newType,
-			Tags:        newTags,
-			Title:       newTitle,
-			Description: newDescription,
+			Slug:        slug,
+			Type:        noteType,
+			Tags:        tags,
+			Title:       title,
+			Description: description,
 			Body:        body,
 		})
 		if err != nil {
@@ -65,10 +63,10 @@ func isTerminal(f *os.File) bool {
 }
 
 func init() {
-	newCmd.Flags().StringVar(&newSlug, "slug", "", "descriptive slug appended to filename")
-	newCmd.Flags().StringVar(&newType, "type", "", "note type (todo, backlog, weekly)")
-	newCmd.Flags().StringArrayVar(&newTags, "tag", nil, "tag for frontmatter (repeatable)")
-	newCmd.Flags().StringVar(&newDescription, "description", "", "description for frontmatter")
-	newCmd.Flags().StringVar(&newTitle, "title", "", "title for frontmatter")
+	newCmd.Flags().String("slug", "", "descriptive slug appended to filename")
+	newCmd.Flags().String("type", "", "note type (todo, backlog, weekly)")
+	newCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable)")
+	newCmd.Flags().String("description", "", "description for frontmatter")
+	newCmd.Flags().String("title", "", "title for frontmatter")
 	rootCmd.AddCommand(newCmd)
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -17,7 +17,7 @@ var newCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		slug, _ := cmd.Flags().GetString("slug")
 		noteType, _ := cmd.Flags().GetString("type")
-		tags, _ := cmd.Flags().GetStringArray("tag")
+		tags, _ := cmd.Flags().GetStringSlice("tag")
 		description, _ := cmd.Flags().GetString("description")
 		title, _ := cmd.Flags().GetString("title")
 
@@ -49,7 +49,7 @@ var newCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println(fullPath)
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
 		return nil
 	},
 }
@@ -65,7 +65,7 @@ func isTerminal(f *os.File) bool {
 func init() {
 	newCmd.Flags().String("slug", "", "descriptive slug appended to filename")
 	newCmd.Flags().String("type", "", "note type (todo, backlog, weekly)")
-	newCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable)")
+	newCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable)")
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
 	rootCmd.AddCommand(newCmd)

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,39 +15,31 @@ func runNew(t *testing.T, root string, stdin string, args ...string) (string, er
 	newCmd.ResetFlags()
 	newCmd.Flags().String("slug", "", "descriptive slug appended to filename")
 	newCmd.Flags().String("type", "", "note type (todo, backlog, weekly)")
-	newCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable)")
+	newCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable)")
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
 
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
 	rootCmd.SetArgs(append([]string{"new", "--path", root}, args...))
 
-	// Capture os.Stdout (new prints via fmt.Println, not cmd.OutOrStdout).
-	oldStdout := os.Stdout
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("cannot create stdout pipe: %v", err)
-	}
-	os.Stdout = pw
-	defer func() { os.Stdout = oldStdout }()
-
-	// Replace stdin.
 	oldStdin := os.Stdin
-	sr, sw, err := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("cannot create stdin pipe: %v", err)
 	}
-	os.Stdin = sr
-	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
 
 	go func() {
-		_, _ = io.WriteString(sw, stdin)
-		sw.Close()
+		_, _ = io.WriteString(w, stdin)
+		w.Close()
 	}()
 
 	execErr := rootCmd.Execute()
-	pw.Close()
-	out, _ := io.ReadAll(pr)
-	return strings.TrimSpace(string(out)), execErr
+	return strings.TrimSpace(buf.String()), execErr
 }
 
 func TestNewDefault(t *testing.T) {

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runNew(t *testing.T, root string, stdin string, args ...string) (string, error) {
+	t.Helper()
+
+	newCmd.ResetFlags()
+	newCmd.Flags().String("slug", "", "descriptive slug appended to filename")
+	newCmd.Flags().String("type", "", "note type (todo, backlog, weekly)")
+	newCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable)")
+	newCmd.Flags().String("description", "", "description for frontmatter")
+	newCmd.Flags().String("title", "", "title for frontmatter")
+
+	rootCmd.SetArgs(append([]string{"new", "--path", root}, args...))
+
+	// Capture os.Stdout (new prints via fmt.Println, not cmd.OutOrStdout).
+	oldStdout := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create stdout pipe: %v", err)
+	}
+	os.Stdout = pw
+	defer func() { os.Stdout = oldStdout }()
+
+	// Replace stdin.
+	oldStdin := os.Stdin
+	sr, sw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create stdin pipe: %v", err)
+	}
+	os.Stdin = sr
+	defer func() { os.Stdin = oldStdin }()
+
+	go func() {
+		_, _ = io.WriteString(sw, stdin)
+		sw.Close()
+	}()
+
+	execErr := rootCmd.Execute()
+	pw.Close()
+	out, _ := io.ReadAll(pr)
+	return strings.TrimSpace(string(out)), execErr
+}
+
+func TestNewDefault(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(out, root) {
+		t.Errorf("expected path under root, got %q", out)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("created file does not exist: %v", err)
+	}
+}
+
+func TestNewWithSlug(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--slug", "myslug")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(filepath.Base(out), "_myslug") {
+		t.Errorf("expected slug in filename, got %q", filepath.Base(out))
+	}
+}
+
+func TestNewWithType(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--type", "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(filepath.Base(out), ".todo.") {
+		t.Errorf("expected type in filename, got %q", filepath.Base(out))
+	}
+}
+
+func TestNewInvalidTypeErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runNew(t, root, "", "--type", "invalid")
+	if err == nil {
+		t.Fatal("expected error for unknown type, got nil")
+	}
+}
+
+func TestNewWithTags(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--tag", "work", "--tag", "daily")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "tags: [work, daily]") {
+		t.Errorf("expected tags in frontmatter, got:\n%s", string(data))
+	}
+}
+
+func TestNewWithTitleAndDescription(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--title", "My Note", "--description", "A description")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(out)
+	content := string(data)
+	if !strings.Contains(content, "title: My Note") {
+		t.Errorf("expected title in frontmatter, got:\n%s", content)
+	}
+	if !strings.Contains(content, "description: A description") {
+		t.Errorf("expected description in frontmatter, got:\n%s", content)
+	}
+}
+
+func TestNewWithBody(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "hello world\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "hello world") {
+		t.Errorf("expected body content in file, got:\n%s", string(data))
+	}
+}

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var newTodoForce bool
-
 var newTodoCmd = &cobra.Command{
 	Use:   "new-todo",
 	Short: "Create today's todo from the previous todo",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+
 		root := mustNotesPath()
 		today := time.Now().Format("20060102")
 
@@ -27,7 +27,7 @@ var newTodoCmd = &cobra.Command{
 		}
 
 		// Check if today's todo already exists
-		if !newTodoForce {
+		if !force {
 			if existing := note.FindTodayTodo(notes, today); existing != nil {
 				fmt.Println(filepath.Join(root, existing.RelPath))
 				return nil
@@ -81,6 +81,6 @@ var newTodoCmd = &cobra.Command{
 }
 
 func init() {
-	newTodoCmd.Flags().BoolVar(&newTodoForce, "force", false, "regenerate today's todo even if it exists")
+	newTodoCmd.Flags().Bool("force", false, "regenerate today's todo even if it exists")
 	rootCmd.AddCommand(newTodoCmd)
 }

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -29,7 +29,7 @@ var newTodoCmd = &cobra.Command{
 		// Check if today's todo already exists
 		if !force {
 			if existing := note.FindTodayTodo(notes, today); existing != nil {
-				fmt.Println(filepath.Join(root, existing.RelPath))
+				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, existing.RelPath))
 				return nil
 			}
 		}
@@ -75,7 +75,7 @@ var newTodoCmd = &cobra.Command{
 			return fmt.Errorf("cannot write todo: %w", err)
 		}
 
-		fmt.Println(fullPath)
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
 		return nil
 	},
 }

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,21 +16,13 @@ func runNewTodo(t *testing.T, root string, args ...string) (string, error) {
 	newTodoCmd.ResetFlags()
 	newTodoCmd.Flags().Bool("force", false, "regenerate today's todo even if it exists")
 
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
 	rootCmd.SetArgs(append([]string{"new-todo", "--path", root}, args...))
 
-	// Capture os.Stdout (new-todo prints via fmt.Println, not cmd.OutOrStdout).
-	oldStdout := os.Stdout
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("cannot create stdout pipe: %v", err)
-	}
-	os.Stdout = pw
-	defer func() { os.Stdout = oldStdout }()
-
-	execErr := rootCmd.Execute()
-	pw.Close()
-	out, _ := io.ReadAll(pr)
-	return strings.TrimSpace(string(out)), execErr
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
 }
 
 // emptyNotesRoot creates a temp dir with only id.json, no notes.

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func runNewTodo(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
+	newTodoCmd.ResetFlags()
+	newTodoCmd.Flags().Bool("force", false, "regenerate today's todo even if it exists")
+
+	rootCmd.SetArgs(append([]string{"new-todo", "--path", root}, args...))
+
+	// Capture os.Stdout (new-todo prints via fmt.Println, not cmd.OutOrStdout).
+	oldStdout := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create stdout pipe: %v", err)
+	}
+	os.Stdout = pw
+	defer func() { os.Stdout = oldStdout }()
+
+	execErr := rootCmd.Execute()
+	pw.Close()
+	out, _ := io.ReadAll(pr)
+	return strings.TrimSpace(string(out)), execErr
+}
+
+// emptyNotesRoot creates a temp dir with only id.json, no notes.
+func emptyNotesRoot(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	data, _ := json.Marshal(map[string]int{"last_id": 9000})
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), data, 0o644); err != nil {
+		t.Fatalf("cannot write id.json: %v", err)
+	}
+	return dir
+}
+
+func TestNewTodoCreatesFromPrevious(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	today := time.Now().Format("20060102")
+	if !strings.Contains(filepath.Base(out), today) {
+		t.Errorf("expected today's date %s in filename, got %q", today, filepath.Base(out))
+	}
+	if !strings.Contains(filepath.Base(out), ".todo.") {
+		t.Errorf("expected .todo. in filename, got %q", filepath.Base(out))
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("created file does not exist: %v", err)
+	}
+}
+
+func TestNewTodoReturnsExistingToday(t *testing.T) {
+	root := copyTestdata(t)
+
+	// First call creates today's todo.
+	first, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("first call unexpected error: %v", err)
+	}
+
+	// Second call without --force should return the same path.
+	second, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("second call unexpected error: %v", err)
+	}
+
+	if first != second {
+		t.Errorf("expected same path on second call, got %q then %q", first, second)
+	}
+}
+
+func TestNewTodoForceRegenerates(t *testing.T) {
+	root := copyTestdata(t)
+
+	// First call creates today's todo.
+	first, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("first call unexpected error: %v", err)
+	}
+
+	// --force should create a new file.
+	second, err := runNewTodo(t, root, "--force")
+	if err != nil {
+		t.Fatalf("force call unexpected error: %v", err)
+	}
+
+	if first == second {
+		t.Errorf("expected a different path with --force, got same path %q", first)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Errorf("forced file does not exist: %v", err)
+	}
+}
+
+func TestNewTodoNoPreviousErrors(t *testing.T) {
+	root := emptyNotesRoot(t)
+	_, err := runNewTodo(t, root)
+	if err == nil {
+		t.Fatal("expected error when no previous todo exists, got nil")
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -16,7 +16,7 @@ var updateCmd = &cobra.Command{
 	Short: "Update frontmatter and/or rename a note",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		updateTags, _ := cmd.Flags().GetStringArray("tag")
+		updateTags, _ := cmd.Flags().GetStringSlice("tag")
 		updateNoTags, _ := cmd.Flags().GetBool("no-tags")
 		updateTitle, _ := cmd.Flags().GetString("title")
 		updateDescription, _ := cmd.Flags().GetString("description")
@@ -109,7 +109,7 @@ var updateCmd = &cobra.Command{
 }
 
 func init() {
-	updateCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
+	updateCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
 	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
 	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
 	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,22 +11,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	updateTags        []string
-	updateNoTags      bool
-	updateTitle       string
-	updateDescription string
-	updateSlug        string
-	updateNoSlug      bool
-	updateType        string
-	updateNoType      bool
-)
-
 var updateCmd = &cobra.Command{
 	Use:   "update <ref>",
 	Short: "Update frontmatter and/or rename a note",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		updateTags, _ := cmd.Flags().GetStringArray("tag")
+		updateNoTags, _ := cmd.Flags().GetBool("no-tags")
+		updateTitle, _ := cmd.Flags().GetString("title")
+		updateDescription, _ := cmd.Flags().GetString("description")
+		updateSlug, _ := cmd.Flags().GetString("slug")
+		updateNoSlug, _ := cmd.Flags().GetBool("no-slug")
+		updateType, _ := cmd.Flags().GetString("type")
+		updateNoType, _ := cmd.Flags().GetBool("no-type")
+
 		if updateType != "" && !note.IsKnownType(updateType) {
 			return fmt.Errorf("unknown note type %q (valid types: %s)", updateType, strings.Join(note.KnownTypes, ", "))
 		}
@@ -111,13 +109,13 @@ var updateCmd = &cobra.Command{
 }
 
 func init() {
-	updateCmd.Flags().StringArrayVar(&updateTags, "tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
-	updateCmd.Flags().BoolVar(&updateNoTags, "no-tags", false, "remove all tags from frontmatter")
-	updateCmd.Flags().StringVar(&updateTitle, "title", "", "title for frontmatter (empty string clears it)")
-	updateCmd.Flags().StringVar(&updateDescription, "description", "", "description for frontmatter (empty string clears it)")
-	updateCmd.Flags().StringVar(&updateSlug, "slug", "", "update slug and rename file")
-	updateCmd.Flags().BoolVar(&updateNoSlug, "no-slug", false, "remove slug from filename")
-	updateCmd.Flags().StringVar(&updateType, "type", "", "update note type and rename file (todo, backlog, weekly)")
-	updateCmd.Flags().BoolVar(&updateNoType, "no-type", false, "remove type suffix from filename")
+	updateCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
+	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
+	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
+	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")
+	updateCmd.Flags().String("slug", "", "update slug and rename file")
+	updateCmd.Flags().Bool("no-slug", false, "remove slug from filename")
+	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
+	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
 	rootCmd.AddCommand(updateCmd)
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -12,7 +12,7 @@ func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
 	updateCmd.ResetFlags()
-	updateCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
+	updateCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
 	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
 	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
 	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -6,22 +6,20 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/spf13/pflag"
 )
 
 func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
-	updateNoTags = false
-	updateNoSlug = false
-	updateNoType = false
-	updateTags = nil
-	updateSlug = ""
-	updateType = ""
-	updateTitle = ""
-	updateDescription = ""
-	updateCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	updateCmd.ResetFlags()
+	updateCmd.Flags().StringArray("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
+	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
+	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
+	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")
+	updateCmd.Flags().String("slug", "", "update slug and rename file")
+	updateCmd.Flags().Bool("no-slug", false, "remove slug from filename")
+	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
+	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)


### PR DESCRIPTION
## Summary

- Removes package-level flag vars from `new`, `ls`, `new-todo`, and `update` commands
- Replaces `StringVar`/`BoolVar`/`IntVar` with `String`/`Bool`/`Int` + `GetString`/`GetBool`/`GetInt` in `RunE`
- Updates test helpers to use `ResetFlags()` + flag re-registration instead of manual var resets + `VisitAll`
- Adds missing test coverage for `new` and `new-todo` commands

## References

- Closes #35