### PR TITLE
Unify note ref resolution across read, append, update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Migrate `new`, `ls`, `new-todo`, and `update` flag bindings from package-level vars to `GetString`/`GetBool` (Pattern B) for cleaner test isolation ([#39])
+- Unify note ref resolution across `read`, `append`, and `update` via a single `note.ResolveRef` function: accepts numeric ID, absolute/relative path, basename, slug, or type name ([#40])
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.27] - 2026-03-28
 
 ### Added
 

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -12,7 +12,7 @@ import (
 )
 
 var appendCmd = &cobra.Command{
-	Use:   "append [<id|slug|filename|path>]",
+	Use:   "append [<id|path|basename|slug|type>]",
 	Short: "Append text from stdin to a note, optionally creating it",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -66,22 +66,11 @@ var appendCmd = &cobra.Command{
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 
-			if strings.Contains(args[0], "/") {
-				targetPath, err = resolveFilePath(args[0], root)
-				if err != nil {
-					return err
-				}
-			} else {
-				notes, scanErr := note.Scan(root)
-				if scanErr != nil {
-					return scanErr
-				}
-				n := note.Resolve(notes, args[0])
-				if n == nil {
-					return fmt.Errorf("note not found: %s", args[0])
-				}
-				targetPath = filepath.Join(root, n.RelPath)
+			n, resolveErr := note.ResolveRef(root, args[0])
+			if resolveErr != nil {
+				return resolveErr
 			}
+			targetPath = filepath.Join(root, n.RelPath)
 		} else if hasFilters {
 			notes, scanErr := note.Scan(root)
 			if scanErr != nil {
@@ -144,28 +133,6 @@ var appendCmd = &cobra.Command{
 		fmt.Fprintln(cmd.OutOrStdout(), targetPath)
 		return nil
 	},
-}
-
-func resolveFilePath(arg, root string) (string, error) {
-	absPath, err := filepath.Abs(arg)
-	if err != nil {
-		return "", fmt.Errorf("cannot resolve path: %w", err)
-	}
-	absPath, err = filepath.EvalSymlinks(absPath)
-	if err != nil {
-		return "", fmt.Errorf("note not found: %s", arg)
-	}
-
-	absRoot, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		return "", fmt.Errorf("cannot resolve notes path: %w", err)
-	}
-
-	if !strings.HasPrefix(absPath, absRoot+"/") {
-		return "", fmt.Errorf("path is outside notes directory: %s", arg)
-	}
-
-	return absPath, nil
 }
 
 func init() {

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -98,10 +98,8 @@ func TestAppendByAbsolutePath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// EvalSymlinks may resolve /var → /private/var on macOS
-	resolved, _ := filepath.EvalSymlinks(target)
-	if out != resolved {
-		t.Errorf("got output %q, want %q", out, resolved)
+	if out != target {
+		t.Errorf("got output %q, want %q", out, target)
 	}
 
 	data, _ := os.ReadFile(target)
@@ -128,9 +126,9 @@ func TestAppendByRelativePath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	resolved, _ := filepath.EvalSymlinks(filepath.Join(root, "2026/01/20260106_8823.md"))
-	if out != resolved {
-		t.Errorf("got output %q, want %q", out, resolved)
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	if out != want {
+		t.Errorf("got output %q, want %q", out, want)
 	}
 
 	data, _ := os.ReadFile(filepath.Join(root, "2026/01/20260106_8823.md"))

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,19 +9,14 @@ import (
 )
 
 var readCmd = &cobra.Command{
-	Use:   "read <id|slug|filename>",
-	Short: "Read a note by ID, slug, or filename",
+	Use:   "read <id|path|basename|slug|type>",
+	Short: "Read a note by ID, path, basename, slug, or type",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
-		notes, err := note.Scan(root)
+		n, err := note.ResolveRef(root, args[0])
 		if err != nil {
 			return err
-		}
-
-		n := note.Resolve(notes, args[0])
-		if n == nil {
-			return fmt.Errorf("note not found: %s", args[0])
 		}
 
 		data, err := os.ReadFile(filepath.Join(root, n.RelPath))

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -30,14 +30,9 @@ var updateCmd = &cobra.Command{
 		}
 
 		root := mustNotesPath()
-		notes, err := note.Scan(root)
+		n, err := note.ResolveRef(root, args[0])
 		if err != nil {
 			return err
-		}
-
-		n := note.Resolve(notes, args[0])
-		if n == nil {
-			return fmt.Errorf("note not found: %s", args[0])
 		}
 
 		oldPath := filepath.Join(root, n.RelPath)

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -62,47 +62,6 @@ func TestScanSkipsInvalidFiles(t *testing.T) {
 	}
 }
 
-func TestResolve(t *testing.T) {
-	notes := []Note{
-		{RelPath: "2026/01/20260106_8823.md", ID: "8823", Slug: "", Type: "", BaseName: "20260106_8823"},
-		{RelPath: "2026/01/20260102_8814.todo.md", ID: "8814", Slug: "", Type: "todo", BaseName: "20260102_8814"},
-		{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", ID: "6973", Slug: "disable-letter_opener", Type: "", BaseName: "20241203_6973_disable-letter_opener"},
-	}
-
-	tests := []struct {
-		name   string
-		query  string
-		wantID string
-	}{
-		{"by id", "8823", "8823"},
-		{"by id second", "6973", "6973"},
-		{"by slug with special chars", "disable-letter_opener", "6973"},
-		{"by type", "todo", "8814"},
-		{"by basename", "20260106_8823", "8823"},
-		{"by basename with md", "20260106_8823.md", "8823"},
-		{"not found", "9999", ""},
-		{"empty query", "", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := Resolve(notes, tt.query)
-			if tt.wantID == "" {
-				if got != nil {
-					t.Errorf("Resolve(%q) = %v, want nil", tt.query, got)
-				}
-				return
-			}
-			if got == nil {
-				t.Fatalf("Resolve(%q) = nil, want ID %q", tt.query, tt.wantID)
-			}
-			if got.ID != tt.wantID {
-				t.Errorf("Resolve(%q).ID = %q, want %q", tt.query, got.ID, tt.wantID)
-			}
-		})
-	}
-}
-
 func TestResolveRef(t *testing.T) {
 	root := testdataPath(t)
 

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -103,6 +103,51 @@ func TestResolve(t *testing.T) {
 	}
 }
 
+func TestResolveRef(t *testing.T) {
+	root := testdataPath(t)
+
+	tests := []struct {
+		name    string
+		query   string
+		wantID  string
+		wantErr bool
+	}{
+		{"by id", "8823", "8823", false},
+		{"by id todo", "8814", "8814", false},
+		{"by type todo", "todo", "8814", false},
+		{"by slug", "disable-letter_opener", "6973", false},
+		{"by basename", "20260106_8823", "8823", false},
+		{"by basename with md", "20260106_8823.md", "8823", false},
+		{"by absolute path", "", "8823", false}, // set in test body
+		{"not found id", "9999", "", true},
+		{"not found slug", "nonexistent", "", true},
+		{"path outside root", "/tmp", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := tt.query
+			if tt.name == "by absolute path" {
+				query = filepath.Join(root, "2026/01/20260106_8823.md")
+			}
+
+			got, err := ResolveRef(root, query)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ResolveRef(%q) expected error, got nil", query)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveRef(%q) unexpected error: %v", query, err)
+			}
+			if got.ID != tt.wantID {
+				t.Errorf("ResolveRef(%q).ID = %q, want %q", query, got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestFilter(t *testing.T) {
 	notes := []Note{
 		{RelPath: "2026/01/20260106_8823.md", BaseName: "20260106_8823", Type: ""},

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -64,6 +64,7 @@ func TestScanSkipsInvalidFiles(t *testing.T) {
 
 func TestResolveRef(t *testing.T) {
 	root := testdataPath(t)
+	absPath := filepath.Join(root, "2026/01/20260106_8823.md")
 
 	tests := []struct {
 		name    string
@@ -77,7 +78,7 @@ func TestResolveRef(t *testing.T) {
 		{"by slug", "disable-letter_opener", "6973", false},
 		{"by basename", "20260106_8823", "8823", false},
 		{"by basename with md", "20260106_8823.md", "8823", false},
-		{"by absolute path", "", "8823", false}, // set in test body
+		{"by absolute path", absPath, "8823", false},
 		{"not found id", "9999", "", true},
 		{"not found slug", "nonexistent", "", true},
 		{"path outside root", "/tmp", "", true},
@@ -85,23 +86,18 @@ func TestResolveRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			query := tt.query
-			if tt.name == "by absolute path" {
-				query = filepath.Join(root, "2026/01/20260106_8823.md")
-			}
-
-			got, err := ResolveRef(root, query)
+			got, err := ResolveRef(root, tt.query)
 			if tt.wantErr {
 				if err == nil {
-					t.Errorf("ResolveRef(%q) expected error, got nil", query)
+					t.Errorf("ResolveRef(%q) expected error, got nil", tt.query)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ResolveRef(%q) unexpected error: %v", query, err)
+				t.Fatalf("ResolveRef(%q) unexpected error: %v", tt.query, err)
 			}
 			if got.ID != tt.wantID {
-				t.Errorf("ResolveRef(%q).ID = %q, want %q", query, got.ID, tt.wantID)
+				t.Errorf("ResolveRef(%q).ID = %q, want %q", tt.query, got.ID, tt.wantID)
 			}
 		})
 	}

--- a/note/store.go
+++ b/note/store.go
@@ -78,9 +78,6 @@ func ResolveRef(root, query string) (*Note, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot resolve path: %w", err)
 		}
-		if _, statErr := os.Stat(absPath); statErr != nil {
-			return nil, fmt.Errorf("note not found: %s", query)
-		}
 		absRoot, err := filepath.EvalSymlinks(root)
 		if err != nil {
 			return nil, fmt.Errorf("cannot resolve notes path: %w", err)

--- a/note/store.go
+++ b/note/store.go
@@ -50,43 +50,6 @@ func Scan(root string) ([]Note, error) {
 	return notes, nil
 }
 
-// Resolve finds a single note matching the query by ID, slug, type, or base filename.
-// Returns the first (most recent) match, or nil if not found.
-func Resolve(notes []Note, query string) *Note {
-	// Strip .md extension if provided
-	query = strings.TrimSuffix(query, ".md")
-
-	// Try exact ID match first
-	for i := range notes {
-		if notes[i].ID == query {
-			return &notes[i]
-		}
-	}
-
-	// Try exact slug match
-	for i := range notes {
-		if notes[i].Slug != "" && notes[i].Slug == query {
-			return &notes[i]
-		}
-	}
-
-	// Try exact type match
-	for i := range notes {
-		if notes[i].Type != "" && notes[i].Type == query {
-			return &notes[i]
-		}
-	}
-
-	// Try exact base filename match
-	for i := range notes {
-		if notes[i].BaseName == query {
-			return &notes[i]
-		}
-	}
-
-	return nil
-}
-
 // ResolveRef resolves a note reference to a Note using the following priority:
 //  1. Numeric ID
 //  2. Absolute or relative path (must exist and be under root)

--- a/note/store.go
+++ b/note/store.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -84,6 +85,86 @@ func Resolve(notes []Note, query string) *Note {
 	}
 
 	return nil
+}
+
+// ResolveRef resolves a note reference to a Note using the following priority:
+//  1. Numeric ID
+//  2. Absolute or relative path (must exist and be under root)
+//  3. Basename (exact filename without .md extension)
+//  4. Slug
+//  5. Type — most recent note of that type (e.g. "todo", "backlog", "weekly")
+func ResolveRef(root, query string) (*Note, error) {
+	notes, err := Scan(root)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 1: numeric ID
+	if query != "" && isDigits(query) {
+		for i := range notes {
+			if notes[i].ID == query {
+				return &notes[i], nil
+			}
+		}
+		return nil, fmt.Errorf("note not found: %s", query)
+	}
+
+	// Step 2: absolute or relative path
+	if strings.ContainsRune(query, filepath.Separator) || strings.HasPrefix(query, ".") {
+		absPath, err := filepath.Abs(query)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve path: %w", err)
+		}
+		if _, statErr := os.Stat(absPath); statErr != nil {
+			return nil, fmt.Errorf("note not found: %s", query)
+		}
+		absRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve notes path: %w", err)
+		}
+		absPathResolved, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("note not found: %s", query)
+		}
+		if !strings.HasPrefix(absPathResolved, absRoot+string(filepath.Separator)) {
+			return nil, fmt.Errorf("path is outside notes directory: %s", query)
+		}
+		rel, err := filepath.Rel(absRoot, absPathResolved)
+		if err != nil {
+			return nil, fmt.Errorf("cannot compute relative path: %w", err)
+		}
+		for i := range notes {
+			if notes[i].RelPath == rel {
+				return &notes[i], nil
+			}
+		}
+		return nil, fmt.Errorf("note not found: %s", query)
+	}
+
+	stripped := strings.TrimSuffix(query, ".md")
+
+	// Step 3: basename
+	for i := range notes {
+		if notes[i].BaseName == stripped {
+			return &notes[i], nil
+		}
+	}
+
+	// Step 4: slug
+	for i := range notes {
+		if notes[i].Slug != "" && notes[i].Slug == query {
+			return &notes[i], nil
+		}
+	}
+
+	// Step 5: type — most recent match
+	for i := range notes {
+		if notes[i].Type != "" && notes[i].Type == query {
+			return &notes[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("note not found: %s", query)
 }
 
 // Filter returns all notes whose filename contains the fragment (case-insensitive).

--- a/note/store.go
+++ b/note/store.go
@@ -73,7 +73,7 @@ func ResolveRef(root, query string) (*Note, error) {
 	}
 
 	// Step 2: absolute or relative path
-	if strings.ContainsRune(query, filepath.Separator) || strings.HasPrefix(query, ".") {
+	if strings.ContainsRune(query, filepath.Separator) {
 		absPath, err := filepath.Abs(query)
 		if err != nil {
 			return nil, fmt.Errorf("cannot resolve path: %w", err)


### PR DESCRIPTION
Closes #40

## Summary

- Add `note.ResolveRef(root, query string) (*Note, error)` with priority order: numeric ID → absolute/relative path → basename → slug → type
- Replace `read` and `update`'s `note.Resolve` calls and `append`'s split `resolveFilePath` + `note.Resolve` logic with the single unified function
- Remove the fragile `strings.Contains(arg, "/")` path heuristic from `append`
- Update `read` help text to document path and type resolution