### PR TITLE
Add resolve command (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.34] - 2026-03-28
+
+### Added
+
+- Add `resolve` command to print the absolute path of a note by ref ([#44])
+
+[#44]: https://github.com/dreikanter/notescli/pull/44
+
 ## [0.1.32] - 2026-03-28
 
 ### Added

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+var resolveCmd = &cobra.Command{
+	Use:   "resolve <id|path|basename|slug|type>",
+	Short: "Resolve a note reference and print its absolute path",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root := mustNotesPath()
+		n, err := note.ResolveRef(root, args[0])
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resolveCmd)
+}


### PR DESCRIPTION
## Summary

- Add `resolve` command that resolves a note reference and prints its absolute path
- Uses the same `<id|path|basename|slug|type>` ref format as `read`, `append`, and `update`

## References

- Closes #44