### PR TITLE
Add resolve tests and minor consistency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.35] - 2026-03-28
+
+### Added
+
+- Add tests for `resolve` command ([#45])
+
+[#45]: https://github.com/dreikanter/notescli/pull/45
+
 ## [0.1.34] - 2026-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add tests for `resolve` command ([#45])
+- Add tests for `resolve` command, use `cmd.OutOrStdout()` in `read`, and minor test cleanup ([#45])
 
 [#45]: https://github.com/dreikanter/notescli/pull/45
 

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -29,7 +29,7 @@ var readCmd = &cobra.Command{
 			data = note.StripFrontmatter(data)
 		}
 
-		_, err = os.Stdout.Write(data)
+		_, err = cmd.OutOrStdout().Write(data)
 		return err
 	},
 }

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -75,14 +74,7 @@ func TestResolveByAbsolutePath(t *testing.T) {
 func TestResolveByRelativePath(t *testing.T) {
 	root := testdataPath(t)
 
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("cannot get working directory: %v", err)
-	}
-	if err := os.Chdir(root); err != nil {
-		t.Fatalf("cannot chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	t.Chdir(root)
 
 	out, err := runResolve(t, root, "2026/01/20260106_8823.md")
 	if err != nil {

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runResolve(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"resolve", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func TestResolveByID(t *testing.T) {
+	root := testdataPath(t)
+	out, err := runResolve(t, root, "8823")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestResolveBySlug(t *testing.T) {
+	root := testdataPath(t)
+	out, err := runResolve(t, root, "meeting")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestResolveByType(t *testing.T) {
+	root := testdataPath(t)
+	out, err := runResolve(t, root, "todo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260102_8814.todo.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestResolveByAbsolutePath(t *testing.T) {
+	root := testdataPath(t)
+	target := filepath.Join(root, "2026/01/20260106_8823.md")
+	out, err := runResolve(t, root, target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out != target {
+		t.Errorf("got %q, want %q", out, target)
+	}
+}
+
+func TestResolveByRelativePath(t *testing.T) {
+	root := testdataPath(t)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get working directory: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("cannot chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	out, err := runResolve(t, root, "2026/01/20260106_8823.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestResolveNonExistentErrors(t *testing.T) {
+	root := testdataPath(t)
+	_, err := runResolve(t, root, "9999")
+	if err == nil {
+		t.Fatal("expected error for non-existent ref, got nil")
+	}
+}

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -10,13 +10,14 @@ import (
 func runResolve(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
 	rootCmd.SetArgs(append([]string{"resolve", "--path", root}, args...))
 
 	err := rootCmd.Execute()
-	return strings.TrimSpace(buf.String()), err
+	return strings.TrimSpace(stdout.String()), err
 }
 
 func TestResolveByID(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add tests for `resolve` command covering ID, slug, type, absolute path, relative path, and error cases
- Use `cmd.OutOrStdout()` in `read` command for consistency with rest of package
- Use `t.Chdir` instead of `os.Chdir` in `TestResolveByRelativePath`
- Use separate stdout/stderr buffers in `runResolve` test helper

## References

- Closes #