### PR TITLE
Add frontmatter extension design spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.36] - 2026-03-29
+
+### Added
+
+- Add `Slug` and `Public` fields to `FrontmatterFields`; extend parser and builder; sync `slug:` frontmatter when `--slug`/`--no-slug` is used in `update` ([#46])
+
+[#46]: https://github.com/dreikanter/notescli/pull/46
+
 ## [0.1.35] - 2026-03-28
 
 ### Added

--- a/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
+++ b/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
@@ -1,0 +1,47 @@
+# notescli Frontmatter Extension Design
+
+Date: 2026-03-29
+
+## Context
+
+`notescli/note` is the canonical source of note-format knowledge, shared with `notespub` as a Go module dependency. Currently `ParseFrontmatterFields` returns a limited `FrontmatterFields` struct covering only `title`, `tags`, and `description`. The `notespub` site builder needs access to additional fields (`public`, `slug`) and potentially arbitrary frontmatter keys — without duplicating parsing logic.
+
+## Goal
+
+Extend the `note` package to expose full YAML frontmatter as a generic map, covering all fields any consumer might need, while keeping the existing typed API available for callers that prefer it.
+
+## Approach
+
+Add a new function alongside the existing one:
+
+```go
+// ParseFrontmatter returns all frontmatter fields as a map.
+// Returns nil if no valid frontmatter is present.
+func ParseFrontmatter(data []byte) map[string]any
+```
+
+- Uses `gopkg.in/yaml.v3` to unmarshal the frontmatter block into `map[string]any`
+- `StripFrontmatter` and the frontmatter delimiter logic are reused as-is
+- Existing `ParseFrontmatterFields` remains unchanged for backward compatibility
+- `FrontmatterFields` convenience struct stays, backed by `ParseFrontmatter` internally to avoid duplication
+
+## Fields notespub requires
+
+| Field | Type | Purpose |
+|---|---|---|
+| `public` | bool | Whether note is included in the build |
+| `title` | string | Page title |
+| `slug` | string | URL slug override (falls back to slugified title) |
+| `tags` | []string | Tag pages + related notes |
+| `description` | string | Meta description (future use) |
+
+## Implementation Notes
+
+- Add `gopkg.in/yaml.v3` as a direct dependency (currently only in indirect deps via golangci-lint)
+- No changes to `Note` struct or store scanning — frontmatter parsing is a separate concern
+- New function covered by unit tests in `frontmatter_test.go`
+
+## Out of Scope
+
+- Validating frontmatter schema
+- Supporting TOML or JSON frontmatter

--- a/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
+++ b/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
@@ -9,17 +9,19 @@ Date: 2026-03-29
 - `ParseFrontmatterFields` — line-by-line string matching, only reads `title`, `tags`, `description`
 - `BuildFrontmatter` — manual string concatenation to produce YAML output
 
-Both are fragile: special YAML characters (colons, quotes) in titles or tags would produce invalid output or silently misparse. `notespub` also needs fields not covered (`public`, `slug`), and any future consumer would need to duplicate knowledge of the format.
+Both are fragile: special YAML characters (colons, quotes) in titles or tags would produce invalid output or silently misparse. `notespub` also needs fields not covered (`public`), and any future consumer would need to duplicate knowledge of the format.
+
+Additionally, `BuildFrontmatter` drops all fields it doesn't know about — round-tripping a note with unknown fields (e.g. `public: true`) through notescli would silently lose them.
 
 ## Goal
 
-Replace all manual YAML handling with `gopkg.in/yaml.v3`. No mix of manual and library approaches — all frontmatter reading and writing goes through the library.
+Replace all manual YAML handling with `gopkg.in/yaml.v3`. No mix of manual and library approaches. Preserve unknown frontmatter fields on update.
 
-## Approach
+## API Changes
 
 ### Parsing
 
-Replace hand-rolled parser with a new function using `yaml.v3`:
+Replace hand-rolled parser with a generic function:
 
 ```go
 // ParseFrontmatter returns all frontmatter fields as a map.
@@ -27,42 +29,69 @@ Replace hand-rolled parser with a new function using `yaml.v3`:
 func ParseFrontmatter(data []byte) map[string]any
 ```
 
-- Extracts the YAML block using the existing delimiter logic
+- Extracts the YAML block using existing delimiter logic
 - Unmarshals into `map[string]any` via `yaml.v3` — supports any field, any value type
-- `ParseFrontmatterFields` is reimplemented on top of `ParseFrontmatter` (no duplication, backward compatible)
-- `StripFrontmatter` is unchanged — delimiter logic stays as-is
+- `ParseFrontmatterFields` is reimplemented on top of `ParseFrontmatter` — same signature, backward compatible
+- `StripFrontmatter` is unchanged
 
-### Writing
-
-Replace manual string builder with `yaml.v3` marshaling:
+### Writing — new notes
 
 ```go
 // BuildFrontmatter generates YAML frontmatter from the given fields.
+// Use for new notes. Same signature, now backed by yaml.v3 marshal.
 func BuildFrontmatter(f FrontmatterFields) string
 ```
 
-- Same signature and behavior, now backed by `yaml.v3` marshal
 - Correctly handles special characters in all field values
+- Used only when creating a note from scratch
 
-## Fields notespub requires
+### Writing — existing notes
 
-| Field | Type | Purpose |
-|---|---|---|
-| `public` | bool | Whether note is included in the build |
-| `title` | string | Page title |
-| `slug` | string | URL slug override (falls back to slugified title) |
-| `tags` | []string | Tag pages + related notes |
-| `description` | string | Meta description |
+```go
+// UpdateFrontmatter merges fields into the note's existing frontmatter.
+// Unknown frontmatter fields are preserved.
+// Returns the full updated note content (frontmatter + body).
+func UpdateFrontmatter(data []byte, f FrontmatterFields) ([]byte, error)
+```
+
+- `data` is the full note file content
+- Extracts existing YAML block → unmarshals to `map[string]any`
+- Merges known fields from `f` onto the map (only non-zero values)
+- Marshals full map back to YAML — unknown fields survive
+- Reconstructs note: new frontmatter + original body via `StripFrontmatter`
+- No file I/O — caller reads and writes the file
+
+### `FrontmatterFields` struct
+
+Add `Slug` — it is a note management concern (can be set in frontmatter to override the filename slug):
+
+```go
+type FrontmatterFields struct {
+    Title       string
+    Slug        string   // ← added
+    Tags        []string
+    Description string
+}
+```
+
+`public` is a publishing concern — not added to `FrontmatterFields`. notespub reads it directly from `ParseFrontmatter` map:
+
+```go
+fm := note.ParseFrontmatter(data)
+public, _ := fm["public"].(bool)
+```
 
 ## Implementation Notes
 
 - Promote `gopkg.in/yaml.v3` from indirect to direct dependency (already in module graph via golangci-lint)
 - No changes to `Note` struct, store scanning, or `StripFrontmatter`
 - All changes in `frontmatter.go` and `frontmatter_test.go`
-- Existing tests must continue to pass; add cases for special characters and new fields
+- Existing tests must continue to pass; add cases for:
+  - Special characters in field values
+  - Unknown fields preserved through `UpdateFrontmatter`
+  - Block-style tag syntax (`- tag`) now supported via yaml.v3
 
 ## Out of Scope
 
 - Validating frontmatter schema
 - Supporting TOML or JSON frontmatter
-- Block-style tag syntax (already supported via yaml.v3 unmarshal)

--- a/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
+++ b/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
@@ -1,97 +1,66 @@
-# notescli Frontmatter Refactor Design
+# notescli Frontmatter Extension Design
 
 Date: 2026-03-29
 
 ## Context
 
-`notescli/note` is the canonical source of note-format knowledge, shared with `notespub` as a Go module dependency. Currently all YAML frontmatter handling is hand-rolled:
-
-- `ParseFrontmatterFields` — line-by-line string matching, only reads `title`, `tags`, `description`
-- `BuildFrontmatter` — manual string concatenation to produce YAML output
-
-Both are fragile: special YAML characters (colons, quotes) in titles or tags would produce invalid output or silently misparse. `notespub` also needs fields not covered (`public`), and any future consumer would need to duplicate knowledge of the format.
-
-Additionally, `BuildFrontmatter` drops all fields it doesn't know about — round-tripping a note with unknown fields (e.g. `public: true`) through notescli would silently lose them.
+`notescli/note` is the canonical source of note-format knowledge, shared with `notespub` as a Go module dependency. `notespub` needs fields not currently in `FrontmatterFields` (`public`, `slug`), and any future consumer would need to duplicate format knowledge or parse filenames itself.
 
 ## Goal
 
-Replace all manual YAML handling with `gopkg.in/yaml.v3`. No mix of manual and library approaches. Preserve unknown frontmatter fields on update.
+Add `Slug` and `Public` to `FrontmatterFields` so external tools (e.g. `notespub`) can read all relevant fields without parsing filenames or duplicating format knowledge. Keep the existing hand-rolled parser and builder — no yaml.v3 refactor.
 
 ## API Changes
 
-### Parsing
-
-Replace hand-rolled parser with a generic function:
-
-```go
-// ParseFrontmatter returns all frontmatter fields as a map.
-// Returns nil if no valid frontmatter is present.
-func ParseFrontmatter(data []byte) map[string]any
-```
-
-- Extracts the YAML block using existing delimiter logic
-- Unmarshals into `map[string]any` via `yaml.v3` — supports any field, any value type
-- `ParseFrontmatterFields` is reimplemented on top of `ParseFrontmatter` — same signature, backward compatible
-- `StripFrontmatter` is unchanged
-
-### Writing — new notes
-
-```go
-// BuildFrontmatter generates YAML frontmatter from the given fields.
-// Use for new notes. Same signature, now backed by yaml.v3 marshal.
-func BuildFrontmatter(f FrontmatterFields) string
-```
-
-- Correctly handles special characters in all field values
-- Used only when creating a note from scratch
-
-### Writing — existing notes
-
-```go
-// UpdateFrontmatter merges fields into the note's existing frontmatter.
-// Unknown frontmatter fields are preserved.
-// Returns the full updated note content (frontmatter + body).
-func UpdateFrontmatter(data []byte, f FrontmatterFields) ([]byte, error)
-```
-
-- `data` is the full note file content
-- Extracts existing YAML block → unmarshals to `map[string]any`
-- Merges known fields from `f` onto the map (only non-zero values)
-- Marshals full map back to YAML — unknown fields survive
-- Reconstructs note: new frontmatter + original body via `StripFrontmatter`
-- No file I/O — caller reads and writes the file
-
 ### `FrontmatterFields` struct
-
-Add `Slug` — it is a note management concern (can be set in frontmatter to override the filename slug):
 
 ```go
 type FrontmatterFields struct {
     Title       string
-    Slug        string   // ← added
+    Slug        string // overrides filename slug for external consumers
     Tags        []string
     Description string
+    Public      bool
 }
 ```
 
-`public` is a publishing concern — not added to `FrontmatterFields`. notespub reads it directly from `ParseFrontmatter` map:
+Empty/zero values are omitted from frontmatter output (existing behavior, unchanged).
+
+### Parsing
+
+Extend the existing hand-rolled parser in `ParseFrontmatterFields` to recognize:
+- `slug: <value>`
+- `public: true` (absent or any non-`true` value → `false`)
+
+### Writing
+
+Extend `BuildFrontmatter` with the same omit-if-zero pattern:
 
 ```go
-fm := note.ParseFrontmatter(data)
-public, _ := fm["public"].(bool)
+if f.Slug != "" {
+    lines = append(lines, "slug: "+f.Slug)
+}
+if f.Public {
+    lines = append(lines, "public: true")
+}
 ```
+
+Field order: `title`, `slug`, `tags`, `description`, `public`.
+
+### `update.go` changes
+
+When `--slug foo` is passed: updates both the filename and the `slug` frontmatter field (kept in sync).
+When `--no-slug` is passed: removes slug from both filename and frontmatter.
 
 ## Implementation Notes
 
-- Promote `gopkg.in/yaml.v3` from indirect to direct dependency (already in module graph via golangci-lint)
-- No changes to `Note` struct, store scanning, or `StripFrontmatter`
-- All changes in `frontmatter.go` and `frontmatter_test.go`
-- Existing tests must continue to pass; add cases for:
-  - Special characters in field values
-  - Unknown fields preserved through `UpdateFrontmatter`
-  - Block-style tag syntax (`- tag`) now supported via yaml.v3
+- All changes in `frontmatter.go`, `frontmatter_test.go`, and `internal/cli/update.go`
+- Existing tests must continue to pass; add cases for `Slug` and `Public` round-trip
+- No new dependencies
 
 ## Out of Scope
 
+- Special character handling in field values
+- Block-style tag syntax
+- Preserving unknown frontmatter fields on update
 - Validating frontmatter schema
-- Supporting TOML or JSON frontmatter

--- a/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
+++ b/docs/superpowers/specs/2026-03-29-frontmatter-extension-design.md
@@ -1,18 +1,25 @@
-# notescli Frontmatter Extension Design
+# notescli Frontmatter Refactor Design
 
 Date: 2026-03-29
 
 ## Context
 
-`notescli/note` is the canonical source of note-format knowledge, shared with `notespub` as a Go module dependency. Currently `ParseFrontmatterFields` returns a limited `FrontmatterFields` struct covering only `title`, `tags`, and `description`. The `notespub` site builder needs access to additional fields (`public`, `slug`) and potentially arbitrary frontmatter keys — without duplicating parsing logic.
+`notescli/note` is the canonical source of note-format knowledge, shared with `notespub` as a Go module dependency. Currently all YAML frontmatter handling is hand-rolled:
+
+- `ParseFrontmatterFields` — line-by-line string matching, only reads `title`, `tags`, `description`
+- `BuildFrontmatter` — manual string concatenation to produce YAML output
+
+Both are fragile: special YAML characters (colons, quotes) in titles or tags would produce invalid output or silently misparse. `notespub` also needs fields not covered (`public`, `slug`), and any future consumer would need to duplicate knowledge of the format.
 
 ## Goal
 
-Extend the `note` package to expose full YAML frontmatter as a generic map, covering all fields any consumer might need, while keeping the existing typed API available for callers that prefer it.
+Replace all manual YAML handling with `gopkg.in/yaml.v3`. No mix of manual and library approaches — all frontmatter reading and writing goes through the library.
 
 ## Approach
 
-Add a new function alongside the existing one:
+### Parsing
+
+Replace hand-rolled parser with a new function using `yaml.v3`:
 
 ```go
 // ParseFrontmatter returns all frontmatter fields as a map.
@@ -20,10 +27,22 @@ Add a new function alongside the existing one:
 func ParseFrontmatter(data []byte) map[string]any
 ```
 
-- Uses `gopkg.in/yaml.v3` to unmarshal the frontmatter block into `map[string]any`
-- `StripFrontmatter` and the frontmatter delimiter logic are reused as-is
-- Existing `ParseFrontmatterFields` remains unchanged for backward compatibility
-- `FrontmatterFields` convenience struct stays, backed by `ParseFrontmatter` internally to avoid duplication
+- Extracts the YAML block using the existing delimiter logic
+- Unmarshals into `map[string]any` via `yaml.v3` — supports any field, any value type
+- `ParseFrontmatterFields` is reimplemented on top of `ParseFrontmatter` (no duplication, backward compatible)
+- `StripFrontmatter` is unchanged — delimiter logic stays as-is
+
+### Writing
+
+Replace manual string builder with `yaml.v3` marshaling:
+
+```go
+// BuildFrontmatter generates YAML frontmatter from the given fields.
+func BuildFrontmatter(f FrontmatterFields) string
+```
+
+- Same signature and behavior, now backed by `yaml.v3` marshal
+- Correctly handles special characters in all field values
 
 ## Fields notespub requires
 
@@ -33,15 +52,17 @@ func ParseFrontmatter(data []byte) map[string]any
 | `title` | string | Page title |
 | `slug` | string | URL slug override (falls back to slugified title) |
 | `tags` | []string | Tag pages + related notes |
-| `description` | string | Meta description (future use) |
+| `description` | string | Meta description |
 
 ## Implementation Notes
 
-- Add `gopkg.in/yaml.v3` as a direct dependency (currently only in indirect deps via golangci-lint)
-- No changes to `Note` struct or store scanning — frontmatter parsing is a separate concern
-- New function covered by unit tests in `frontmatter_test.go`
+- Promote `gopkg.in/yaml.v3` from indirect to direct dependency (already in module graph via golangci-lint)
+- No changes to `Note` struct, store scanning, or `StripFrontmatter`
+- All changes in `frontmatter.go` and `frontmatter_test.go`
+- Existing tests must continue to pass; add cases for special characters and new fields
 
 ## Out of Scope
 
 - Validating frontmatter schema
 - Supporting TOML or JSON frontmatter
+- Block-style tag syntax (already supported via yaml.v3 unmarshal)

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -17,6 +17,7 @@ type createNoteParams struct {
 	Tags        []string
 	Title       string
 	Description string
+	Public      bool
 	Body        string // initial content after frontmatter
 }
 
@@ -44,6 +45,7 @@ func createNote(p createNoteParams) (string, error) {
 		Slug:        p.Slug,
 		Tags:        p.Tags,
 		Description: p.Description,
+		Public:      p.Public,
 	})
 	content += p.Body
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -41,6 +41,7 @@ func createNote(p createNoteParams) (string, error) {
 
 	content := note.BuildFrontmatter(note.FrontmatterFields{
 		Title:       p.Title,
+		Slug:        p.Slug,
 		Tags:        p.Tags,
 		Description: p.Description,
 	})

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -20,6 +20,8 @@ var newCmd = &cobra.Command{
 		tags, _ := cmd.Flags().GetStringSlice("tag")
 		description, _ := cmd.Flags().GetString("description")
 		title, _ := cmd.Flags().GetString("title")
+		publicFlag, _ := cmd.Flags().GetBool("public")
+		privateFlag, _ := cmd.Flags().GetBool("private")
 
 		if noteType != "" && !note.IsKnownType(noteType) {
 			return fmt.Errorf("unknown note type %q (valid types: %s)", noteType, strings.Join(note.KnownTypes, ", "))
@@ -36,6 +38,7 @@ var newCmd = &cobra.Command{
 			body = string(data)
 		}
 
+		public := publicFlag && !privateFlag
 		fullPath, err := createNote(createNoteParams{
 			Root:        root,
 			Slug:        slug,
@@ -43,6 +46,7 @@ var newCmd = &cobra.Command{
 			Tags:        tags,
 			Title:       title,
 			Description: description,
+			Public:      public,
 			Body:        body,
 		})
 		if err != nil {
@@ -68,5 +72,7 @@ func init() {
 	newCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable)")
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
+	newCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
+	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default; overrides --public)")
 	rootCmd.AddCommand(newCmd)
 }

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -18,6 +18,8 @@ func runNew(t *testing.T, root string, stdin string, args ...string) (string, er
 	newCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable)")
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
+	newCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
+	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default; overrides --public)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -118,6 +120,36 @@ func TestNewWithTitleAndDescription(t *testing.T) {
 	}
 	if !strings.Contains(content, "description: A description") {
 		t.Errorf("expected description in frontmatter, got:\n%s", content)
+	}
+}
+
+func TestNewWithPublic(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--public")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if !strings.Contains(string(data), "public: true") {
+		t.Errorf("expected public: true in frontmatter, got:\n%s", string(data))
+	}
+}
+
+func TestNewPublicPrivateBothPrivateWins(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "", "--public", "--private")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if strings.Contains(string(data), "public:") {
+		t.Errorf("expected public field absent when --private wins, got:\n%s", string(data))
 	}
 }
 

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -65,6 +65,13 @@ func TestNewWithSlug(t *testing.T) {
 	if !strings.Contains(filepath.Base(out), "_myslug") {
 		t.Errorf("expected slug in filename, got %q", filepath.Base(out))
 	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if !strings.Contains(string(data), "slug: myslug") {
+		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
+	}
 }
 
 func TestNewWithType(t *testing.T) {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -66,7 +66,9 @@ var updateCmd = &cobra.Command{
 		} else if cmd.Flags().Changed("slug") {
 			newSlug = updateSlug
 		}
-		updated.Slug = newSlug
+		if updateNoSlug || cmd.Flags().Changed("slug") {
+			updated.Slug = newSlug
+		}
 
 		// Determine new type.
 		newType := n.Type

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -66,6 +66,7 @@ var updateCmd = &cobra.Command{
 		} else if cmd.Flags().Changed("slug") {
 			newSlug = updateSlug
 		}
+		updated.Slug = newSlug
 
 		// Determine new type.
 		newType := n.Type

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -24,6 +24,7 @@ var updateCmd = &cobra.Command{
 		updateNoSlug, _ := cmd.Flags().GetBool("no-slug")
 		updateType, _ := cmd.Flags().GetString("type")
 		updateNoType, _ := cmd.Flags().GetBool("no-type")
+		updatePrivate, _ := cmd.Flags().GetBool("private")
 
 		if updateType != "" && !note.IsKnownType(updateType) {
 			return fmt.Errorf("unknown note type %q (valid types: %s)", updateType, strings.Join(note.KnownTypes, ", "))
@@ -68,6 +69,11 @@ var updateCmd = &cobra.Command{
 		}
 		if updateNoSlug || cmd.Flags().Changed("slug") {
 			updated.Slug = newSlug
+		}
+		if updatePrivate {
+			updated.Public = false
+		} else if cmd.Flags().Changed("public") {
+			updated.Public = true
 		}
 
 		// Determine new type.
@@ -115,5 +121,7 @@ func init() {
 	updateCmd.Flags().Bool("no-slug", false, "remove slug from filename")
 	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
 	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
+	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
+	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter (overrides --public)")
 	rootCmd.AddCommand(updateCmd)
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -20,6 +20,8 @@ func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 	updateCmd.Flags().Bool("no-slug", false, "remove slug from filename")
 	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
 	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
+	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
+	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter (overrides --public)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -334,5 +336,85 @@ func TestUpdateNoFlagDoesNotTouchFrontmatterSlug(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "slug: keep-me") {
 		t.Errorf("expected slug frontmatter to be preserved, got:\n%s", string(data))
+	}
+}
+
+// TestUpdatePublicSetsPublicField verifies that --public writes public: true to frontmatter.
+func TestUpdatePublicSetsPublicField(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runUpdate(t, root, "8823", "--public")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if !strings.Contains(string(data), "public: true") {
+		t.Errorf("expected public: true in frontmatter, got:\n%s", string(data))
+	}
+}
+
+// TestUpdatePrivateRemovesPublicField verifies that --private removes public: true from frontmatter.
+func TestUpdatePrivateRemovesPublicField(t *testing.T) {
+	root := copyTestdata(t)
+	// First mark as public
+	_, err := runUpdate(t, root, "8823", "--public")
+	if err != nil {
+		t.Fatalf("unexpected error setting public: %v", err)
+	}
+	// Then mark as private
+	out, err := runUpdate(t, root, "8823", "--private")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if strings.Contains(string(data), "public:") {
+		t.Errorf("expected public field removed from frontmatter, got:\n%s", string(data))
+	}
+}
+
+// TestUpdatePrivateTakesPrecedenceOverPublic verifies --private wins when combined with --public.
+func TestUpdatePrivateTakesPrecedenceOverPublic(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runUpdate(t, root, "8823", "--public", "--private")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if strings.Contains(string(data), "public:") {
+		t.Errorf("expected public field absent when --private wins, got:\n%s", string(data))
+	}
+}
+
+// TestUpdateNoPublicFlagPreservesPublicField verifies unrelated updates don't touch the public field.
+func TestUpdateNoPublicFlagPreservesPublicField(t *testing.T) {
+	root := copyTestdata(t)
+	// Mark as public
+	_, err := runUpdate(t, root, "8823", "--public")
+	if err != nil {
+		t.Fatalf("unexpected error setting public: %v", err)
+	}
+	// Update only the title — no public/private flag
+	out, err := runUpdate(t, root, "8823", "--title", "New Title")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if !strings.Contains(string(data), "public: true") {
+		t.Errorf("expected public: true preserved after unrelated update, got:\n%s", string(data))
 	}
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -273,3 +273,37 @@ func TestUpdateBodyPreserved(t *testing.T) {
 		t.Errorf("body content not preserved after update, got:\n%s", content)
 	}
 }
+
+// TestUpdateSlugSyncsToFrontmatter verifies that --slug also sets the slug frontmatter field.
+func TestUpdateSlugSyncsToFrontmatter(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runUpdate(t, root, "8823", "--slug", "new-slug")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "slug: new-slug") {
+		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
+	}
+}
+
+// TestUpdateNoSlugRemovesSlugFromFrontmatter verifies that --no-slug removes the slug frontmatter field.
+func TestUpdateNoSlugRemovesSlugFromFrontmatter(t *testing.T) {
+	root := copyTestdata(t)
+	// First add a slug to frontmatter on note 8823
+	_, err := runUpdate(t, root, "8823", "--slug", "to-remove")
+	if err != nil {
+		t.Fatalf("unexpected error setting slug: %v", err)
+	}
+	// Then remove it
+	out, err := runUpdate(t, root, "8823", "--no-slug")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(out)
+	if strings.Contains(string(data), "slug:") {
+		t.Errorf("expected slug removed from frontmatter, got:\n%s", string(data))
+	}
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -307,3 +307,23 @@ func TestUpdateNoSlugRemovesSlugFromFrontmatter(t *testing.T) {
 		t.Errorf("expected slug removed from frontmatter, got:\n%s", string(data))
 	}
 }
+
+// TestUpdateNoFlagDoesNotTouchFrontmatterSlug verifies that unrelated updates don't clobber an existing frontmatter slug.
+func TestUpdateNoFlagDoesNotTouchFrontmatterSlug(t *testing.T) {
+	root := copyTestdata(t)
+	// Give note 8823 a slug in frontmatter
+	_, err := runUpdate(t, root, "8823", "--slug", "keep-me")
+	if err != nil {
+		t.Fatalf("unexpected error setting slug: %v", err)
+	}
+	// Update only the title — slug flags are NOT passed
+	out, err := runUpdate(t, root, "8823", "--title", "New Title")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "slug: keep-me") {
+		t.Errorf("expected slug frontmatter to be preserved, got:\n%s", string(data))
+	}
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -282,7 +282,10 @@ func TestUpdateSlugSyncsToFrontmatter(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, _ := os.ReadFile(out)
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
 	if !strings.Contains(string(data), "slug: new-slug") {
 		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
 	}
@@ -302,7 +305,10 @@ func TestUpdateNoSlugRemovesSlugFromFrontmatter(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, _ := os.ReadFile(out)
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
 	if strings.Contains(string(data), "slug:") {
 		t.Errorf("expected slug removed from frontmatter, got:\n%s", string(data))
 	}
@@ -322,7 +328,10 @@ func TestUpdateNoFlagDoesNotTouchFrontmatterSlug(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, _ := os.ReadFile(out)
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
 	if !strings.Contains(string(data), "slug: keep-me") {
 		t.Errorf("expected slug frontmatter to be preserved, got:\n%s", string(data))
 	}

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -22,11 +22,17 @@ func BuildFrontmatter(f FrontmatterFields) string {
 	if f.Title != "" {
 		lines = append(lines, "title: "+f.Title)
 	}
+	if f.Slug != "" {
+		lines = append(lines, "slug: "+f.Slug)
+	}
 	if len(f.Tags) > 0 {
 		lines = append(lines, "tags: ["+strings.Join(f.Tags, ", ")+"]")
 	}
 	if f.Description != "" {
 		lines = append(lines, "description: "+f.Description)
+	}
+	if f.Public {
+		lines = append(lines, "public: true")
 	}
 
 	if len(lines) == 0 {

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -8,8 +8,10 @@ import (
 // FrontmatterFields holds optional fields for note frontmatter.
 type FrontmatterFields struct {
 	Title       string
+	Slug        string
 	Tags        []string
 	Description string
+	Public      bool
 }
 
 // BuildFrontmatter generates YAML frontmatter from the given fields.
@@ -63,6 +65,8 @@ func ParseFrontmatterFields(data []byte) FrontmatterFields {
 		s := string(trimmed)
 		if t := strings.TrimPrefix(s, "title: "); t != s {
 			f.Title = t
+		} else if t := strings.TrimPrefix(s, "slug: "); t != s {
+			f.Slug = t
 		} else if t := strings.TrimPrefix(s, "description: "); t != s {
 			f.Description = t
 		} else if bytes.HasPrefix(trimmed, []byte("tags: [")) && bytes.HasSuffix(trimmed, []byte("]")) {
@@ -70,6 +74,8 @@ func ParseFrontmatterFields(data []byte) FrontmatterFields {
 			if inner != "" {
 				f.Tags = strings.Split(inner, ", ")
 			}
+		} else if s == "public: true" {
+			f.Public = true
 		}
 
 		if !found {

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -85,6 +85,16 @@ func TestParseFrontmatterFields(t *testing.T) {
 				Public:      true,
 			},
 		},
+		{
+			name: "roundtrip with slug and public",
+			input: BuildFrontmatter(FrontmatterFields{
+				Title:  "T",
+				Slug:   "s",
+				Tags:   []string{"a"},
+				Public: true,
+			}) + "body\n",
+			want: FrontmatterFields{Title: "T", Slug: "s", Tags: []string{"a"}, Public: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -152,6 +162,32 @@ func TestBuildFrontmatter(t *testing.T) {
 			name:   "title only",
 			fields: FrontmatterFields{Title: "My Note"},
 			want:   "---\ntitle: My Note\n---\n\n",
+		},
+		{
+			name:   "slug only",
+			fields: FrontmatterFields{Slug: "my-slug"},
+			want:   "---\nslug: my-slug\n---\n\n",
+		},
+		{
+			name:   "public true",
+			fields: FrontmatterFields{Public: true},
+			want:   "---\npublic: true\n---\n\n",
+		},
+		{
+			name:   "public false omitted",
+			fields: FrontmatterFields{Title: "T"},
+			want:   "---\ntitle: T\n---\n\n",
+		},
+		{
+			name: "all fields including slug and public",
+			fields: FrontmatterFields{
+				Title:       "T",
+				Slug:        "s",
+				Tags:        []string{"a"},
+				Description: "D",
+				Public:      true,
+			},
+			want: "---\ntitle: T\nslug: s\ntags: [a]\ndescription: D\npublic: true\n---\n\n",
 		},
 	}
 

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -54,6 +54,37 @@ func TestParseFrontmatterFields(t *testing.T) {
 			input: BuildFrontmatter(FrontmatterFields{Title: "T", Tags: []string{"a", "b"}, Description: "D"}) + "body\n",
 			want:  FrontmatterFields{Title: "T", Tags: []string{"a", "b"}, Description: "D"},
 		},
+		{
+			name:  "slug only",
+			input: "---\nslug: my-slug\n---\n\n# Content\n",
+			want:  FrontmatterFields{Slug: "my-slug"},
+		},
+		{
+			name:  "public true",
+			input: "---\npublic: true\n---\n\n# Content\n",
+			want:  FrontmatterFields{Public: true},
+		},
+		{
+			name:  "public absent means false",
+			input: "---\ntitle: T\n---\n\n# Content\n",
+			want:  FrontmatterFields{Title: "T"},
+		},
+		{
+			name:  "public non-true value means false",
+			input: "---\npublic: yes\n---\n\n# Content\n",
+			want:  FrontmatterFields{},
+		},
+		{
+			name:  "all fields including slug and public",
+			input: "---\ntitle: T\nslug: s\ntags: [a]\ndescription: D\npublic: true\n---\n\n# Content\n",
+			want: FrontmatterFields{
+				Title:       "T",
+				Slug:        "s",
+				Tags:        []string{"a"},
+				Description: "D",
+				Public:      true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -72,6 +103,12 @@ func TestParseFrontmatterFields(t *testing.T) {
 				if got.Tags[i] != tt.want.Tags[i] {
 					t.Errorf("Tags[%d] = %q, want %q", i, got.Tags[i], tt.want.Tags[i])
 				}
+			}
+			if got.Slug != tt.want.Slug {
+				t.Errorf("Slug = %q, want %q", got.Slug, tt.want.Slug)
+			}
+			if got.Public != tt.want.Public {
+				t.Errorf("Public = %v, want %v", got.Public, tt.want.Public)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds design spec for extending `FrontmatterFields` with `Slug` and `Public` fields
- Documents the minimal approach: extend the hand-rolled parser, no new dependencies
- Covers `update.go` slug sync behavior and field ordering