### PR TITLE
Fix resolve lookup failure on queries with whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.37] - 2026-03-30
+
+### Fixed
+
+- Trim whitespace from `resolve` query to prevent lookup failures from trailing spaces or newlines ([#48])
+- Skip hidden directories (`.git`, `.claude`, etc.) during note scanning ([#48])
+
+[#48]: https://github.com/dreikanter/notescli/pull/48
+
 ## [0.1.36] - 2026-03-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Trim whitespace from `resolve` query to prevent lookup failures from trailing spaces or newlines ([#48])
-- Skip hidden directories (`.git`, `.claude`, etc.) during note scanning ([#48])
+- Restrict note scanning to known `YYYY/MM/` directory structure ([#48])
 
 [#48]: https://github.com/dreikanter/notescli/pull/48
 

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -88,6 +88,33 @@ func TestResolveByRelativePath(t *testing.T) {
 	}
 }
 
+func TestResolveByIDWithWhitespace(t *testing.T) {
+	root := testdataPath(t)
+	want := filepath.Join(root, "2026/01/20260106_8823.md")
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"trailing space", "8823 "},
+		{"leading space", " 8823"},
+		{"both spaces", " 8823 "},
+		{"trailing tab", "8823\t"},
+		{"trailing newline", "8823\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runResolve(t, root, tt.query)
+			if err != nil {
+				t.Fatalf("unexpected error for query %q: %v", tt.query, err)
+			}
+			if out != want {
+				t.Errorf("got %q, want %q", out, want)
+			}
+		})
+	}
+}
+
 func TestResolveNonExistentErrors(t *testing.T) {
 	root := testdataPath(t)
 	_, err := runResolve(t, root, "9999")

--- a/note/store.go
+++ b/note/store.go
@@ -2,48 +2,59 @@ package note
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 )
 
-// Scan walks the store directory and returns all valid notes, sorted newest first.
+// Scan enumerates notes under root using the known YYYY/MM/ directory structure.
+// Only directories matching year (all digits) and month (01–12) patterns are visited.
 func Scan(root string) ([]Note, error) {
 	var notes []Note
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if path != root && strings.HasPrefix(d.Name(), ".") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if filepath.Ext(path) != ".md" {
-			return nil
-		}
-
-		base := strings.TrimSuffix(filepath.Base(path), ".md")
-		n, parseErr := ParseFilename(base)
-		if parseErr != nil {
-			return nil // skip files that don't match the naming convention
-		}
-
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return nil
-		}
-
-		n.RelPath = rel
-		notes = append(notes, n)
-		return nil
-	})
+	years, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, y := range years {
+		if !y.IsDir() || !isDigits(y.Name()) {
+			continue
+		}
+
+		yearPath := filepath.Join(root, y.Name())
+		months, err := os.ReadDir(yearPath)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, m := range months {
+			if !m.IsDir() || len(m.Name()) != 2 || !isDigits(m.Name()) {
+				continue
+			}
+
+			monthPath := filepath.Join(yearPath, m.Name())
+			files, err := os.ReadDir(monthPath)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, f := range files {
+				if f.IsDir() || filepath.Ext(f.Name()) != ".md" {
+					continue
+				}
+
+				base := strings.TrimSuffix(f.Name(), ".md")
+				n, parseErr := ParseFilename(base)
+				if parseErr != nil {
+					continue
+				}
+
+				n.RelPath = filepath.Join(y.Name(), m.Name(), f.Name())
+				notes = append(notes, n)
+			}
+		}
 	}
 
 	sort.Slice(notes, func(i, j int) bool {

--- a/note/store.go
+++ b/note/store.go
@@ -18,6 +18,9 @@ func Scan(root string) ([]Note, error) {
 			return err
 		}
 		if d.IsDir() {
+			if path != root && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if filepath.Ext(path) != ".md" {
@@ -57,6 +60,8 @@ func Scan(root string) ([]Note, error) {
 //  4. Slug
 //  5. Type — most recent note of that type (e.g. "todo", "backlog", "weekly")
 func ResolveRef(root, query string) (*Note, error) {
+	query = strings.TrimSpace(query)
+
 	notes, err := Scan(root)
 	if err != nil {
 		return nil, err

--- a/note/store.go
+++ b/note/store.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Scan enumerates notes under root using the known YYYY/MM/ directory structure.
-// Only directories matching year (all digits) and month (01–12) patterns are visited.
+// Only directories matching year (all digits) and month (two-digit) patterns are visited.
 func Scan(root string) ([]Note, error) {
 	var notes []Note
 


### PR DESCRIPTION
## Summary

- Trim whitespace from `ResolveRef` query before processing — a trailing space or newline causes `isDigits()` to return false, skipping the numeric ID lookup entirely and resulting in "note not found"
- Skip hidden directories (`.git`, `.claude`, etc.) during `Scan` to avoid unnecessary traversal and potential transient errors
- Add test cases for whitespace-padded ID queries

## References

- Closes #