### PR TITLE
Remove default limit from ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.39] - 2026-04-04
+
+### Changed
+
+- Remove default limit from `ls`; output all notes unless `--limit` is specified. Handle SIGPIPE for clean pipe behavior ([#50])
+
+[#50]: https://github.com/dreikanter/notescli/pull/50
 ## [0.1.37] - 2026-03-30
 
 ### Fixed

--- a/cmd/notes/main.go
+++ b/cmd/notes/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "github.com/dreikanter/notescli/internal/cli"
+import (
+	"os/signal"
+	"syscall"
+
+	"github.com/dreikanter/notescli/internal/cli"
+)
 
 func main() {
+	// Let the OS terminate the process on SIGPIPE (conventional
+	// behavior for CLI tools piped through head, less, etc.).
+	signal.Reset(syscall.SIGPIPE)
 	cli.Execute()
 }

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -10,7 +10,7 @@ import (
 
 var lsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "List recent notes",
+	Short: "List notes",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lsLimit, _ := cmd.Flags().GetInt("limit")
@@ -61,7 +61,7 @@ var lsCmd = &cobra.Command{
 }
 
 func init() {
-	lsCmd.Flags().Int("limit", 20, "maximum number of notes to list")
+	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
 	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
 	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -11,7 +11,7 @@ func runLs(t *testing.T, args ...string) (string, error) {
 
 	root := testdataPath(t)
 	lsCmd.ResetFlags()
-	lsCmd.Flags().Int("limit", 20, "maximum number of notes to list")
+	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
 	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
 	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
@@ -164,6 +164,18 @@ func TestLsToday(t *testing.T) {
 	}
 	if out != "" {
 		t.Errorf("expected empty output for --today on past testdata, got %q", out)
+	}
+}
+
+func TestLsUnlimitedByDefault(t *testing.T) {
+	out, err := runLs(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected all 4 testdata notes without limit, got %d:\n%s", len(lines), out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the default `--limit 20` from `notes ls`; all notes are now listed by default (`--limit 0` means no limit)
- Add `signal.Reset(syscall.SIGPIPE)` in `main.go` so piping to `head`/`less` exits cleanly

## References

- Closes #50