### PR TITLE
Add --today flag to resolve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.40] - 2026-04-04
+
+### Added
+
+- Add `--today` flag to `resolve` command for date-based note existence checks ([#53])
+
+[#53]: https://github.com/dreikanter/notescli/pull/53
+
 ## [0.1.39] - 2026-04-04
 
 ### Changed

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
@@ -13,8 +14,16 @@ var resolveCmd = &cobra.Command{
 	Short: "Resolve a note reference and print its absolute path",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		today, _ := cmd.Flags().GetBool("today")
+
 		root := mustNotesPath()
-		n, err := note.ResolveRef(root, args[0])
+
+		var date string
+		if today {
+			date = time.Now().Format("20060102")
+		}
+
+		n, err := note.ResolveRefDate(root, args[0], date)
 		if err != nil {
 			return err
 		}
@@ -25,5 +34,6 @@ var resolveCmd = &cobra.Command{
 }
 
 func init() {
+	resolveCmd.Flags().Bool("today", false, "only match notes created today")
 	rootCmd.AddCommand(resolveCmd)
 }

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func runResolve(t *testing.T, root string, args ...string) (string, error) {
@@ -120,5 +122,38 @@ func TestResolveNonExistentErrors(t *testing.T) {
 	_, err := runResolve(t, root, "9999")
 	if err == nil {
 		t.Fatal("expected error for non-existent ref, got nil")
+	}
+}
+
+func TestResolveTodayFilterExcludesOldNotes(t *testing.T) {
+	root := testdataPath(t)
+	// "meeting" slug exists but is from 20260104, not today
+	_, err := runResolve(t, root, "--today", "meeting")
+	if err == nil {
+		t.Fatal("expected error when --today excludes matching note")
+	}
+}
+
+func TestResolveTodayFilterMatchesToday(t *testing.T) {
+	root := t.TempDir()
+	today := time.Now().Format("20060102")
+	month := today[:6]
+	dir := filepath.Join(root, today[:4], month[4:6])
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fname := today + "_0001_daily.md"
+	if err := os.WriteFile(filepath.Join(dir, fname), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runResolve(t, root, "--today", "daily")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(dir, fname)
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
 	}
 }

--- a/note/store.go
+++ b/note/store.go
@@ -71,11 +71,21 @@ func Scan(root string) ([]Note, error) {
 //  4. Slug
 //  5. Type — most recent note of that type (e.g. "todo", "backlog", "weekly")
 func ResolveRef(root, query string) (*Note, error) {
+	return ResolveRefDate(root, query, "")
+}
+
+// ResolveRefDate works like ResolveRef but optionally restricts candidates to
+// notes matching the given YYYYMMDD date string. Pass "" to skip date filtering.
+func ResolveRefDate(root, query, date string) (*Note, error) {
 	query = strings.TrimSpace(query)
 
 	notes, err := Scan(root)
 	if err != nil {
 		return nil, err
+	}
+
+	if date != "" {
+		notes = FilterByDate(notes, date)
 	}
 
 	// Step 1: numeric ID


### PR DESCRIPTION
## Summary

- Add `--today` flag to `resolve` that restricts note lookup to today's date, enabling clean existence checks like `notes resolve report --today`

## References

- Closes #46