### PR TITLE
Error when update called with no flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.41] - 2026-04-04
+
+### Changed
+
+- `update` command now returns an error when called with no flags instead of silently rewriting the file unchanged ([#69])
+
+[#69]: https://github.com/dreikanter/notescli/pull/69
+
 ## [0.1.40] - 2026-04-04
 
 ### Added

--- a/docs/superpowers/plans/2026-04-04-update-no-flags-error.md
+++ b/docs/superpowers/plans/2026-04-04-update-no-flags-error.md
@@ -1,0 +1,96 @@
+# Update No-Flags Error Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Return an error when `notes update <id>` is called with no update flags, instead of silently rewriting the file unchanged.
+
+**Architecture:** Add an early guard in the update command's `RunE` function that checks whether any update flag was explicitly set via `cmd.Flags().Changed()`. If none were set, return an error before any file I/O. Update the existing test to expect an error.
+
+**Tech Stack:** Go, cobra (CLI framework)
+
+---
+
+### Task 1: Update test to expect error on no flags
+
+**Files:**
+- Modify: `internal/cli/update_test.go:196-214`
+
+- [ ] **Step 1: Replace `TestUpdateNoFlagsUnchanged` with `TestUpdateNoFlagsErrors`**
+
+Replace the existing test at line 196-214 with:
+
+```go
+// TestUpdateNoFlagsErrors verifies that update with no flags returns an error.
+func TestUpdateNoFlagsErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runUpdate(t, root, "8823")
+	if err == nil {
+		t.Fatal("expected error when no update flags provided, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one update flag is required") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/cli/ -run TestUpdateNoFlagsErrors -v`
+Expected: FAIL — the current code returns nil error when no flags are provided.
+
+- [ ] **Step 3: Commit failing test**
+
+```bash
+git add internal/cli/update_test.go
+git commit -m "Test that update with no flags returns error (#69)"
+```
+
+### Task 2: Add no-flags guard to update command
+
+**Files:**
+- Modify: `internal/cli/update.go:18-28`
+
+- [ ] **Step 4: Add the early check in `update.go`**
+
+Insert the following block after line 28 (the `updatePrivate` assignment) and before line 29 (the type validation):
+
+```go
+		// At least one update flag must be provided.
+		updateFlags := []string{
+			"tag", "no-tags", "title", "description",
+			"slug", "no-slug", "type", "no-type",
+			"public", "private",
+		}
+		hasFlag := false
+		for _, name := range updateFlags {
+			if cmd.Flags().Changed(name) {
+				hasFlag = true
+				break
+			}
+		}
+		if !hasFlag {
+			return fmt.Errorf("at least one update flag is required")
+		}
+```
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+Run: `go test ./internal/cli/ -run TestUpdateNoFlagsErrors -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the full test suite to verify no regressions**
+
+Run: `make test`
+Expected: All tests pass.
+
+- [ ] **Step 7: Run linter**
+
+Run: `make lint`
+Expected: No issues.
+
+- [ ] **Step 8: Commit implementation**
+
+```bash
+git add internal/cli/update.go
+git commit -m "Error when update called with no flags (#69)"
+```

--- a/docs/superpowers/specs/2026-04-04-update-no-flags-error-design.md
+++ b/docs/superpowers/specs/2026-04-04-update-no-flags-error-design.md
@@ -1,0 +1,68 @@
+# Error on `update` with no flags
+
+**Issue:** [#69](https://github.com/dreikanter/notescli/issues/69)
+**Date:** 2026-04-04
+
+## Problem
+
+`notes update <id>` with no flags silently reads the file, re-serializes it unchanged, writes it back, and prints the path as if the update succeeded. This is confusing for users and masks bugs in scripts where a flag variable may be empty.
+
+## Solution
+
+Return an error when no update flags are provided. Exit before any file I/O or note resolution.
+
+**Error message:** `at least one update flag is required`
+
+## Implementation
+
+### Detection
+
+Check `cmd.Flags().Changed()` for all update flags immediately after flag parsing. The flags to check:
+
+- `tag`, `no-tags`
+- `title`, `description`
+- `slug`, `no-slug`
+- `type`, `no-type`
+- `public`, `private`
+
+If none are changed, return an error.
+
+### Placement in `update.go`
+
+Insert the check after line 28 (flag variable assignments), before the type validation on line 29. This is the earliest exit point — before note resolution and file I/O.
+
+```go
+// Check that at least one update flag was provided.
+updateFlags := []string{
+    "tag", "no-tags", "title", "description",
+    "slug", "no-slug", "type", "no-type",
+    "public", "private",
+}
+hasFlag := false
+for _, name := range updateFlags {
+    if cmd.Flags().Changed(name) {
+        hasFlag = true
+        break
+    }
+}
+if !hasFlag {
+    return fmt.Errorf("at least one update flag is required")
+}
+```
+
+### Test changes
+
+In `update_test.go`, replace `TestUpdateNoFlagsUnchanged` with `TestUpdateNoFlagsErrors`:
+
+- Call `runUpdate(t, root, "8823")` with no flags
+- Assert error is returned (non-nil)
+- Assert error message contains "at least one update flag is required"
+- Remove the file-content comparison (file should not be touched)
+
+No other tests are affected — all other test cases provide at least one flag.
+
+## Scope
+
+- **Files changed:** `internal/cli/update.go`, `internal/cli/update_test.go`
+- **No new dependencies**
+- **No changes to other commands**

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -26,6 +26,23 @@ var updateCmd = &cobra.Command{
 		updateNoType, _ := cmd.Flags().GetBool("no-type")
 		updatePrivate, _ := cmd.Flags().GetBool("private")
 
+		// At least one update flag must be provided.
+		updateFlags := []string{
+			"tag", "no-tags", "title", "description",
+			"slug", "no-slug", "type", "no-type",
+			"public", "private",
+		}
+		hasFlag := false
+		for _, name := range updateFlags {
+			if cmd.Flags().Changed(name) {
+				hasFlag = true
+				break
+			}
+		}
+		if !hasFlag {
+			return fmt.Errorf("at least one update flag is required")
+		}
+
 		if updateType != "" && !note.IsKnownType(updateType) {
 			return fmt.Errorf("unknown note type %q (valid types: %s)", updateType, strings.Join(note.KnownTypes, ", "))
 		}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -193,23 +193,15 @@ func TestUpdateDescription(t *testing.T) {
 	}
 }
 
-// TestUpdateNoFlagsUnchanged verifies no change when no flags are provided.
-func TestUpdateNoFlagsUnchanged(t *testing.T) {
+// TestUpdateNoFlagsErrors verifies that update with no flags returns an error.
+func TestUpdateNoFlagsErrors(t *testing.T) {
 	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260106_8823.md")
-	before, _ := os.ReadFile(target)
-
-	out, err := runUpdate(t, root, "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := runUpdate(t, root, "8823")
+	if err == nil {
+		t.Fatal("expected error when no update flags provided, got nil")
 	}
-	if out != target {
-		t.Errorf("got path %q, want %q", out, target)
-	}
-
-	after, _ := os.ReadFile(target)
-	if string(before) != string(after) {
-		t.Error("file should not have changed when no flags provided")
+	if !strings.Contains(err.Error(), "at least one update flag is required") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `notes update <id>` with no flags now returns an error instead of silently rewriting the file unchanged
- Early exit before any file I/O or note resolution when no update flags are provided

## References

- Closes #69