### PR TITLE
Output absolute paths from ls command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.41] - 2026-04-04
+
+### Fixed
+
+- Output absolute paths from `ls` to enable Unix pipelines like `notes ls | xargs notes read` ([#55])
+
+[#55]: https://github.com/dreikanter/notescli/pull/55
+
 ## [0.1.40] - 2026-04-04
 
 ### Added

--- a/docs/superpowers/plans/2026-04-04-ls-absolute-paths.md
+++ b/docs/superpowers/plans/2026-04-04-ls-absolute-paths.md
@@ -1,0 +1,169 @@
+# ls Absolute Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ls` output absolute paths so its output is consumable by other commands via Unix pipelines.
+
+**Architecture:** One-line change in `ls` RunE to prepend the store root to each `RelPath`. Update tests to assert absolute paths. Update changelog.
+
+**Tech Stack:** Go, cobra
+
+---
+
+### Task 1: Update `ls` to output absolute paths
+
+**Files:**
+- Modify: `internal/cli/ls.go:1-7` (import block) and `internal/cli/ls.go:57` (output line)
+
+- [ ] **Step 1: Add `path/filepath` to the import block**
+
+In `internal/cli/ls.go`, change the import block from:
+
+```go
+import (
+	"fmt"
+	"time"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+```
+
+to:
+
+```go
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+```
+
+- [ ] **Step 2: Change the output line to use absolute paths**
+
+In `internal/cli/ls.go`, line 57, change:
+
+```go
+fmt.Fprintln(cmd.OutOrStdout(), n.RelPath)
+```
+
+to:
+
+```go
+fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
+```
+
+`root` is already available in scope (line 23: `root := mustNotesPath()`).
+
+- [ ] **Step 3: Run existing tests to see which ones break**
+
+Run: `cd /Users/alex/src/notescli-issue-55 && go test ./internal/cli/ -run TestLs -v`
+
+Expected: Tests that check `strings.Contains` on filenames like `"todo"`, `"meeting"`, `"8814"` should still pass because the absolute path still contains those substrings. Tests that only check line counts should still pass. Observe which (if any) fail.
+
+### Task 2: Update tests to verify absolute paths
+
+**Files:**
+- Modify: `internal/cli/ls_test.go`
+
+- [ ] **Step 1: Add an assertion that `ls` output contains absolute paths**
+
+Add a new test to `internal/cli/ls_test.go` that verifies output lines are absolute paths:
+
+```go
+func TestLsOutputsAbsolutePaths(t *testing.T) {
+	out, err := runLs(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	for _, line := range strings.Split(out, "\n") {
+		if !filepath.IsAbs(line) {
+			t.Errorf("expected absolute path, got %q", line)
+		}
+		if !strings.HasPrefix(line, root) {
+			t.Errorf("expected path under %s, got %q", root, line)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Add `path/filepath` to the test file imports**
+
+In `internal/cli/ls_test.go`, change the import block from:
+
+```go
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+```
+
+to:
+
+```go
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 3: Run all ls tests**
+
+Run: `cd /Users/alex/src/notescli-issue-55 && go test ./internal/cli/ -run TestLs -v`
+
+Expected: All tests pass, including the new `TestLsOutputsAbsolutePaths`.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /Users/alex/src/notescli-issue-55 && make test`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Run linter**
+
+Run: `cd /Users/alex/src/notescli-issue-55 && make lint`
+
+Expected: No lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/ls.go internal/cli/ls_test.go
+git commit -m "Output absolute paths from ls command (#55)"
+```
+
+### Task 3: Update changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entry for v0.1.41**
+
+At the top of `CHANGELOG.md`, after the `# Changelog` heading and before the `## [0.1.40]` entry, add:
+
+```markdown
+## [0.1.41] - 2026-04-04
+
+### Fixed
+
+- Output absolute paths from `ls` to enable Unix pipelines like `notes ls | xargs notes read` ([#55])
+
+[#55]: https://github.com/dreikanter/notescli/pull/55
+```
+
+Note: The `[#55]` link reference goes at the end of the new entry block, before the blank line separating it from the `## [0.1.40]` entry. Follow the same pattern as existing entries (each entry has its own link reference immediately after it).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "Add changelog entry for v0.1.41"
+```

--- a/docs/superpowers/specs/2026-04-04-ls-absolute-paths-design.md
+++ b/docs/superpowers/specs/2026-04-04-ls-absolute-paths-design.md
@@ -1,0 +1,60 @@
+# Design: Make `ls` output absolute paths
+
+**Issue:** [#55](https://github.com/dreikanter/notescli/issues/55)
+**Date:** 2026-04-04
+
+## Problem
+
+`ls` outputs store-relative paths (e.g. `2026/04/20260404_103.todo.md`), but every
+ref-consuming command (`read`, `resolve`, `append`, `update`) uses `ResolveRef` which
+resolves paths containing `/` via `filepath.Abs` relative to CWD — not the store root.
+
+This breaks the natural Unix pipeline: `notes ls --type todo | xargs notes read`.
+
+Every other path-emitting command (`new`, `append`, `latest`, `resolve`, `update`) already
+outputs absolute paths. `ls` is the only outlier.
+
+## Solution
+
+Change `ls` to output absolute paths by prepending the store root to each `RelPath`.
+
+### Code change
+
+**`internal/cli/ls.go:57`** — replace:
+
+```go
+fmt.Fprintln(cmd.OutOrStdout(), n.RelPath)
+```
+
+with:
+
+```go
+fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
+```
+
+Add `"path/filepath"` to the import block.
+
+`root` is already resolved at line 23 via `mustNotesPath()`.
+
+This matches the pattern in `latest.go:22` and `resolve.go:31`.
+
+### Test changes
+
+**`internal/cli/ls_test.go`** — tests that inspect output lines need to expect absolute
+paths. The test helper `runLs` already passes `--path root` where `root` is the testdata
+directory, so assertions using `strings.Contains` on filenames (e.g. `"todo"`, `"meeting"`,
+`"8814"`) will continue to pass without changes. Tests that check line counts are unaffected.
+
+Verify all existing tests pass after the one-line production change. If any assertion
+compares exact path strings, update to expect the absolute form.
+
+### Changelog
+
+Next version will be `v0.1.41`. Add entry to `CHANGELOG.md` referencing PR number.
+
+## What is NOT changing
+
+- No new flags (no `--relative`, no `--absolute`)
+- No changes to `ResolveRef`
+- No changes to any other command
+- No changes to `note.Note` struct or `Scan`

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/dreikanter/notescli/note"
@@ -54,7 +55,7 @@ var lsCmd = &cobra.Command{
 		}
 
 		for _, n := range notes {
-			fmt.Fprintln(cmd.OutOrStdout(), n.RelPath)
+			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
 		}
 		return nil
 	},

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -191,5 +192,25 @@ func TestLsNameAndType(t *testing.T) {
 	}
 	if !strings.Contains(lines[0], "8814") {
 		t.Errorf("expected note 8814, got %q", lines[0])
+	}
+}
+
+func TestLsOutputsAbsolutePaths(t *testing.T) {
+	out, err := runLs(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	root := testdataPath(t)
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" {
+			continue
+		}
+		if !filepath.IsAbs(line) {
+			t.Errorf("expected absolute path, got %q", line)
+		}
+		if !strings.HasPrefix(line, root) {
+			t.Errorf("expected path under %s, got %q", root, line)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Output absolute paths from `ls` instead of store-relative paths, matching every other path-emitting command (`new`, `append`, `latest`, `resolve`, `update`)
- Add `TestLsOutputsAbsolutePaths` test verifying output lines are absolute and rooted under the store directory

## References

- Closes #55