### PR TITLE
Reject conflicting update flags (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.44] - 2026-04-04
+
+### Fixed
+
+- Reject conflicting `update` flags (`--slug`/`--no-slug`, `--type`/`--no-type`, `--tag`/`--no-tags`, `--public`/`--private`) instead of silently picking a winner ([#57])
+
+[#57]: https://github.com/dreikanter/notescli/pull/57
+
 ## [0.1.43] - 2026-04-04
 
 ### Fixed

--- a/docs/superpowers/specs/2026-04-04-conflicting-update-flags-design.md
+++ b/docs/superpowers/specs/2026-04-04-conflicting-update-flags-design.md
@@ -1,0 +1,84 @@
+# Reject conflicting update flags (#57)
+
+## Problem
+
+`notes update` accepts mutually exclusive flag pairs without error, silently
+picking one winner. This makes intent ambiguous and can cause unexpected results
+in scripts where flags are composed from variables.
+
+Conflicting pairs:
+
+| Flag A    | Flag B     | Current winner |
+|-----------|------------|----------------|
+| `--slug`  | `--no-slug`| `--no-slug`    |
+| `--type`  | `--no-type`| `--no-type`    |
+| `--tag`   | `--no-tags`| `--no-tags`    |
+| `--public`| `--private`| `--private`    |
+
+## Approach
+
+Use Cobra's built-in `MarkFlagsMutuallyExclusive` API. This validates flag
+groups before `RunE` executes using the same `pflag.Changed` check the manual
+approach would use.
+
+Benefits over hand-rolled validation:
+- 4 declarative lines vs ~12 lines of if-statements
+- Free shell completion behavior (conflicting flags auto-hidden)
+- Consistent Cobra error formatting
+
+## Changes
+
+### `internal/cli/update.go`
+
+**In `init()` (after flag registration, before `rootCmd.AddCommand`):**
+
+Add four mutual exclusion declarations:
+
+```go
+updateCmd.MarkFlagsMutuallyExclusive("slug", "no-slug")
+updateCmd.MarkFlagsMutuallyExclusive("type", "no-type")
+updateCmd.MarkFlagsMutuallyExclusive("tag", "no-tags")
+updateCmd.MarkFlagsMutuallyExclusive("public", "private")
+```
+
+**Flag description update (line 125):**
+
+Change `"mark note as private in frontmatter (overrides --public)"` to
+`"mark note as private in frontmatter"` since the flags are now mutually
+exclusive rather than one overriding.
+
+**`RunE` body:** No changes. The existing precedence logic becomes unreachable
+for conflicting inputs but is harmless to keep.
+
+### `internal/cli/update_test.go`
+
+**Update three existing tests** that validate precedence behavior to instead
+assert an error is returned:
+
+- `TestUpdateNoSlugTakesPrecedenceOverSlug` (line 234) — rename to
+  `TestUpdateSlugAndNoSlugConflict`, assert `err != nil`
+- `TestUpdateNoTypeTakesPrecedenceOverType` (line 249) — rename to
+  `TestUpdateTypeAndNoTypeConflict`, assert `err != nil`
+- `TestUpdatePrivateTakesPrecedenceOverPublic` (line 382) — rename to
+  `TestUpdatePublicAndPrivateConflict`, assert `err != nil`
+
+**Add one new test:**
+
+- `TestUpdateTagAndNoTagsConflict` — run with `--tag foo --no-tags`, assert
+  `err != nil`
+
+All four tests should verify the error message contains the conflicting flag
+names (e.g., `strings.Contains(err.Error(), "slug")` and
+`strings.Contains(err.Error(), "no-slug")`).
+
+### `CHANGELOG.md`
+
+Add entry for next patch version referencing PR number.
+
+## Files affected
+
+| File | Type of change |
+|------|----------------|
+| `internal/cli/update.go` | Add 4 `MarkFlagsMutuallyExclusive` calls, update flag description |
+| `internal/cli/update_test.go` | Update 3 tests, add 1 new test |
+| `CHANGELOG.md` | Add version entry |

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -145,6 +145,10 @@ func init() {
 	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
 	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
 	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
-	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter (overrides --public)")
+	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter")
+	updateCmd.MarkFlagsMutuallyExclusive("slug", "no-slug")
+	updateCmd.MarkFlagsMutuallyExclusive("type", "no-type")
+	updateCmd.MarkFlagsMutuallyExclusive("tag", "no-tags")
+	updateCmd.MarkFlagsMutuallyExclusive("public", "private")
 	rootCmd.AddCommand(updateCmd)
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -21,7 +21,11 @@ func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 	updateCmd.Flags().String("type", "", "update note type and rename file (todo, backlog, weekly)")
 	updateCmd.Flags().Bool("no-type", false, "remove type suffix from filename")
 	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
-	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter (overrides --public)")
+	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter")
+	updateCmd.MarkFlagsMutuallyExclusive("slug", "no-slug")
+	updateCmd.MarkFlagsMutuallyExclusive("type", "no-type")
+	updateCmd.MarkFlagsMutuallyExclusive("tag", "no-tags")
+	updateCmd.MarkFlagsMutuallyExclusive("public", "private")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -223,33 +227,39 @@ func TestUpdateInvalidTypeErrors(t *testing.T) {
 	}
 }
 
-// TestUpdateNoSlugTakesPrecedenceOverSlug verifies --no-slug wins when combined with --slug.
-func TestUpdateNoSlugTakesPrecedenceOverSlug(t *testing.T) {
+// TestUpdateSlugAndNoSlugConflict verifies --slug and --no-slug cannot be used together.
+func TestUpdateSlugAndNoSlugConflict(t *testing.T) {
 	root := copyTestdata(t)
-	// 8818 already has slug "meeting"; pass both --slug and --no-slug
-	out, err := runUpdate(t, root, "8818", "--slug", "other", "--no-slug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := runUpdate(t, root, "8818", "--slug", "other", "--no-slug")
+	if err == nil {
+		t.Fatal("expected error for --slug and --no-slug together, got nil")
 	}
-
-	want := filepath.Join(root, "2026/01/20260104_8818.md")
-	if out != want {
-		t.Errorf("got path %q, want %q (--no-slug should win)", out, want)
+	if !strings.Contains(err.Error(), "slug") || !strings.Contains(err.Error(), "no-slug") {
+		t.Errorf("expected error mentioning both flags, got: %v", err)
 	}
 }
 
-// TestUpdateNoTypeTakesPrecedenceOverType verifies --no-type wins when combined with --type.
-func TestUpdateNoTypeTakesPrecedenceOverType(t *testing.T) {
+// TestUpdateTagAndNoTagsConflict verifies --tag and --no-tags cannot be used together.
+func TestUpdateTagAndNoTagsConflict(t *testing.T) {
 	root := copyTestdata(t)
-	// 8814 has type "todo"; pass both --type backlog and --no-type
-	out, err := runUpdate(t, root, "8814", "--type", "backlog", "--no-type")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := runUpdate(t, root, "8823", "--tag", "foo", "--no-tags")
+	if err == nil {
+		t.Fatal("expected error for --tag and --no-tags together, got nil")
 	}
+	if !strings.Contains(err.Error(), "tag") || !strings.Contains(err.Error(), "no-tags") {
+		t.Errorf("expected error mentioning both flags, got: %v", err)
+	}
+}
 
-	want := filepath.Join(root, "2026/01/20260102_8814.md")
-	if out != want {
-		t.Errorf("got path %q, want %q (--no-type should win)", out, want)
+// TestUpdateTypeAndNoTypeConflict verifies --type and --no-type cannot be used together.
+func TestUpdateTypeAndNoTypeConflict(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runUpdate(t, root, "8814", "--type", "backlog", "--no-type")
+	if err == nil {
+		t.Fatal("expected error for --type and --no-type together, got nil")
+	}
+	if !strings.Contains(err.Error(), "type") || !strings.Contains(err.Error(), "no-type") {
+		t.Errorf("expected error mentioning both flags, got: %v", err)
 	}
 }
 
@@ -371,20 +381,15 @@ func TestUpdatePrivateRemovesPublicField(t *testing.T) {
 	}
 }
 
-// TestUpdatePrivateTakesPrecedenceOverPublic verifies --private wins when combined with --public.
-func TestUpdatePrivateTakesPrecedenceOverPublic(t *testing.T) {
+// TestUpdatePublicAndPrivateConflict verifies --public and --private cannot be used together.
+func TestUpdatePublicAndPrivateConflict(t *testing.T) {
 	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8823", "--public", "--private")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := runUpdate(t, root, "8823", "--public", "--private")
+	if err == nil {
+		t.Fatal("expected error for --public and --private together, got nil")
 	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if strings.Contains(string(data), "public:") {
-		t.Errorf("expected public field absent when --private wins, got:\n%s", string(data))
+	if !strings.Contains(err.Error(), "public") || !strings.Contains(err.Error(), "private") {
+		t.Errorf("expected error mentioning both flags, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use Cobra's `MarkFlagsMutuallyExclusive` to reject ambiguous flag combinations on `update`: `--slug`/`--no-slug`, `--type`/`--no-type`, `--tag`/`--no-tags`, `--public`/`--private`
- Update existing precedence tests to expect errors; add new `--tag`/`--no-tags` conflict test

## References

- Closes #57