### PR TITLE
Fix new-todo to always succeed without a previous todo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.45] - 2026-04-04
+
+### Fixed
+
+- `new-todo` no longer fails when no previous todo exists; creates an empty todo instead. `--force` works correctly when today's todo is the only one ([#58])
+
+[#58]: https://github.com/dreikanter/notescli/pull/58
+
 ## [0.1.44] - 2026-04-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For development, use `make build` or `make install` from a local clone.
 notes new
 notes new --title "Meeting notes" --slug meeting --tag work
 
-# Create today's todo from the previous todo
+# Create today's todo (rolls over pending tasks from the previous one)
 notes new-todo
 
 # List recent notes

--- a/docs/superpowers/plans/2026-04-04-new-todo-always-succeed.md
+++ b/docs/superpowers/plans/2026-04-04-new-todo-always-succeed.md
@@ -1,0 +1,294 @@
+# new-todo Always-Succeed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `new-todo` always create today's todo, treating rollover as optional when a previous todo exists.
+
+**Architecture:** Single behavioral change in the CLI command handler — when no previous todo is found, skip rollover and create an empty todo instead of erroring. Update command description to clarify that rollover is not the primary purpose.
+
+**Tech Stack:** Go, cobra CLI framework, existing `note` package
+
+---
+
+### Task 1: Fix `new-todo` to succeed without a previous todo (TDD)
+
+**Files:**
+- Modify: `internal/cli/new_todo_test.go:101-107` (rename + rewrite existing test)
+- Modify: `internal/cli/new_todo.go:37-41` (remove error, add skip-rollover path)
+
+- [ ] **Step 1: Rewrite `TestNewTodoNoPreviousErrors` as `TestNewTodoNoPreviousCreatesEmpty`**
+
+In `internal/cli/new_todo_test.go`, replace the existing test (lines 101–107) with:
+
+```go
+func TestNewTodoNoPreviousCreatesEmpty(t *testing.T) {
+	root := emptyNotesRoot(t)
+	out, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("expected success when no previous todo, got error: %v", err)
+	}
+	if out == "" {
+		t.Fatal("expected output path, got empty string")
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("created file does not exist: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("cannot read created file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "[ ]") {
+		t.Errorf("expected no tasks in empty todo, got:\n%s", content)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/alex/src/notescli-issue-58 && go test ./internal/cli/ -run TestNewTodoNoPreviousCreatesEmpty -v`
+
+Expected: FAIL — the current code returns an error `"no previous todo found"`.
+
+- [ ] **Step 3: Implement the fix in `new_todo.go`**
+
+In `internal/cli/new_todo.go`, replace lines 37–57 (the `FindLatestTodo` call through the `WriteFile` of the previous todo) with:
+
+```go
+		// Find the most recent previous todo and roll over tasks
+		var carriedTasks []note.Task
+		prev := note.FindLatestTodo(notes, today)
+		if prev != nil {
+			prevPath := filepath.Join(root, prev.RelPath)
+			prevData, err := os.ReadFile(prevPath)
+			if err != nil {
+				return fmt.Errorf("cannot read previous todo: %w", err)
+			}
+			prevLines := strings.Split(string(prevData), "\n")
+
+			result := note.RolloverTasks(prevLines)
+			carriedTasks = result.CarriedTasks
+
+			if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
+				return fmt.Errorf("cannot update previous todo: %w", err)
+			}
+		}
+```
+
+Then update line 72 (the `FormatTodoContent` call) to use `carriedTasks` instead of `result.CarriedTasks`:
+
+```go
+		content := note.FormatTodoContent(carriedTasks)
+```
+
+The full `RunE` function after the change:
+
+```go
+	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+
+		root := mustNotesPath()
+		today := time.Now().Format("20060102")
+
+		notes, err := note.Scan(root)
+		if err != nil {
+			return err
+		}
+
+		// Check if today's todo already exists
+		if !force {
+			if existing := note.FindTodayTodo(notes, today); existing != nil {
+				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, existing.RelPath))
+				return nil
+			}
+		}
+
+		// Find the most recent previous todo and roll over tasks
+		var carriedTasks []note.Task
+		prev := note.FindLatestTodo(notes, today)
+		if prev != nil {
+			prevPath := filepath.Join(root, prev.RelPath)
+			prevData, err := os.ReadFile(prevPath)
+			if err != nil {
+				return fmt.Errorf("cannot read previous todo: %w", err)
+			}
+			prevLines := strings.Split(string(prevData), "\n")
+
+			result := note.RolloverTasks(prevLines)
+			carriedTasks = result.CarriedTasks
+
+			if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
+				return fmt.Errorf("cannot update previous todo: %w", err)
+			}
+		}
+
+		// Allocate new ID and create new todo
+		id, err := note.NextID(root)
+		if err != nil {
+			return err
+		}
+
+		filename := note.NoteFilename(today, id, "", "todo")
+		dir := note.NoteDirPath(root, today)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("cannot create directory %s: %w", dir, err)
+		}
+
+		fullPath := filepath.Join(dir, filename)
+		content := note.FormatTodoContent(carriedTasks)
+
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("cannot write todo: %w", err)
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+		return nil
+	},
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `cd /Users/alex/src/notescli-issue-58 && go test ./internal/cli/ -run TestNewTodoNoPreviousCreatesEmpty -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Run all existing tests to verify no regressions**
+
+Run: `cd /Users/alex/src/notescli-issue-58 && go test ./internal/cli/ -run TestNewTodo -v`
+
+Expected: All `TestNewTodo*` tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/new_todo.go internal/cli/new_todo_test.go
+git commit -m "Make new-todo succeed without a previous todo (#58)"
+```
+
+---
+
+### Task 2: Add test for `--force` when today's todo is the only one
+
+**Files:**
+- Modify: `internal/cli/new_todo_test.go` (add new test)
+
+- [ ] **Step 1: Write the test**
+
+Add to `internal/cli/new_todo_test.go`:
+
+```go
+func TestNewTodoForceOnlyTodayExists(t *testing.T) {
+	root := emptyNotesRoot(t)
+
+	// Create today's todo (no previous todo to roll from).
+	first, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("first call unexpected error: %v", err)
+	}
+
+	// --force should regenerate even with no previous todo.
+	second, err := runNewTodo(t, root, "--force")
+	if err != nil {
+		t.Fatalf("force call unexpected error: %v", err)
+	}
+
+	if first == second {
+		t.Errorf("expected a different path with --force, got same path %q", first)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Errorf("forced file does not exist: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd /Users/alex/src/notescli-issue-58 && go test ./internal/cli/ -run TestNewTodoForceOnlyTodayExists -v`
+
+Expected: PASS (the fix from Task 1 already handles this).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/new_todo_test.go
+git commit -m "Add test for --force when only today's todo exists (#58)"
+```
+
+---
+
+### Task 3: Update command description and README
+
+**Files:**
+- Modify: `internal/cli/new_todo.go:16` (command `Short` field)
+- Modify: `README.md:27-28` (usage comment)
+
+- [ ] **Step 1: Update the cobra command `Short` description**
+
+In `internal/cli/new_todo.go`, change line 16 from:
+
+```go
+	Short: "Create today's todo from the previous todo",
+```
+
+to:
+
+```go
+	Short: "Create today's todo",
+```
+
+- [ ] **Step 2: Update the README usage comment**
+
+In `README.md`, change line 27-28 from:
+
+```markdown
+# Create today's todo from the previous todo
+notes new-todo
+```
+
+to:
+
+```markdown
+# Create today's todo (rolls over pending tasks from the previous one)
+notes new-todo
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd /Users/alex/src/notescli-issue-58 && make lint`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/new_todo.go README.md
+git commit -m "Update new-todo description to clarify rollover is optional (#58)"
+```
+
+---
+
+### Task 4: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (add entry at top)
+
+- [ ] **Step 1: Add changelog entry**
+
+Add at the top of `CHANGELOG.md`, after the `# Changelog` heading and before the `## [0.1.40]` entry:
+
+```markdown
+## [0.1.41] - 2026-04-04
+
+### Fixed
+
+- `new-todo` no longer fails when no previous todo exists; creates an empty todo instead. `--force` works correctly when today's todo is the only one ([#58])
+
+[#58]: https://github.com/dreikanter/notescli/pull/58
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "Add changelog entry for v0.1.41 (#58)"
+```

--- a/docs/superpowers/specs/2026-04-04-new-todo-always-succeed-design.md
+++ b/docs/superpowers/specs/2026-04-04-new-todo-always-succeed-design.md
@@ -1,0 +1,87 @@
+# new-todo: Remove rollover requirement, always create today's todo
+
+**Issue:** [#58](https://github.com/dreikanter/notescli/issues/58)
+**Date:** 2026-04-04
+
+## Problem
+
+`new-todo` treats rollover from a previous todo as mandatory. When no previous
+todo exists, the command fails with `"no previous todo found"`. This is wrong:
+the command's purpose is to create today's todo, and rollover is an optional
+convenience when a prior todo happens to exist.
+
+The `--force` flag compounds the confusion. A user with today's todo as the
+only todo runs `new-todo --force` expecting regeneration, but gets the same
+error — even though a todo clearly exists.
+
+The root cause is not the error message wording. The root cause is that the
+command should never error here. There is no scenario where "no previous todo"
+should prevent creating today's todo. No previous todo is equivalent to an
+empty previous todo — zero tasks to carry over.
+
+## Design
+
+### Behavioral change
+
+`new-todo` always succeeds in creating today's todo. The `FindLatestTodo` result
+controls whether rollover happens, not whether the command proceeds:
+
+- **Previous todo found:** roll over pending/daily tasks (current behavior,
+  unchanged).
+- **No previous todo found:** skip rollover, create today's todo with no
+  carried tasks.
+
+This applies to both the default and `--force` paths. The error
+`"no previous todo found"` is removed entirely.
+
+### Command description update
+
+The current `Short` description is:
+
+```
+Create today's todo from the previous todo
+```
+
+This implies rollover is the primary purpose and reinforces the misconception
+that a previous todo is required. Update to:
+
+```
+Create today's todo
+```
+
+The `--force` flag description stays as-is (`"regenerate today's todo even if
+it exists"`) — it's already clear.
+
+Update the README usage comment similarly:
+
+```
+# Create today's todo (rolls over pending tasks from the previous one)
+```
+
+This makes the actual behavior unambiguous: the command creates a todo, and
+rollover is a side effect when applicable.
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `internal/cli/new_todo.go` | When `FindLatestTodo` returns nil, skip rollover and proceed with empty carried tasks. Remove the error. Update `Short` description. |
+| `internal/cli/new_todo_test.go` | Rename `TestNewTodoNoPreviousErrors` → `TestNewTodoNoPreviousCreatesEmpty` (expect success, verify empty todo file). Add `TestNewTodoForceOnlyTodayExists` (today's todo is the only one, `--force` succeeds). |
+| `README.md` | Update `new-todo` usage comment. |
+| `CHANGELOG.md` | Add entry for the fix. |
+
+### What does NOT change
+
+- `note/todo.go` — `RolloverTasks`, `FormatTodoContent`, `FindLatestTodo` are
+  all correct. The logic change is entirely in the CLI command handler.
+- `--force` semantics — it still means "regenerate even if today's todo exists."
+- Rollover behavior when a previous todo exists — completely unchanged.
+
+## Testing
+
+1. **No previous todo (new test):** `new-todo` on an empty store creates an
+   empty todo file. Verify the file exists and contains no task lines.
+2. **Force with only today's todo (new test):** Create today's todo, then
+   `new-todo --force`. Verify it succeeds and creates a new file.
+3. **Existing tests pass unchanged:** rollover, idempotency, force-regeneration
+   with a previous todo all work as before.

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -34,26 +34,23 @@ var newTodoCmd = &cobra.Command{
 			}
 		}
 
-		// Find the most recent previous todo
+		// Find the most recent previous todo and roll over tasks
+		var carriedTasks []note.Task
 		prev := note.FindLatestTodo(notes, today)
-		if prev == nil {
-			return fmt.Errorf("no previous todo found")
-		}
+		if prev != nil {
+			prevPath := filepath.Join(root, prev.RelPath)
+			prevData, err := os.ReadFile(prevPath)
+			if err != nil {
+				return fmt.Errorf("cannot read previous todo: %w", err)
+			}
+			prevLines := strings.Split(string(prevData), "\n")
 
-		// Read previous todo content
-		prevPath := filepath.Join(root, prev.RelPath)
-		prevData, err := os.ReadFile(prevPath)
-		if err != nil {
-			return fmt.Errorf("cannot read previous todo: %w", err)
-		}
-		prevLines := strings.Split(string(prevData), "\n")
+			result := note.RolloverTasks(prevLines)
+			carriedTasks = result.CarriedTasks
 
-		// Rollover tasks
-		result := note.RolloverTasks(prevLines)
-
-		// Write back modified previous todo
-		if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
-			return fmt.Errorf("cannot update previous todo: %w", err)
+			if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
+				return fmt.Errorf("cannot update previous todo: %w", err)
+			}
 		}
 
 		// Allocate new ID and create new todo
@@ -69,7 +66,7 @@ var newTodoCmd = &cobra.Command{
 		}
 
 		fullPath := filepath.Join(dir, filename)
-		content := note.FormatTodoContent(result.CarriedTasks)
+		content := note.FormatTodoContent(carriedTasks)
 
 		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("cannot write todo: %w", err)

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -13,7 +13,7 @@ import (
 
 var newTodoCmd = &cobra.Command{
 	Use:   "new-todo",
-	Short: "Create today's todo from the previous todo",
+	Short: "Create today's todo",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -98,10 +98,24 @@ func TestNewTodoForceRegenerates(t *testing.T) {
 	}
 }
 
-func TestNewTodoNoPreviousErrors(t *testing.T) {
+func TestNewTodoNoPreviousCreatesEmpty(t *testing.T) {
 	root := emptyNotesRoot(t)
-	_, err := runNewTodo(t, root)
-	if err == nil {
-		t.Fatal("expected error when no previous todo exists, got nil")
+	out, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("expected success when no previous todo, got error: %v", err)
+	}
+	if out == "" {
+		t.Fatal("expected output path, got empty string")
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("created file does not exist: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("cannot read created file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "[ ]") {
+		t.Errorf("expected no tasks in empty todo, got:\n%s", content)
 	}
 }

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -119,3 +119,26 @@ func TestNewTodoNoPreviousCreatesEmpty(t *testing.T) {
 		t.Errorf("expected no tasks in empty todo, got:\n%s", content)
 	}
 }
+
+func TestNewTodoForceOnlyTodayExists(t *testing.T) {
+	root := emptyNotesRoot(t)
+
+	// Create today's todo (no previous todo to roll from).
+	first, err := runNewTodo(t, root)
+	if err != nil {
+		t.Fatalf("first call unexpected error: %v", err)
+	}
+
+	// --force should regenerate even with no previous todo.
+	second, err := runNewTodo(t, root, "--force")
+	if err != nil {
+		t.Fatalf("force call unexpected error: %v", err)
+	}
+
+	if first == second {
+		t.Errorf("expected a different path with --force, got same path %q", first)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Errorf("forced file does not exist: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `new-todo` no longer fails when no previous todo exists; creates an empty todo instead. Rollover is performed when a previous todo is available, skipped otherwise.
- `--force` works correctly when today's todo is the only one
- Updated command description and README to clarify rollover is optional, not mandatory

## References

- Closes #58