### PR TITLE
Fix ls --type and --slug to use StringSlice (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.47] - 2026-04-05
+
+### Fixed
+
+- Fix `ls --type` and `--slug` flags to accept multiple values, matching `latest` behavior ([#64])
+
+[#64]: https://github.com/dreikanter/notescli/pull/78
+
 ## [0.1.46] - 2026-04-04
 
 ### Added
@@ -49,6 +57,7 @@
 - `update` command now returns an error when called with no flags instead of silently rewriting the file unchanged ([#69])
 
 [#69]: https://github.com/dreikanter/notescli/pull/69
+
 ## [0.1.40] - 2026-04-04
 
 ### Added

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -15,8 +15,8 @@ var lsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lsLimit, _ := cmd.Flags().GetInt("limit")
-		lsType, _ := cmd.Flags().GetString("type")
-		lsSlug, _ := cmd.Flags().GetString("slug")
+		lsTypes, _ := cmd.Flags().GetStringSlice("type")
+		lsSlugs, _ := cmd.Flags().GetStringSlice("slug")
 		lsTags, _ := cmd.Flags().GetStringSlice("tag")
 		lsName, _ := cmd.Flags().GetString("name")
 		lsToday, _ := cmd.Flags().GetBool("today")
@@ -35,12 +35,12 @@ var lsCmd = &cobra.Command{
 			notes = note.Filter(notes, lsName)
 		}
 
-		if lsType != "" {
-			notes = note.FilterByType(notes, lsType)
+		if len(lsTypes) > 0 {
+			notes = note.FilterByTypes(notes, lsTypes)
 		}
 
-		if lsSlug != "" {
-			notes = note.FilterBySlug(notes, lsSlug)
+		if len(lsSlugs) > 0 {
+			notes = note.FilterBySlugs(notes, lsSlugs)
 		}
 
 		if len(lsTags) > 0 {
@@ -63,8 +63,8 @@ var lsCmd = &cobra.Command{
 
 func init() {
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
-	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
-	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
+	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	lsCmd.Flags().StringSlice("slug", nil, "filter by descriptive slug (repeatable)")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 	lsCmd.Flags().Bool("today", false, "filter notes created today")

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -13,8 +13,8 @@ func runLs(t *testing.T, args ...string) (string, error) {
 	root := testdataPath(t)
 	lsCmd.ResetFlags()
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
-	lsCmd.Flags().String("type", "", "filter by note type, e.g. todo, backlog, weekly")
-	lsCmd.Flags().String("slug", "", "filter by descriptive slug")
+	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	lsCmd.Flags().StringSlice("slug", nil, "filter by descriptive slug (repeatable)")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 	lsCmd.Flags().Bool("today", false, "filter notes created today")
@@ -212,5 +212,34 @@ func TestLsOutputsAbsolutePaths(t *testing.T) {
 		if !strings.HasPrefix(line, root) {
 			t.Errorf("expected path under %s, got %q", root, line)
 		}
+	}
+}
+
+func TestLsMultipleTypes(t *testing.T) {
+	// "todo" exists; "backlog" does not — union should return the 1 todo note
+	out, err := runLs(t, "--type", "todo", "--type", "backlog")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "todo") {
+		t.Errorf("expected todo note, got %q", lines[0])
+	}
+}
+
+func TestLsMultipleSlugs(t *testing.T) {
+	// testdata has one note with slug "meeting" and one with "disable-letter_opener"
+	out, err := runLs(t, "--slug", "meeting", "--slug", "disable-letter_opener")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2:\n%s", len(lines), out)
 	}
 }


### PR DESCRIPTION
## Summary

- `ls --type` and `ls --slug` now accept multiple values (repeatable flags), matching `latest` behavior
- Switches from `String`/`FilterByType`/`FilterBySlug` to `StringSlice`/`FilterByTypes`/`FilterBySlugs`
- Adds `TestLsMultipleTypes` and `TestLsMultipleSlugs` tests

## References

- Closes #64