### PR TITLE
Simplify --slug to single-value and fix broken tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 ## References
 
-- Closes #
+- <!-- closes | relates to | depends on | blocked by --> #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.54] - 2026-04-05
+
+### Changed
+
+- Simplify `--slug` flag to single-value on `ls` and `latest` commands ([#85])
+
+### Fixed
+
+- Fix broken tests for `edit` and `rm` commands after testdata rename in [#72] ([#85])
+
 ## [0.1.41] - 2026-04-05
 
 ### Added
@@ -217,6 +227,7 @@
 - Add `new` and `new-todo` commands ([#2])
 - Add `--no-frontmatter` flag to `read` command ([#3], [#4])
 
+[0.1.54]: https://github.com/dreikanter/notescli/releases/tag/v0.1.54
 [0.1.41]: https://github.com/dreikanter/notescli/releases/tag/v0.1.41
 [0.1.40]: https://github.com/dreikanter/notescli/releases/tag/v0.1.40
 [0.1.39]: https://github.com/dreikanter/notescli/releases/tag/v0.1.39
@@ -297,3 +308,4 @@
 [#81]: https://github.com/dreikanter/notescli/pull/81
 [#82]: https://github.com/dreikanter/notescli/pull/82
 [#83]: https://github.com/dreikanter/notescli/pull/83
+[#85]: https://github.com/dreikanter/notescli/issues/85

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -103,7 +103,7 @@ var appendCmd = &cobra.Command{
 				notes = note.FilterByTypes(notes, []string{noteType})
 			}
 			if slug != "" {
-				notes = note.FilterBySlugs(notes, []string{slug})
+				notes = note.FilterBySlug(notes, slug)
 			}
 			if len(tags) > 0 {
 				notes, err = note.FilterByTags(notes, root, tags)

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -45,7 +45,7 @@ func TestEditOpensEditor(t *testing.T) {
 		t.Fatalf("marker file not created: %v", err)
 	}
 
-	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
 	if strings.TrimSpace(string(got)) != want {
 		t.Errorf("editor received %q, want %q", strings.TrimSpace(string(got)), want)
 	}
@@ -80,7 +80,7 @@ func TestEditPrefersVisual(t *testing.T) {
 		t.Fatalf("marker file not created: %v", err)
 	}
 
-	want := filepath.Join(root, "2026/01/20260106_8823.md")
+	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
 	if strings.TrimSpace(string(got)) != want {
 		t.Errorf("editor received %q, want %q", strings.TrimSpace(string(got)), want)
 	}

--- a/internal/cli/latest.go
+++ b/internal/cli/latest.go
@@ -35,7 +35,7 @@ func scanAndFilter(cmd *cobra.Command, root string) (*note.Note, error) {
 
 	today, _ := cmd.Flags().GetBool("today")
 	types, _ := cmd.Flags().GetStringSlice("type")
-	slugs, _ := cmd.Flags().GetStringSlice("slug")
+	slug, _ := cmd.Flags().GetString("slug")
 	tags, _ := cmd.Flags().GetStringSlice("tag")
 
 	if today {
@@ -46,8 +46,8 @@ func scanAndFilter(cmd *cobra.Command, root string) (*note.Note, error) {
 		notes = note.FilterByTypes(notes, types)
 	}
 
-	if len(slugs) > 0 {
-		notes = note.FilterBySlugs(notes, slugs)
+	if slug != "" {
+		notes = note.FilterBySlug(notes, slug)
 	}
 
 	if len(tags) > 0 {
@@ -58,7 +58,7 @@ func scanAndFilter(cmd *cobra.Command, root string) (*note.Note, error) {
 	}
 
 	if len(notes) == 0 {
-		if len(types) > 0 || len(slugs) > 0 || len(tags) > 0 || today {
+		if len(types) > 0 || slug != "" || len(tags) > 0 || today {
 			return nil, fmt.Errorf("no notes found matching the given criteria")
 		}
 		return nil, fmt.Errorf("no notes found")
@@ -69,7 +69,7 @@ func scanAndFilter(cmd *cobra.Command, root string) (*note.Note, error) {
 
 func init() {
 	latestCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	latestCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	latestCmd.Flags().String("slug", "", "filter by slug")
 	latestCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	latestCmd.Flags().Bool("today", false, "filter to notes created today")
 	rootCmd.AddCommand(latestCmd)

--- a/internal/cli/latest_test.go
+++ b/internal/cli/latest_test.go
@@ -24,7 +24,7 @@ func runLatest(t *testing.T, args ...string) (string, error) {
 	// Reset flags to avoid state leaking between tests.
 	latestCmd.ResetFlags()
 	latestCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	latestCmd.Flags().StringSlice("slug", nil, "filter by slug (repeatable)")
+	latestCmd.Flags().String("slug", "", "filter by slug")
 	latestCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	latestCmd.Flags().Bool("today", false, "filter to notes created today")
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -16,7 +16,7 @@ var lsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lsLimit, _ := cmd.Flags().GetInt("limit")
 		lsTypes, _ := cmd.Flags().GetStringSlice("type")
-		lsSlugs, _ := cmd.Flags().GetStringSlice("slug")
+		lsSlug, _ := cmd.Flags().GetString("slug")
 		lsTags, _ := cmd.Flags().GetStringSlice("tag")
 		lsName, _ := cmd.Flags().GetString("name")
 		lsToday, _ := cmd.Flags().GetBool("today")
@@ -39,8 +39,8 @@ var lsCmd = &cobra.Command{
 			notes = note.FilterByTypes(notes, lsTypes)
 		}
 
-		if len(lsSlugs) > 0 {
-			notes = note.FilterBySlugs(notes, lsSlugs)
+		if lsSlug != "" {
+			notes = note.FilterBySlug(notes, lsSlug)
 		}
 
 		if len(lsTags) > 0 {
@@ -64,7 +64,7 @@ var lsCmd = &cobra.Command{
 func init() {
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
 	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	lsCmd.Flags().StringSlice("slug", nil, "filter by descriptive slug (repeatable)")
+	lsCmd.Flags().String("slug", "", "filter by slug")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 	lsCmd.Flags().Bool("today", false, "filter notes created today")

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -14,7 +14,7 @@ func runLs(t *testing.T, args ...string) (string, error) {
 	lsCmd.ResetFlags()
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
 	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	lsCmd.Flags().StringSlice("slug", nil, "filter by descriptive slug (repeatable)")
+	lsCmd.Flags().String("slug", "", "filter by slug")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
 	lsCmd.Flags().Bool("today", false, "filter notes created today")
@@ -231,15 +231,17 @@ func TestLsMultipleTypes(t *testing.T) {
 	}
 }
 
-func TestLsMultipleSlugs(t *testing.T) {
-	// testdata has one note with slug "meeting" and one with "disable-letter_opener"
-	out, err := runLs(t, "--slug", "meeting", "--slug", "disable-letter_opener")
+func TestLsSlug(t *testing.T) {
+	out, err := runLs(t, "--slug", "meeting")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	lines := strings.Split(out, "\n")
-	if len(lines) != 2 {
-		t.Fatalf("got %d lines, want 2:\n%s", len(lines), out)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "meeting") {
+		t.Errorf("expected meeting note, got %q", lines[0])
 	}
 }

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -49,7 +49,7 @@ var readCmd = &cobra.Command{
 				notes = note.FilterByTypes(notes, []string{noteType})
 			}
 			if slug != "" {
-				notes = note.FilterBySlugs(notes, []string{slug})
+				notes = note.FilterBySlug(notes, slug)
 			}
 			if len(tags) > 0 {
 				notes, err = note.FilterByTags(notes, root, tags)

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -26,7 +26,7 @@ func runRm(t *testing.T, root string, args ...string) (string, error) {
 
 func TestRmByID(t *testing.T) {
 	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260106_8823.md")
+	target := filepath.Join(root, "2026/01/20260106_8823_999.md")
 
 	out, err := runRm(t, root, "8823")
 	if err != nil {

--- a/note/store.go
+++ b/note/store.go
@@ -208,15 +208,9 @@ func FilterByDate(notes []Note, date string) []Note {
 
 // FilterBySlug returns notes with an exact slug match.
 func FilterBySlug(notes []Note, slug string) []Note {
-	return FilterBySlugs(notes, []string{slug})
-}
-
-// FilterBySlugs returns notes whose slug matches any of the given values.
-func FilterBySlugs(notes []Note, slugs []string) []Note {
-	set := toSet(slugs)
 	var results []Note
 	for _, n := range notes {
-		if _, ok := set[n.Slug]; ok {
+		if n.Slug == slug {
 			results = append(results, n)
 		}
 	}


### PR DESCRIPTION
## Summary

- Revert `--slug` flag from `StringSlice` to `String` on `ls` and `latest` commands — multi-slug OR filtering was over-engineered for a field that identifies individual notes
- Remove `FilterBySlugs` from `note/store.go`; simplify `FilterBySlug` to a direct loop
- Update `read` and `append` call sites from `FilterBySlugs` to `FilterBySlug`
- Fix broken `TestRmByID`, `TestEditOpensEditor`, and `TestEditPrefersVisual` tests that expected `20260106_8823.md` but testdata was renamed to `20260106_8823_999.md` in #72

## References

- Relates to #85