### PR TITLE
Change daily task tag format from [daily] to #daily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.67] - 2026-04-18
+
+### Changed
+
+- Change daily task tag format from `[daily]` to `#daily` ([#104])
+
 ## [0.1.66] - 2026-04-09
 
 ### Changed
@@ -403,3 +409,4 @@
 [#99]: https://github.com/dreikanter/notes-cli/pull/99
 [#100]: https://github.com/dreikanter/notes-cli/pull/100
 [#102]: https://github.com/dreikanter/notes-cli/pull/102
+[#104]: https://github.com/dreikanter/notes-cli/pull/104

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Change daily task tag format from `[daily]` to `#daily` ([#104])
+- Change daily task tag format from `[daily]` to `#daily` ([#106])
 
 ## [0.1.66] - 2026-04-09
 
@@ -409,4 +409,4 @@
 [#99]: https://github.com/dreikanter/notes-cli/pull/99
 [#100]: https://github.com/dreikanter/notes-cli/pull/100
 [#102]: https://github.com/dreikanter/notes-cli/pull/102
-[#104]: https://github.com/dreikanter/notes-cli/pull/104
+[#106]: https://github.com/dreikanter/notes-cli/pull/106

--- a/note/todo.go
+++ b/note/todo.go
@@ -14,7 +14,7 @@ type Task struct {
 	Prefix     string // everything before the marker character: e.g. "  - ["
 	Marker     string // single char marker: " ", "x", "+", etc.
 	Suffix     string // everything after marker: e.g. "] some task"
-	IsDaily    bool   // whether line contains [daily]
+	IsDaily    bool   // whether line contains #daily
 	IsMoved    bool   // whether line contains (moved)
 	LineNumber int    // 0-based index in the source file lines
 }
@@ -30,7 +30,7 @@ func ParseTask(line string, lineNumber int) *Task {
 		Prefix:     m[1],
 		Marker:     m[2],
 		Suffix:     m[3],
-		IsDaily:    strings.Contains(line, "[daily]"),
+		IsDaily:    strings.Contains(line, "#daily"),
 		IsMoved:    strings.Contains(line, "(moved)"),
 		LineNumber: lineNumber,
 	}

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -19,8 +19,8 @@ func TestParseTask(t *testing.T) {
 		{"pending indented", "  [ ] Buy milk", false, " ", false, false},
 		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false, false},
 		{"completed", "[+] Done task", false, "+", false, false},
-		{"daily", "[ ] Standup [daily]", false, " ", true, false},
-		{"daily completed", "[+] Standup [daily]", false, "+", true, false},
+		{"daily", "[ ] Standup #daily", false, " ", true, false},
+		{"daily completed", "[+] Standup #daily", false, "+", true, false},
 		{"moved", "- [ ] (moved) Buy milk", false, " ", false, true},
 		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, " ", false, true},
 		{"not a task", "Just a regular line", true, "", false, false},
@@ -105,7 +105,7 @@ slug: todo
 
 [+] Completed task
 
-[ ] Standup [daily]`, "\n")
+[ ] Standup #daily`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -187,7 +187,7 @@ func TestRolloverTasksSkipsMoved(t *testing.T) {
 }
 
 func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
-	prev := strings.Split(`[+] Standup [daily]
+	prev := strings.Split(`[+] Standup #daily
 
 [+] Completed other task`, "\n")
 
@@ -203,7 +203,7 @@ func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
 
 func TestRolloverTasksNoDuplicates(t *testing.T) {
 	// A daily task that is also pending should appear only once
-	prev := strings.Split(`[ ] Standup [daily]`, "\n")
+	prev := strings.Split(`[ ] Standup #daily`, "\n")
 
 	result := RolloverTasks(prev)
 


### PR DESCRIPTION
## Summary

- Switch the inline daily task tag from `[daily]` to `#daily` in todo notes
- `(moved)` label is unchanged; it remains the rollover marker
- `daily` was the only `[...]`-style inline task tag; no other tag formats are affected