### PR TITLE
Add notes annotate command (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `notes annotate <ref>` command that uses Claude Code CLI to fill empty frontmatter fields (`title`, `description`, `tags`). Defaults to `claude-haiku-4-5`; override with `--model`. Non-destructive: existing field values are never overwritten. ([#N])
+- `notes annotate <ref>` command that uses Claude Code CLI to fill empty frontmatter fields (`title`, `description`, `tags`). Defaults to `claude-haiku-4-5`; override with `--model`. Non-destructive: existing field values are never overwritten. ([#109])
 
 ## [0.1.68] - 2026-04-18
 
@@ -423,4 +423,4 @@
 [#102]: https://github.com/dreikanter/notes-cli/pull/102
 [#106]: https://github.com/dreikanter/notes-cli/pull/106
 [#107]: https://github.com/dreikanter/notes-cli/pull/107
-[#N]: https://github.com/dreikanter/notes-cli/pull/N
+[#109]: https://github.com/dreikanter/notes-cli/pull/N

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.69] - 2026-04-19
+
+### Added
+
+- `notes annotate <ref>` command that uses Claude Code CLI to fill empty frontmatter fields (`title`, `description`, `tags`). Defaults to `claude-haiku-4-5`; override with `--model`. Non-destructive: existing field values are never overwritten. ([#N])
+
 ## [0.1.68] - 2026-04-18
 
 ### Changed
@@ -417,3 +423,4 @@
 [#102]: https://github.com/dreikanter/notes-cli/pull/102
 [#106]: https://github.com/dreikanter/notes-cli/pull/106
 [#107]: https://github.com/dreikanter/notes-cli/pull/107
+[#N]: https://github.com/dreikanter/notes-cli/pull/N

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ notes edit meeting
 # Fill empty frontmatter (title, description, tags) using Claude Code CLI
 notes annotate 8823
 notes annotate meeting --model claude-sonnet-4-6
+notes annotate 8823 --max-chars 4000   # truncate body before sending
 
 # Append stdin text to a note
 echo "text" | notes append 8823

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ notes read --type todo --no-frontmatter
 notes edit todo
 notes edit meeting
 
+# Fill empty frontmatter (title, description, tags) using Claude Code CLI
+notes annotate 8823
+notes annotate meeting --model claude-sonnet-4-6
+
 # Append stdin text to a note
 echo "text" | notes append 8823
 echo "text" | notes append --type todo

--- a/docs/superpowers/plans/2026-04-18-annotate-command.md
+++ b/docs/superpowers/plans/2026-04-18-annotate-command.md
@@ -1,0 +1,1229 @@
+# `notes annotate` Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `notes annotate <ref>` command that shells out to the Claude Code CLI to fill empty `title`, `description`, and `tags` fields in a note's frontmatter.
+
+**Architecture:** One new file `internal/cli/annotate.go` holds the cobra command, Claude invocation, schema builder, response parser, and merge logic. Tests in `internal/cli/annotate_test.go` use a fake `claude` shell script (pattern from `edit_test.go`) swapped in via a package-level `claudeBinary` variable. The command is non-destructive: filled fields are never touched, file is left unchanged on any error.
+
+**Tech Stack:** Go 1.x, Cobra, `os/exec` for subprocess, `encoding/json` for schema/response, Claude Code CLI as external dependency.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-annotate-command-design.md`
+
+**Issue:** [#105](https://github.com/dreikanter/notes-cli/issues/105)
+
+---
+
+## File Structure
+
+- **Create** `internal/cli/annotate.go` — command, helpers, main flow
+- **Create** `internal/cli/annotate_test.go` — all tests (pure helpers + integration via fake binary)
+- **Modify** `CHANGELOG.md` — one entry for the next patch version
+- **Modify** `README.md` — add `notes annotate` to usage section
+
+---
+
+## Task 1: Scaffold the command
+
+**Files:**
+- Create: `internal/cli/annotate.go`
+- Create: `internal/cli/annotate_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+File: `internal/cli/annotate_test.go`
+
+```go
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
+	annotateCmd.ResetFlags()
+	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"annotate", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func TestAnnotateCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"annotate"})
+	if err != nil {
+		t.Fatalf("annotate command not registered: %v", err)
+	}
+	if cmd.Use == "" || !strings.HasPrefix(cmd.Use, "annotate") {
+		t.Errorf("expected annotate Use, got %q", cmd.Use)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/ -run TestAnnotateCommandRegistered -v`
+Expected: FAIL — `annotateCmd` / `annotateDefaultModel` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+File: `internal/cli/annotate.go`
+
+```go
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+// claudeBinary is the name or absolute path of the Claude Code CLI binary.
+// Tests override this to point at a fake shell script.
+var claudeBinary = "claude"
+
+const annotateDefaultModel = "claude-haiku-4-5"
+
+var annotateCmd = &cobra.Command{
+	Use:   "annotate <id|type|query>",
+	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("not implemented")
+	},
+}
+
+func init() {
+	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+	rootCmd.AddCommand(annotateCmd)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/ -run TestAnnotateCommandRegistered -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/annotate.go internal/cli/annotate_test.go
+git commit -m "Scaffold notes annotate command"
+```
+
+---
+
+## Task 2: Probe Claude CLI JSON envelope
+
+**Files:**
+- Modify: `internal/cli/annotate.go` (add a documented envelope shape as a comment + Go struct)
+
+This is a one-time investigation. The spec requires inspecting what `claude -p --output-format json --json-schema ...` actually writes to stdout so the parser matches reality.
+
+- [ ] **Step 1: Run the probe**
+
+Run:
+```bash
+claude -p --model claude-haiku-4-5 \
+  --output-format json \
+  --json-schema '{"type":"object","properties":{"greeting":{"type":"string"}},"required":["greeting"],"additionalProperties":false}' \
+  'Output a friendly greeting as the `greeting` field.'
+```
+
+Capture the stdout verbatim. It is expected to be a JSON object; common Claude Code CLI shape has fields like `type`, `subtype`, `is_error`, `result`, `session_id`, `total_cost_usd`. When `--json-schema` is supplied, the schema-conforming object is typically either the value of `result` (as a JSON string) or an object field in the envelope.
+
+- [ ] **Step 2: Record the observed shape**
+
+Add a comment at the top of `internal/cli/annotate.go` (below the package clause), pasting a pruned copy of the real stdout and naming the field that contains the schema-validated payload:
+
+```go
+// Claude CLI envelope (observed 2026-04-18, claude-haiku-4-5,
+// --output-format json --json-schema):
+//
+//   {
+//     "type": "result",
+//     "subtype": "success",
+//     "is_error": false,
+//     "result": "{\"greeting\":\"hi\"}",   // <- schema-validated payload as a JSON string
+//     ...
+//   }
+//
+// If the observed shape differs, update annotateEnvelope and parseAnnotation below
+// and refresh the testdata in annotateSampleEnvelope.
+```
+
+**If the observed shape is different from the template above (for example, the payload is nested as an object rather than a JSON string):**
+
+- Update the `annotateEnvelope` struct defined in Task 4 to match the observed shape.
+- Update the `parseAnnotation` implementation in Task 4 to extract the payload from the correct field.
+- Update `annotateSampleEnvelope` (used by Task 4's test) so its bytes match the observed shape.
+
+Do NOT guess. Paste the real observed JSON into the comment and derive the struct from it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/annotate.go
+git commit -m "Document observed Claude CLI JSON envelope shape"
+```
+
+---
+
+## Task 3: Schema builder and empty-field detection
+
+**Files:**
+- Modify: `internal/cli/annotate.go`
+- Modify: `internal/cli/annotate_test.go`
+
+Two pure helpers:
+- `annotateEmptyFields(f) []string` — returns a stable-order list of empty field names among `{"title", "description", "tags"}`.
+- `buildAnnotateSchema(fields []string) string` — returns a JSON Schema requiring only the given fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+import (
+	// ...existing imports...
+	"encoding/json"
+
+	"github.com/dreikanter/notes-cli/note"
+)
+
+func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
+	got := annotateEmptyFields(note.FrontmatterFields{})
+	want := []string{"title", "description", "tags"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnnotateEmptyFieldsPartial(t *testing.T) {
+	f := note.FrontmatterFields{Title: "Existing"}
+	got := annotateEmptyFields(f)
+	want := []string{"description", "tags"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnnotateEmptyFieldsAllFilled(t *testing.T) {
+	f := note.FrontmatterFields{Title: "T", Description: "D", Tags: []string{"x"}}
+	got := annotateEmptyFields(f)
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestBuildAnnotateSchemaAllFields(t *testing.T) {
+	s := buildAnnotateSchema([]string{"title", "description", "tags"})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, s)
+	}
+	if parsed["type"] != "object" {
+		t.Errorf("type = %v, want object", parsed["type"])
+	}
+	if parsed["additionalProperties"] != false {
+		t.Errorf("additionalProperties = %v, want false", parsed["additionalProperties"])
+	}
+
+	req, ok := parsed["required"].([]any)
+	if !ok || len(req) != 3 {
+		t.Fatalf("required = %v, want 3 entries", parsed["required"])
+	}
+
+	props, ok := parsed["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties is not an object: %v", parsed["properties"])
+	}
+	for _, f := range []string{"title", "description", "tags"} {
+		if _, ok := props[f]; !ok {
+			t.Errorf("properties missing %q", f)
+		}
+	}
+	tags, _ := props["tags"].(map[string]any)
+	if tags["type"] != "array" {
+		t.Errorf("tags.type = %v, want array", tags["type"])
+	}
+}
+
+func TestBuildAnnotateSchemaTagsOnly(t *testing.T) {
+	s := buildAnnotateSchema([]string{"tags"})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	props, _ := parsed["properties"].(map[string]any)
+	if len(props) != 1 {
+		t.Errorf("expected 1 property, got %d: %v", len(props), props)
+	}
+	if _, ok := props["tags"]; !ok {
+		t.Errorf("missing tags property")
+	}
+}
+
+// equalStrings reports whether two string slices have the same length and elements in order.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cli/ -run "TestAnnotateEmptyFields|TestBuildAnnotateSchema" -v`
+Expected: FAIL — `annotateEmptyFields` and `buildAnnotateSchema` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/cli/annotate.go`:
+
+```go
+import (
+	// add:
+	"encoding/json"
+
+	"github.com/dreikanter/notes-cli/note"
+)
+
+// annotateEmptyFields returns the empty fields among {title, description, tags}
+// in a deterministic order. "tags" counts as empty when the slice is empty.
+func annotateEmptyFields(f note.FrontmatterFields) []string {
+	var empty []string
+	if f.Title == "" {
+		empty = append(empty, "title")
+	}
+	if f.Description == "" {
+		empty = append(empty, "description")
+	}
+	if len(f.Tags) == 0 {
+		empty = append(empty, "tags")
+	}
+	return empty
+}
+
+// buildAnnotateSchema returns a JSON Schema string requiring only the given fields.
+// Fields must be a subset of {"title", "description", "tags"}.
+func buildAnnotateSchema(fields []string) string {
+	props := map[string]any{}
+	for _, f := range fields {
+		switch f {
+		case "title", "description":
+			props[f] = map[string]string{"type": "string"}
+		case "tags":
+			props[f] = map[string]any{
+				"type":  "array",
+				"items": map[string]string{"type": "string"},
+			}
+		}
+	}
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"required":             fields,
+		"additionalProperties": false,
+	}
+	b, _ := json.Marshal(schema)
+	return string(b)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run "TestAnnotateEmptyFields|TestBuildAnnotateSchema" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/annotate.go internal/cli/annotate_test.go
+git commit -m "Add empty-field detection and schema builder for annotate"
+```
+
+---
+
+## Task 4: Response parser
+
+**Files:**
+- Modify: `internal/cli/annotate.go`
+- Modify: `internal/cli/annotate_test.go`
+
+Parses the full stdout of `claude` into an `annotateResult` struct. Use the envelope shape observed in Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+// annotateSampleEnvelope is the JSON shape observed in Task 2.
+// If the shape differs on your system, update this fixture to match.
+const annotateSampleEnvelope = `{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "result": "{\"title\":\"Weekly sync\",\"description\":\"Notes from the weekly team sync.\",\"tags\":[\"meeting\",\"weekly\"]}"
+}`
+
+func TestParseAnnotationHappyPath(t *testing.T) {
+	res, err := parseAnnotation([]byte(annotateSampleEnvelope))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Title != "Weekly sync" {
+		t.Errorf("title = %q, want %q", res.Title, "Weekly sync")
+	}
+	if res.Description != "Notes from the weekly team sync." {
+		t.Errorf("description = %q", res.Description)
+	}
+	if !equalStrings(res.Tags, []string{"meeting", "weekly"}) {
+		t.Errorf("tags = %v", res.Tags)
+	}
+}
+
+func TestParseAnnotationInvalidEnvelope(t *testing.T) {
+	_, err := parseAnnotation([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid envelope")
+	}
+}
+
+func TestParseAnnotationInvalidInnerJSON(t *testing.T) {
+	bad := `{"type":"result","subtype":"success","is_error":false,"result":"not json"}`
+	_, err := parseAnnotation([]byte(bad))
+	if err == nil {
+		t.Fatal("expected error for invalid inner JSON")
+	}
+}
+
+func TestParseAnnotationErrorFlag(t *testing.T) {
+	bad := `{"type":"result","subtype":"error","is_error":true,"result":"something broke"}`
+	_, err := parseAnnotation([]byte(bad))
+	if err == nil {
+		t.Fatal("expected error when is_error=true")
+	}
+	if !strings.Contains(err.Error(), "something broke") {
+		t.Errorf("error message should include server-side message: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cli/ -run TestParseAnnotation -v`
+Expected: FAIL — `parseAnnotation` / `annotateResult` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/cli/annotate.go`:
+
+```go
+// annotateEnvelope mirrors the outer JSON written by `claude -p --output-format json`.
+// Only the fields we rely on are declared.
+type annotateEnvelope struct {
+	IsError bool   `json:"is_error"`
+	Result  string `json:"result"`
+}
+
+// annotateResult is the schema-validated payload carried by annotateEnvelope.Result.
+type annotateResult struct {
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+// parseAnnotation unmarshals the claude CLI stdout into an annotateResult.
+func parseAnnotation(raw []byte) (annotateResult, error) {
+	var env annotateEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w", err)
+	}
+	if env.IsError {
+		return annotateResult{}, fmt.Errorf("claude returned error: %s", env.Result)
+	}
+	var res annotateResult
+	if err := json.Unmarshal([]byte(env.Result), &res); err != nil {
+		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w", err)
+	}
+	return res, nil
+}
+```
+
+Also add `"fmt"` to the imports if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run TestParseAnnotation -v`
+Expected: PASS.
+
+If any case fails because the real envelope observed in Task 2 has a different shape (e.g., the payload is a nested object, not a JSON string), adjust `annotateEnvelope`, `parseAnnotation`, and the test fixture together, then re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/annotate.go internal/cli/annotate_test.go
+git commit -m "Add claude response parser for annotate"
+```
+
+---
+
+## Task 5: Merge helper
+
+**Files:**
+- Modify: `internal/cli/annotate.go`
+- Modify: `internal/cli/annotate_test.go`
+
+Non-destructive merge: only previously-empty fields are filled from the generated result; other fields (slug, public) preserved.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+func TestMergeAnnotationFillsEmpty(t *testing.T) {
+	existing := note.FrontmatterFields{Slug: "meeting", Public: true}
+	gen := annotateResult{
+		Title:       "New",
+		Description: "Generated desc",
+		Tags:        []string{"a", "b"},
+	}
+	merged := mergeAnnotation(existing, gen)
+
+	if merged.Title != "New" {
+		t.Errorf("title = %q", merged.Title)
+	}
+	if merged.Description != "Generated desc" {
+		t.Errorf("description = %q", merged.Description)
+	}
+	if !equalStrings(merged.Tags, []string{"a", "b"}) {
+		t.Errorf("tags = %v", merged.Tags)
+	}
+	if merged.Slug != "meeting" {
+		t.Errorf("slug should be preserved, got %q", merged.Slug)
+	}
+	if !merged.Public {
+		t.Error("public should be preserved")
+	}
+}
+
+func TestMergeAnnotationPreservesFilledFields(t *testing.T) {
+	existing := note.FrontmatterFields{
+		Title:       "Existing title",
+		Description: "Existing desc",
+		Tags:        []string{"keep"},
+	}
+	gen := annotateResult{
+		Title:       "Should not win",
+		Description: "Should not win",
+		Tags:        []string{"bad"},
+	}
+	merged := mergeAnnotation(existing, gen)
+
+	if merged.Title != "Existing title" {
+		t.Errorf("title overwritten: %q", merged.Title)
+	}
+	if merged.Description != "Existing desc" {
+		t.Errorf("description overwritten: %q", merged.Description)
+	}
+	if !equalStrings(merged.Tags, []string{"keep"}) {
+		t.Errorf("tags overwritten: %v", merged.Tags)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cli/ -run TestMergeAnnotation -v`
+Expected: FAIL — `mergeAnnotation` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/cli/annotate.go`:
+
+```go
+// mergeAnnotation fills empty fields in existing from gen.
+// Non-empty fields in existing are preserved.
+func mergeAnnotation(existing note.FrontmatterFields, gen annotateResult) note.FrontmatterFields {
+	merged := existing
+	if merged.Title == "" {
+		merged.Title = gen.Title
+	}
+	if merged.Description == "" {
+		merged.Description = gen.Description
+	}
+	if len(merged.Tags) == 0 && len(gen.Tags) > 0 {
+		merged.Tags = gen.Tags
+	}
+	return merged
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run TestMergeAnnotation -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/annotate.go internal/cli/annotate_test.go
+git commit -m "Add frontmatter merge helper for annotate"
+```
+
+---
+
+## Task 6: Happy-path end-to-end with fake claude
+
+**Files:**
+- Modify: `internal/cli/annotate.go`
+- Modify: `internal/cli/annotate_test.go`
+
+Wire up the full command: read file, call `claude`, merge, rewrite. Happy-path test uses a fake `claude` shell script that echoes a canned envelope.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+import (
+	// add:
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFakeClaude writes a shell script named "claude" into a temp dir
+// that echoes the given JSON envelope to stdout. Returns the script path.
+func writeFakeClaude(t *testing.T, envelope string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	body := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\n", envelope)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+// noteWithOnlyBody writes a fresh note file in a temp root and returns the root + ref.
+// The resulting note has no frontmatter — just body text.
+func noteWithOnlyBody(t *testing.T, body string) (root, ref string) {
+	t.Helper()
+	root = t.TempDir()
+	dir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "20260418_9000.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, "9000"
+}
+
+func withClaudeBinary(t *testing.T, path string) {
+	t.Helper()
+	old := claudeBinary
+	claudeBinary = path
+	t.Cleanup(func() { claudeBinary = old })
+}
+
+func TestAnnotateFillsEmptyFields(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "# Weekly sync\n\nDiscussed Q2 roadmap, hiring, and launch dates.\n")
+	withClaudeBinary(t, writeFakeClaude(t, annotateSampleEnvelope))
+
+	out, err := runAnnotate(t, root, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/04/20260418_9000.md")
+	if out != want {
+		t.Errorf("stdout path = %q, want %q", out, want)
+	}
+
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, s := range []string{
+		"title: Weekly sync",
+		"description: Notes from the weekly team sync.",
+		"tags: [meeting, weekly]",
+	} {
+		if !strings.Contains(content, s) {
+			t.Errorf("expected %q in file, got:\n%s", s, content)
+		}
+	}
+	if !strings.Contains(content, "# Weekly sync\n\nDiscussed Q2 roadmap") {
+		t.Errorf("body missing or modified, got:\n%s", content)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/ -run TestAnnotateFillsEmptyFields -v`
+Expected: FAIL — `runAnnotate` returns `"not implemented"`.
+
+- [ ] **Step 3: Write the full command implementation**
+
+Replace the body of `annotateCmd.RunE` and add supporting functions in `internal/cli/annotate.go`. The final file (after this step) imports:
+
+```go
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/dreikanter/notes-cli/note"
+	"github.com/spf13/cobra"
+)
+```
+
+Replace the command and append new helpers:
+
+```go
+const annotateSystemPrompt = `You are annotating a personal note stored as a markdown file.
+Generate concise metadata for the provided note body, returning ONLY the fields required by the response schema.
+- title: short title, <= 8 words.
+- description: single-sentence summary, <= 140 characters.
+- tags: 1-5 lowercase single-word slugs related to the content.`
+
+var annotateCmd = &cobra.Command{
+	Use:   "annotate <id|type|query>",
+	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAnnotate,
+}
+
+func runAnnotate(cmd *cobra.Command, args []string) error {
+	model, _ := cmd.Flags().GetString("model")
+
+	root := mustNotesPath()
+	n, err := note.ResolveRef(root, args[0])
+	if err != nil {
+		return err
+	}
+
+	fullPath := filepath.Join(root, n.RelPath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return fmt.Errorf("cannot read note: %w", err)
+	}
+
+	existing := note.ParseFrontmatterFields(data)
+	body := note.StripFrontmatter(data)
+
+	empty := annotateEmptyFields(existing)
+	if len(empty) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+		return nil
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return errors.New("note has no body content to annotate")
+	}
+
+	schema := buildAnnotateSchema(empty)
+	out, err := runClaude(model, schema, string(body))
+	if err != nil {
+		return err
+	}
+
+	gen, err := parseAnnotation(out)
+	if err != nil {
+		return err
+	}
+
+	merged := mergeAnnotation(existing, gen)
+	newContent := note.BuildFrontmatter(merged) + string(body)
+
+	tmpPath := fullPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(newContent), 0o644); err != nil {
+		return fmt.Errorf("cannot write note: %w", err)
+	}
+	if err := os.Rename(tmpPath, fullPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("cannot rename note: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+	return nil
+}
+
+// runClaude executes the Claude Code CLI non-interactively and returns its stdout.
+// Returns a clear error if the binary is not found or exits non-zero.
+func runClaude(model, schema, prompt string) ([]byte, error) {
+	bin, err := exec.LookPath(claudeBinary)
+	if err != nil {
+		return nil, errors.New("claude CLI not found in PATH")
+	}
+
+	args := []string{
+		"-p",
+		"--model", model,
+		"--output-format", "json",
+		"--json-schema", schema,
+		"--append-system-prompt", annotateSystemPrompt,
+		prompt,
+	}
+
+	c := exec.Command(bin, args...)
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("claude failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/ -run TestAnnotateFillsEmptyFields -v`
+Expected: PASS.
+
+Also run the full file to confirm nothing else regressed:
+
+Run: `go test ./internal/cli/ -v`
+Expected: All previous tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/annotate.go internal/cli/annotate_test.go
+git commit -m "Implement notes annotate end-to-end"
+```
+
+---
+
+## Task 7: No-op when all fields are filled; empty body error
+
+**Files:**
+- Modify: `internal/cli/annotate_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+// noteWithFrontmatter writes a note with the given frontmatter + body and returns (root, ref).
+func noteWithFrontmatter(t *testing.T, fm, body string) (root, ref string) {
+	t.Helper()
+	root = t.TempDir()
+	dir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "20260418_9001.md")
+	if err := os.WriteFile(path, []byte(fm+body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, "9001"
+}
+
+// fakeClaudeSentinel writes a fake claude script that fails if ever invoked.
+// Used to assert the command never called claude.
+func fakeClaudeSentinel(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho SHOULD NOT BE CALLED >&2\nexit 99\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestAnnotateNoOpWhenAllFieldsFilled(t *testing.T) {
+	fm := "---\ntitle: Existing\ndescription: Already here\ntags: [x, y]\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "body content")
+	withClaudeBinary(t, fakeClaudeSentinel(t))
+
+	out, err := runAnnotate(t, root, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/04/20260418_9001.md")
+	if out != want {
+		t.Errorf("stdout = %q, want %q", out, want)
+	}
+
+	data, _ := os.ReadFile(want)
+	if string(data) != fm+"body content" {
+		t.Errorf("file modified; got:\n%s", string(data))
+	}
+}
+
+func TestAnnotateNoBodyErrors(t *testing.T) {
+	fm := "---\ntitle: only title\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "")
+	withClaudeBinary(t, fakeClaudeSentinel(t))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error for empty body")
+	}
+	if !strings.Contains(err.Error(), "no body content") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify the expected behavior**
+
+Run: `go test ./internal/cli/ -run "TestAnnotateNoOp|TestAnnotateNoBody" -v`
+Expected: PASS.
+
+If either fails, the logic in Task 6's `runAnnotate` has a bug (likely an ordering issue between the `empty == 0` check and the empty-body check). Fix in `annotate.go`; do not loosen the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/annotate_test.go
+git commit -m "Test annotate no-op and empty-body guards"
+```
+
+---
+
+## Task 8: Claude invocation error paths
+
+**Files:**
+- Modify: `internal/cli/annotate_test.go`
+
+Covers: binary not found, non-zero exit, malformed JSON. In each failure case, the file must be left untouched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+func TestAnnotateClaudeNotFound(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+	withClaudeBinary(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error when claude binary missing")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAnnotateClaudeNonZeroExit(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho bad things happened >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withClaudeBinary(t, script)
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "bad things happened") {
+		t.Errorf("stderr not surfaced: %v", err)
+	}
+
+	// File must be untouched.
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	if string(data) != "body text here" {
+		t.Errorf("file was modified: %q", string(data))
+	}
+}
+
+func TestAnnotateMalformedJSON(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+	withClaudeBinary(t, writeFakeClaude(t, `not valid json`))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "claude response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	if string(data) != "body text here" {
+		t.Errorf("file was modified: %q", string(data))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run "TestAnnotateClaude|TestAnnotateMalformedJSON" -v`
+Expected: PASS. If any fails, the bug is in `runClaude` or `parseAnnotation` (Tasks 4, 6). Fix there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/annotate_test.go
+git commit -m "Test annotate error paths (missing binary, non-zero exit, malformed JSON)"
+```
+
+---
+
+## Task 9: Flag, schema, and body-preservation tests
+
+**Files:**
+- Modify: `internal/cli/annotate.go` (introduce an args-capturing hook for testing)
+- Modify: `internal/cli/annotate_test.go`
+
+These assertions need visibility into the exact `argv` passed to `claude`. Easiest mechanism: have the fake script dump its argv to a file via an env-var-declared path, which the test reads back.
+
+- [ ] **Step 1: Add arg-dumping fake claude helper**
+
+Append to `internal/cli/annotate_test.go`:
+
+```go
+// writeFakeClaudeRecording writes a fake claude script that dumps its argv
+// one-per-line to argsPath, then echoes envelope to stdout.
+func writeFakeClaudeRecording(t *testing.T, envelope, argsPath string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	body := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do
+  printf '%%s\n' "$a" >> %q
+done
+cat <<'EOF'
+%s
+EOF
+`, argsPath, envelope)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestAnnotateModelFlagPropagates(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body for model test")
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
+
+	_, err := runAnnotate(t, root, ref, "--model", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+
+	if !containsPair(argv, "--model", "claude-sonnet-4-6") {
+		t.Errorf("expected --model claude-sonnet-4-6 in argv: %v", argv)
+	}
+}
+
+func TestAnnotateSchemaOnlyContainsEmptyFields(t *testing.T) {
+	// Start with title filled; only description + tags should be in schema.
+	fm := "---\ntitle: Fixed title\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "body for schema test")
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	// Envelope only needs to supply the two empty fields.
+	env := `{"type":"result","subtype":"success","is_error":false,"result":"{\"description\":\"d\",\"tags\":[\"t\"]}"}`
+	withClaudeBinary(t, writeFakeClaudeRecording(t, env, argsPath))
+
+	if _, err := runAnnotate(t, root, ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	schema := nextValue(argv, "--json-schema")
+	if schema == "" {
+		t.Fatalf("--json-schema missing from argv: %v", argv)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(schema), &parsed); err != nil {
+		t.Fatalf("schema is not valid JSON: %v\n%s", err, schema)
+	}
+	req, _ := parsed["required"].([]any)
+	if len(req) != 2 {
+		t.Errorf("required should have 2 entries, got %v", req)
+	}
+	for _, f := range req {
+		if f == "title" {
+			t.Errorf("title should not be required (already filled): %v", req)
+		}
+	}
+}
+
+func TestAnnotatePreservesBody(t *testing.T) {
+	body := "# heading\n\nparagraph one\n\n- list item 1\n- list item 2\n\nparagraph two with *emphasis* and `code`.\n"
+	root, ref := noteWithOnlyBody(t, body)
+	withClaudeBinary(t, writeFakeClaude(t, annotateSampleEnvelope))
+
+	if _, err := runAnnotate(t, root, ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	// After the frontmatter closing "---\n\n", body must be byte-identical.
+	idx := strings.Index(string(data), "\n---\n\n")
+	if idx < 0 {
+		t.Fatalf("could not find frontmatter terminator in:\n%s", string(data))
+	}
+	got := string(data)[idx+len("\n---\n\n"):]
+	if got != body {
+		t.Errorf("body modified.\ngot:\n%q\nwant:\n%q", got, body)
+	}
+}
+
+// containsPair reports whether argv contains flag immediately followed by value.
+func containsPair(argv []string, flag, value string) bool {
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == flag && argv[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// nextValue returns the element immediately after the first occurrence of flag, or "".
+func nextValue(argv []string, flag string) string {
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == flag {
+			return argv[i+1]
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./internal/cli/ -run "TestAnnotateModelFlag|TestAnnotateSchemaOnly|TestAnnotatePreservesBody" -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite and lint**
+
+Run: `go test ./...`
+Expected: PASS across the repository.
+
+Run: `make lint`
+Expected: No warnings.
+
+Fix any fallout inline. Common issues: unused imports, `_ = err` warnings, package comment missing on a new file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/annotate_test.go
+git commit -m "Test annotate --model flag, schema field set, and body preservation"
+```
+
+---
+
+## Task 10: Docs and changelog
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update README**
+
+Add an `annotate` example in `README.md` after the `edit` block (around the "Open a note in $EDITOR" section), matching the existing comment-then-example style:
+
+```markdown
+# Fill empty frontmatter (title, description, tags) using Claude Code CLI
+notes annotate 8823
+notes annotate meeting --model claude-sonnet-4-6
+```
+
+- [ ] **Step 2: Update CHANGELOG**
+
+Compute the next version:
+
+```bash
+git describe --tags
+```
+
+Increment the patch number (e.g., `v0.1.68` → `v0.1.69`). Find the upcoming PR number (either the one you'll create, or ask `gh` after pushing the branch).
+
+Prepend a new section at the top of `CHANGELOG.md`, immediately after the `# Changelog` heading:
+
+```markdown
+## [0.1.69] - 2026-04-18
+
+### Added
+
+- `notes annotate <ref>` command that uses Claude Code CLI to fill empty frontmatter fields (`title`, `description`, `tags`). Defaults to `claude-haiku-4-5`; override with `--model`. Non-destructive: existing field values are never overwritten. ([#N])
+```
+
+Add the PR-number link footer entry at the bottom of `CHANGELOG.md` (sorted with the other `[#…]: …` entries):
+
+```markdown
+[#N]: https://github.com/dreikanter/notes-cli/pull/N
+```
+
+Replace `N` with the actual PR number. Replace `0.1.69` if `git describe --tags` gives a different next patch version. Replace the date if today's date is different.
+
+- [ ] **Step 3: Verify build and full test suite one more time**
+
+```bash
+make build
+make test
+make lint
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "Document notes annotate command"
+```
+
+---
+
+## Post-implementation checklist (not part of TDD loop)
+
+- [ ] All tests pass: `go test ./...`
+- [ ] Lint clean: `make lint`
+- [ ] Binary builds: `make build`
+- [ ] `./notes annotate --help` shows the expected short description
+- [ ] End-to-end sanity: run `./notes annotate <some-ref>` against a real note with real `claude` in PATH; inspect the file; confirm it added only empty fields
+- [ ] CHANGELOG entry uses the version that `git describe --tags` will produce on merge
+- [ ] PR body uses `.github/pull_request_template.md`

--- a/docs/superpowers/specs/2026-04-18-annotate-command-design.md
+++ b/docs/superpowers/specs/2026-04-18-annotate-command-design.md
@@ -1,0 +1,127 @@
+# Design: `notes annotate <ref>` — AI-generated frontmatter
+
+**Issue:** #105 — Annotate a note using AI
+
+## Problem
+
+Notes are created with minimal metadata. Users want the `title`, `description`, and `tags` fields filled in without retyping them by hand. The Claude Code CLI is already installed on the developer's machine; we can shell out to it non-interactively and merge its output into the note's frontmatter.
+
+## Solution
+
+Add a new command:
+
+```
+notes annotate <ref> [--model <name>]
+```
+
+It resolves the ref (same rules as `read`/`edit`/`update`), shells out to `claude` for structured metadata, and rewrites the note's frontmatter — filling only previously-empty fields.
+
+## Behavior
+
+1. Resolve `<ref>` via `note.ResolveRef`. Read the file, parse existing frontmatter, strip the body.
+2. Compute the set of empty fields among `{title, description, tags}`. `tags` counts as empty when the slice is empty.
+3. If no fields are empty, print the note path and return (no-op).
+4. If the body is empty, return an error: `"note has no body content to annotate"`.
+5. Build a JSON schema containing only the empty fields. Invoke `claude` with the schema, the fixed instructions, and the body as the prompt.
+6. Parse the JSON response. Merge the returned values into the existing frontmatter (the non-empty fields are untouched).
+7. Rewrite the file using the same "tmp file + rename" pattern as `update.go`. The filename does not change (slug untouched).
+8. Print the note's absolute path (matches `update`).
+
+## Scope of changes
+
+Fields the command can generate: `title`, `description`, `tags`. Out of scope:
+
+- `slug` — would rename the file on disk; user decision.
+- `public` — privacy-sensitive signal; user decision.
+
+Merge policy: **non-destructive**. A field that already has a value is never touched. There is no `--overwrite` flag in v1.
+
+## Claude CLI invocation
+
+```
+claude -p --model <model> \
+  --output-format json \
+  --json-schema '<schema>' \
+  --append-system-prompt '<instructions>' \
+  '<note body>'
+```
+
+- `--model` defaults to `claude-haiku-4-5` and is overridable via the `--model` flag. No env var, no config file.
+- `--output-format json` combined with `--json-schema` forces structured output we can parse directly.
+- Schema is built at runtime from the set of empty fields:
+  ```json
+  {"type":"object","properties":{
+    "title":{"type":"string"},
+    "description":{"type":"string"},
+    "tags":{"type":"array","items":{"type":"string"}}
+  },"required":["<only empty fields>"],"additionalProperties":false}
+  ```
+  If only `tags` is empty, only `tags` appears in `properties` and `required`.
+- The system prompt instructs Claude to produce concise frontmatter metadata for a personal note and to return only the requested fields.
+- Binary resolved via `exec.LookPath("claude")`. If not found: `"claude CLI not found in PATH"`.
+- `claude -p --output-format json` emits a JSON envelope on stdout. The exact shape of that envelope must be confirmed during implementation (capture one real invocation's stdout). The command extracts the schema-validated payload from the envelope and unmarshals it into a struct with `title`, `description`, `tags`. If extraction or unmarshalling fails, the parse error surfaces clearly and the file is untouched.
+
+## Files
+
+### New: `internal/cli/annotate.go`
+
+- `annotateCmd` cobra command with `cobra.ExactArgs(1)` and `--model` flag.
+- Package-level `claudeBinary = "claude"` (string) — swappable in tests (pattern from `edit.go`).
+- Helpers:
+  - `buildAnnotateSchema(empty []string) string`
+  - `runClaude(bin, model, prompt string) ([]byte, error)` — executes and returns stdout.
+  - `parseAnnotation(raw []byte, empty []string) (note.FrontmatterFields, error)` — unmarshals the envelope, then the nested fields.
+  - `mergeAnnotation(existing note.FrontmatterFields, generated note.FrontmatterFields, empty []string) note.FrontmatterFields`
+
+The `annotate` command does not call `update.go` directly; it implements its own read/merge/write because the semantics differ (only fill empties, no filename rename, no flag parsing).
+
+### New: `internal/cli/annotate_test.go`
+
+Follow the fake-binary pattern from `edit_test.go`. A helper writes a shell script named `claude` that echoes a canned JSON response, and the test overrides `claudeBinary` to point at that script.
+
+Cases:
+
+| Test | Scenario |
+| --- | --- |
+| `TestAnnotateFillsEmptyFields` | Note has only title set; script returns description+tags; file ends up with all three. |
+| `TestAnnotateSkipsFilledFields` | Note has title+description+tags filled; command is a no-op, script is not called. |
+| `TestAnnotateNoBodyErrors` | Note has frontmatter only; command returns the "no body" error, script not invoked. |
+| `TestAnnotateClaudeNotFound` | `claudeBinary` points to a non-existent path; command returns the not-found error. |
+| `TestAnnotateClaudeNonZeroExit` | Fake script `exit 1`; command surfaces stderr. |
+| `TestAnnotateMalformedJSON` | Fake script prints invalid JSON; command errors; file untouched. |
+| `TestAnnotateSchemaContainsOnlyEmptyFields` | Inspects the args passed to the fake script; schema's `required` matches the empty set. |
+| `TestAnnotateModelFlag` | `--model foo` propagates as `--model foo` in the invocation args. |
+| `TestAnnotatePreservesBody` | Body text after frontmatter is byte-identical after rewrite. |
+
+No network calls; no real `claude` invocation.
+
+### Updated: `CHANGELOG.md`
+
+One entry for the next patch version, referencing the PR.
+
+### Updated: `README.md`
+
+Add `notes annotate <ref>` to the usage section, alongside `edit` and `update`.
+
+## Error behavior summary
+
+| Condition | Message |
+| --- | --- |
+| Ref not found | (delegated to `note.ResolveRef`) |
+| All target fields already filled | (no error; prints path; exits 0) |
+| Body empty after strip | `"note has no body content to annotate"` |
+| `claude` not on PATH | `"claude CLI not found in PATH"` |
+| `claude` returns non-zero | `"claude failed: <stderr>"` |
+| Response not valid JSON or fails schema | `"cannot parse claude response: <err>"` |
+
+In all error cases, the note file is left untouched.
+
+## Out of scope
+
+- Interactive preview or confirmation (`--dry-run`)
+- `--overwrite` flag
+- Slug or public field generation
+- Prompt customization by the user
+- `NOTES_ANNOTATE_MODEL` env var or config file
+- Streaming/progress UI
+- Batch annotation over multiple refs

--- a/docs/superpowers/specs/2026-04-18-annotate-command-design.md
+++ b/docs/superpowers/specs/2026-04-18-annotate-command-design.md
@@ -59,7 +59,7 @@ claude -p --model <model> \
   If only `tags` is empty, only `tags` appears in `properties` and `required`.
 - The system prompt instructs Claude to produce concise frontmatter metadata for a personal note and to return only the requested fields.
 - Binary resolved via `exec.LookPath("claude")`. If not found: `"claude CLI not found in PATH"`.
-- `claude -p --output-format json` emits a JSON envelope on stdout. The exact shape of that envelope must be confirmed during implementation (capture one real invocation's stdout). The command extracts the schema-validated payload from the envelope and unmarshals it into a struct with `title`, `description`, `tags`. If extraction or unmarshalling fails, the parse error surfaces clearly and the file is untouched.
+- `claude -p --output-format json` emits a JSON envelope on stdout. The exact shape of that envelope must be confirmed during implementation — run the command once by hand with a trivial schema, inspect stdout, and code the parser against the observed shape. The command extracts the schema-validated payload from the envelope and unmarshals it into a struct with `title`, `description`, `tags`. If extraction or unmarshalling fails, the parse error surfaces clearly and the file is untouched.
 
 ## Files
 

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -113,6 +113,22 @@ func parseAnnotation(raw []byte) (annotateResult, error) {
 	return res, nil
 }
 
+// mergeAnnotation fills empty fields in existing from gen.
+// Non-empty fields in existing are preserved.
+func mergeAnnotation(existing note.FrontmatterFields, gen annotateResult) note.FrontmatterFields {
+	merged := existing
+	if merged.Title == "" {
+		merged.Title = gen.Title
+	}
+	if merged.Description == "" {
+		merged.Description = gen.Description
+	}
+	if len(merged.Tags) == 0 && len(gen.Tags) > 0 {
+		merged.Tags = gen.Tags
+	}
+	return merged
+}
+
 func init() {
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	rootCmd.AddCommand(annotateCmd)

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -1,22 +1,19 @@
 package cli
 
-// Claude CLI envelope (UNVERIFIED — run-time probe blocked by sandbox,
-// shape derived from claude -p --output-format json docs):
+// Claude CLI envelope from `claude -p --output-format json --json-schema ...`:
 //
 //	{
 //	  "type": "result",
 //	  "subtype": "success",
 //	  "is_error": false,
-//	  "result": "<schema-conforming JSON string>",
+//	  "result": "<schema-conforming JSON as a string>",
 //	  "session_id": "...",
 //	  "duration_ms": 0,
 //	  "total_cost_usd": 0
 //	}
 //
-// The schema-validated payload is the result field (as a JSON string).
-// Task 4 tests must be verified against a real invocation before merging.
-// If the observed shape differs on another machine, update annotateEnvelope
-// and parseAnnotation in Task 4 accordingly.
+// parseAnnotation reads the outer envelope, then unmarshals result as a
+// nested JSON string into annotateResult.
 
 import (
 	"bytes"

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -40,7 +40,7 @@ const annotateSystemPrompt = `You are annotating a personal note stored as a mar
 Generate concise metadata for the provided note body, returning ONLY the fields required by the response schema.
 - title: short title, <= 8 words.
 - description: single-sentence summary, <= 140 characters.
-- tags: 1-5 lowercase single-word slugs related to the content.`
+- tags: 1-3 lowercase single-word slugs related to the content.`
 
 var annotateCmd = &cobra.Command{
 	Use:   "annotate <id|type|query>",
@@ -161,8 +161,9 @@ func buildAnnotateSchema(fields []string) string {
 			props[f] = map[string]string{"type": "string"}
 		case "tags":
 			props[f] = map[string]any{
-				"type":  "array",
-				"items": map[string]string{"type": "string"},
+				"type":     "array",
+				"items":    map[string]string{"type": "string"},
+				"maxItems": 3,
 			}
 		}
 	}

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -19,8 +19,10 @@ package cli
 // and parseAnnotation in Task 4 accordingly.
 
 import (
+	"encoding/json"
 	"errors"
 
+	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +39,47 @@ var annotateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return errors.New("not implemented")
 	},
+}
+
+// annotateEmptyFields returns the empty fields among {title, description, tags}
+// in a deterministic order. "tags" counts as empty when the slice is empty.
+func annotateEmptyFields(f note.FrontmatterFields) []string {
+	var empty []string
+	if f.Title == "" {
+		empty = append(empty, "title")
+	}
+	if f.Description == "" {
+		empty = append(empty, "description")
+	}
+	if len(f.Tags) == 0 {
+		empty = append(empty, "tags")
+	}
+	return empty
+}
+
+// buildAnnotateSchema returns a JSON Schema string requiring only the given fields.
+// Fields must be a subset of {"title", "description", "tags"}.
+func buildAnnotateSchema(fields []string) string {
+	props := map[string]any{}
+	for _, f := range fields {
+		switch f {
+		case "title", "description":
+			props[f] = map[string]string{"type": "string"}
+		case "tags":
+			props[f] = map[string]any{
+				"type":  "array",
+				"items": map[string]string{"type": "string"},
+			}
+		}
+	}
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"required":             fields,
+		"additionalProperties": false,
+	}
+	b, _ := json.Marshal(schema)
+	return string(b)
 }
 
 func init() {

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -51,6 +51,7 @@ var annotateCmd = &cobra.Command{
 
 func annotateRunE(cmd *cobra.Command, args []string) error {
 	model, _ := cmd.Flags().GetString("model")
+	maxChars, _ := cmd.Flags().GetInt("max-chars")
 
 	root := mustNotesPath()
 	n, err := note.ResolveRef(root, args[0])
@@ -77,8 +78,16 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("note has no body content to annotate")
 	}
 
+	prompt := string(body)
+	if maxChars > 0 {
+		if runes := []rune(prompt); len(runes) > maxChars {
+			prompt = string(runes[:maxChars])
+			fmt.Fprintf(cmd.ErrOrStderr(), "truncated note body to %d chars for annotation\n", maxChars)
+		}
+	}
+
 	schema := buildAnnotateSchema(empty)
-	out, err := runClaude(model, schema, string(body))
+	out, err := runClaude(model, schema, prompt)
 	if err != nil {
 		return err
 	}
@@ -233,5 +242,6 @@ func mergeAnnotation(existing note.FrontmatterFields, gen annotateResult) note.F
 
 func init() {
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
 	rootCmd.AddCommand(annotateCmd)
 }

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -192,14 +192,14 @@ type annotateResult struct {
 func parseAnnotation(raw []byte) (annotateResult, error) {
 	var env annotateEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
-		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w", err)
+		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w\nraw: %s", err, snippet(string(raw), 600))
 	}
 	if env.IsError {
 		return annotateResult{}, fmt.Errorf("claude returned error: %s", env.Result)
 	}
 	var res annotateResult
 	if err := json.Unmarshal([]byte(env.Result), &res); err != nil {
-		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w\npayload: %s", err, snippet(env.Result, 300))
+		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w\nresult: %s\nraw envelope: %s", err, snippet(env.Result, 300), snippet(string(raw), 1200))
 	}
 	return res, nil
 }

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -6,14 +6,16 @@ package cli
 //	  "type": "result",
 //	  "subtype": "success",
 //	  "is_error": false,
-//	  "result": "<schema-conforming JSON as a string>",
+//	  "result": "<narrative text>",
+//	  "structured_output": {<schema-conforming object>},
 //	  "session_id": "...",
 //	  "duration_ms": 0,
 //	  "total_cost_usd": 0
 //	}
 //
-// parseAnnotation reads the outer envelope, then unmarshals result as a
-// nested JSON string into annotateResult.
+// parseAnnotation reads the outer envelope and pulls the schema-validated
+// payload from structured_output. The result field holds Claude's narrative
+// response and is used only to surface error messages when is_error is true.
 
 import (
 	"bytes"
@@ -177,11 +179,12 @@ func buildAnnotateSchema(fields []string) string {
 // annotateEnvelope mirrors the outer JSON written by `claude -p --output-format json`.
 // Only the fields we rely on are declared.
 type annotateEnvelope struct {
-	IsError bool   `json:"is_error"`
-	Result  string `json:"result"`
+	IsError          bool            `json:"is_error"`
+	Result           string          `json:"result"`
+	StructuredOutput *annotateResult `json:"structured_output"`
 }
 
-// annotateResult is the schema-validated payload carried by annotateEnvelope.Result.
+// annotateResult is the schema-validated payload carried by annotateEnvelope.StructuredOutput.
 type annotateResult struct {
 	Title       string   `json:"title,omitempty"`
 	Description string   `json:"description,omitempty"`
@@ -192,16 +195,15 @@ type annotateResult struct {
 func parseAnnotation(raw []byte) (annotateResult, error) {
 	var env annotateEnvelope
 	if err := json.Unmarshal(raw, &env); err != nil {
-		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w\nraw: %s", err, snippet(string(raw), 600))
+		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w", err)
 	}
 	if env.IsError {
 		return annotateResult{}, fmt.Errorf("claude returned error: %s", env.Result)
 	}
-	var res annotateResult
-	if err := json.Unmarshal([]byte(env.Result), &res); err != nil {
-		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w\nresult: %s\nraw envelope: %s", err, snippet(env.Result, 300), snippet(string(raw), 1200))
+	if env.StructuredOutput == nil {
+		return annotateResult{}, fmt.Errorf("claude response missing structured_output; got result: %s", snippet(env.Result, 200))
 	}
-	return res, nil
+	return *env.StructuredOutput, nil
 }
 
 // snippet returns up to n bytes of s, with "..." appended when truncated.

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -1,5 +1,23 @@
 package cli
 
+// Claude CLI envelope (UNVERIFIED — run-time probe blocked by sandbox,
+// shape derived from claude -p --output-format json docs):
+//
+//	{
+//	  "type": "result",
+//	  "subtype": "success",
+//	  "is_error": false,
+//	  "result": "<schema-conforming JSON string>",
+//	  "session_id": "...",
+//	  "duration_ms": 0,
+//	  "total_cost_usd": 0
+//	}
+//
+// The schema-validated payload is the result field (as a JSON string).
+// Task 4 tests must be verified against a real invocation before merging.
+// If the observed shape differs on another machine, update annotateEnvelope
+// and parseAnnotation in Task 4 accordingly.
+
 import (
 	"errors"
 

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -19,9 +19,13 @@ package cli
 // and parseAnnotation in Task 4 accordingly.
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
@@ -33,13 +37,103 @@ var claudeBinary = "claude"
 
 const annotateDefaultModel = "claude-haiku-4-5"
 
+const annotateSystemPrompt = `You are annotating a personal note stored as a markdown file.
+Generate concise metadata for the provided note body, returning ONLY the fields required by the response schema.
+- title: short title, <= 8 words.
+- description: single-sentence summary, <= 140 characters.
+- tags: 1-5 lowercase single-word slugs related to the content.`
+
 var annotateCmd = &cobra.Command{
 	Use:   "annotate <id|type|query>",
 	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return errors.New("not implemented")
-	},
+	RunE:  annotateRunE,
+}
+
+func annotateRunE(cmd *cobra.Command, args []string) error {
+	model, _ := cmd.Flags().GetString("model")
+
+	root := mustNotesPath()
+	n, err := note.ResolveRef(root, args[0])
+	if err != nil {
+		return err
+	}
+
+	fullPath := filepath.Join(root, n.RelPath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return fmt.Errorf("cannot read note: %w", err)
+	}
+
+	existing := note.ParseFrontmatterFields(data)
+	body := note.StripFrontmatter(data)
+
+	empty := annotateEmptyFields(existing)
+	if len(empty) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+		return nil
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return errors.New("note has no body content to annotate")
+	}
+
+	schema := buildAnnotateSchema(empty)
+	out, err := runClaude(model, schema, string(body))
+	if err != nil {
+		return err
+	}
+
+	gen, err := parseAnnotation(out)
+	if err != nil {
+		return err
+	}
+
+	merged := mergeAnnotation(existing, gen)
+	newContent := note.BuildFrontmatter(merged) + string(body)
+
+	tmpPath := fullPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(newContent), 0o644); err != nil {
+		return fmt.Errorf("cannot write note: %w", err)
+	}
+	if err := os.Rename(tmpPath, fullPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("cannot rename note: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+	return nil
+}
+
+// runClaude executes the Claude Code CLI non-interactively and returns its stdout.
+// Returns a clear error if the binary is not found or exits non-zero.
+func runClaude(model, schema, prompt string) ([]byte, error) {
+	bin, err := exec.LookPath(claudeBinary)
+	if err != nil {
+		return nil, errors.New("claude CLI not found in PATH")
+	}
+
+	args := []string{
+		"-p",
+		"--model", model,
+		"--output-format", "json",
+		"--json-schema", schema,
+		"--append-system-prompt", annotateSystemPrompt,
+		prompt,
+	}
+
+	c := exec.Command(bin, args...)
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("claude failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
 }
 
 // annotateEmptyFields returns the empty fields among {title, description, tags}

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -199,9 +199,17 @@ func parseAnnotation(raw []byte) (annotateResult, error) {
 	}
 	var res annotateResult
 	if err := json.Unmarshal([]byte(env.Result), &res); err != nil {
-		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w", err)
+		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w\npayload: %s", err, snippet(env.Result, 300))
 	}
 	return res, nil
+}
+
+// snippet returns up to n bytes of s, with "..." appended when truncated.
+func snippet(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 // mergeAnnotation fills empty fields in existing from gen.

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+// claudeBinary is the name or absolute path of the Claude Code CLI binary.
+// Tests override this to point at a fake shell script.
+var claudeBinary = "claude"
+
+const annotateDefaultModel = "claude-haiku-4-5"
+
+var annotateCmd = &cobra.Command{
+	Use:   "annotate <id|type|query>",
+	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.New("not implemented")
+	},
+}
+
+func init() {
+	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+	rootCmd.AddCommand(annotateCmd)
+}

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
@@ -80,6 +81,36 @@ func buildAnnotateSchema(fields []string) string {
 	}
 	b, _ := json.Marshal(schema)
 	return string(b)
+}
+
+// annotateEnvelope mirrors the outer JSON written by `claude -p --output-format json`.
+// Only the fields we rely on are declared.
+type annotateEnvelope struct {
+	IsError bool   `json:"is_error"`
+	Result  string `json:"result"`
+}
+
+// annotateResult is the schema-validated payload carried by annotateEnvelope.Result.
+type annotateResult struct {
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+// parseAnnotation unmarshals the claude CLI stdout into an annotateResult.
+func parseAnnotation(raw []byte) (annotateResult, error) {
+	var env annotateEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return annotateResult{}, fmt.Errorf("cannot parse claude response: %w", err)
+	}
+	if env.IsError {
+		return annotateResult{}, fmt.Errorf("claude returned error: %s", env.Result)
+	}
+	var res annotateResult
+	if err := json.Unmarshal([]byte(env.Result), &res); err != nil {
+		return annotateResult{}, fmt.Errorf("cannot parse claude response payload: %w", err)
+	}
+	return res, nil
 }
 
 func init() {

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -174,3 +174,53 @@ func TestParseAnnotationErrorFlag(t *testing.T) {
 		t.Errorf("error message should include server-side message: %v", err)
 	}
 }
+
+func TestMergeAnnotationFillsEmpty(t *testing.T) {
+	existing := note.FrontmatterFields{Slug: "meeting", Public: true}
+	gen := annotateResult{
+		Title:       "New",
+		Description: "Generated desc",
+		Tags:        []string{"a", "b"},
+	}
+	merged := mergeAnnotation(existing, gen)
+
+	if merged.Title != "New" {
+		t.Errorf("title = %q", merged.Title)
+	}
+	if merged.Description != "Generated desc" {
+		t.Errorf("description = %q", merged.Description)
+	}
+	if !equalStrings(merged.Tags, []string{"a", "b"}) {
+		t.Errorf("tags = %v", merged.Tags)
+	}
+	if merged.Slug != "meeting" {
+		t.Errorf("slug should be preserved, got %q", merged.Slug)
+	}
+	if !merged.Public {
+		t.Error("public should be preserved")
+	}
+}
+
+func TestMergeAnnotationPreservesFilledFields(t *testing.T) {
+	existing := note.FrontmatterFields{
+		Title:       "Existing title",
+		Description: "Existing desc",
+		Tags:        []string{"keep"},
+	}
+	gen := annotateResult{
+		Title:       "Should not win",
+		Description: "Should not win",
+		Tags:        []string{"bad"},
+	}
+	merged := mergeAnnotation(existing, gen)
+
+	if merged.Title != "Existing title" {
+		t.Errorf("title overwritten: %q", merged.Title)
+	}
+	if merged.Description != "Existing desc" {
+		t.Errorf("description overwritten: %q", merged.Description)
+	}
+	if !equalStrings(merged.Tags, []string{"keep"}) {
+		t.Errorf("tags overwritten: %v", merged.Tags)
+	}
+}

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/dreikanter/notes-cli/note"
 )
 
 func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
@@ -19,6 +22,93 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 
 	err := rootCmd.Execute()
 	return strings.TrimSpace(buf.String()), err
+}
+
+func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
+	got := annotateEmptyFields(note.FrontmatterFields{})
+	want := []string{"title", "description", "tags"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnnotateEmptyFieldsPartial(t *testing.T) {
+	f := note.FrontmatterFields{Title: "Existing"}
+	got := annotateEmptyFields(f)
+	want := []string{"description", "tags"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestAnnotateEmptyFieldsAllFilled(t *testing.T) {
+	f := note.FrontmatterFields{Title: "T", Description: "D", Tags: []string{"x"}}
+	got := annotateEmptyFields(f)
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestBuildAnnotateSchemaAllFields(t *testing.T) {
+	s := buildAnnotateSchema([]string{"title", "description", "tags"})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, s)
+	}
+	if parsed["type"] != "object" {
+		t.Errorf("type = %v, want object", parsed["type"])
+	}
+	if parsed["additionalProperties"] != false {
+		t.Errorf("additionalProperties = %v, want false", parsed["additionalProperties"])
+	}
+
+	req, ok := parsed["required"].([]any)
+	if !ok || len(req) != 3 {
+		t.Fatalf("required = %v, want 3 entries", parsed["required"])
+	}
+
+	props, ok := parsed["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties is not an object: %v", parsed["properties"])
+	}
+	for _, f := range []string{"title", "description", "tags"} {
+		if _, ok := props[f]; !ok {
+			t.Errorf("properties missing %q", f)
+		}
+	}
+	tags, _ := props["tags"].(map[string]any)
+	if tags["type"] != "array" {
+		t.Errorf("tags.type = %v, want array", tags["type"])
+	}
+}
+
+func TestBuildAnnotateSchemaTagsOnly(t *testing.T) {
+	s := buildAnnotateSchema([]string{"tags"})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	props, _ := parsed["properties"].(map[string]any)
+	if len(props) != 1 {
+		t.Errorf("expected 1 property, got %d: %v", len(props), props)
+	}
+	if _, ok := props["tags"]; !ok {
+		t.Errorf("missing tags property")
+	}
+}
+
+// equalStrings reports whether two string slices have the same length and elements in order.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestAnnotateCommandRegistered(t *testing.T) {

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -414,3 +414,123 @@ func TestAnnotateMalformedJSON(t *testing.T) {
 		t.Errorf("file was modified: %q", string(data))
 	}
 }
+
+// writeFakeClaudeRecording writes a fake claude script that dumps its argv
+// one-per-line to argsPath, then echoes envelope to stdout.
+func writeFakeClaudeRecording(t *testing.T, envelope, argsPath string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	body := fmt.Sprintf(`#!/bin/sh
+for a in "$@"; do
+  printf '%%s\n' "$a" >> %q
+done
+cat <<'EOF'
+%s
+EOF
+`, argsPath, envelope)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestAnnotateModelFlagPropagates(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body for model test")
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
+
+	_, err := runAnnotate(t, root, ref, "--model", "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+
+	if !containsPair(argv, "--model", "claude-sonnet-4-6") {
+		t.Errorf("expected --model claude-sonnet-4-6 in argv: %v", argv)
+	}
+}
+
+func TestAnnotateSchemaOnlyContainsEmptyFields(t *testing.T) {
+	// Start with title filled; only description + tags should be in schema.
+	fm := "---\ntitle: Fixed title\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "body for schema test")
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	// Envelope only needs to supply the two empty fields.
+	env := `{"type":"result","subtype":"success","is_error":false,"result":"{\"description\":\"d\",\"tags\":[\"t\"]}"}`
+	withClaudeBinary(t, writeFakeClaudeRecording(t, env, argsPath))
+
+	if _, err := runAnnotate(t, root, ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	schema := nextValue(argv, "--json-schema")
+	if schema == "" {
+		t.Fatalf("--json-schema missing from argv: %v", argv)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(schema), &parsed); err != nil {
+		t.Fatalf("schema is not valid JSON: %v\n%s", err, schema)
+	}
+	req, _ := parsed["required"].([]any)
+	if len(req) != 2 {
+		t.Errorf("required should have 2 entries, got %v", req)
+	}
+	for _, f := range req {
+		if f == "title" {
+			t.Errorf("title should not be required (already filled): %v", req)
+		}
+	}
+}
+
+func TestAnnotatePreservesBody(t *testing.T) {
+	body := "# heading\n\nparagraph one\n\n- list item 1\n- list item 2\n\nparagraph two with *emphasis* and `code`.\n"
+	root, ref := noteWithOnlyBody(t, body)
+	withClaudeBinary(t, writeFakeClaude(t, annotateSampleEnvelope))
+
+	if _, err := runAnnotate(t, root, ref); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	// After the frontmatter closing "---\n\n", body must be byte-identical.
+	idx := strings.Index(string(data), "\n---\n\n")
+	if idx < 0 {
+		t.Fatalf("could not find frontmatter terminator in:\n%s", string(data))
+	}
+	got := string(data)[idx+len("\n---\n\n"):]
+	if got != body {
+		t.Errorf("body modified.\ngot:\n%q\nwant:\n%q", got, body)
+	}
+}
+
+// containsPair reports whether argv contains flag immediately followed by value.
+func containsPair(argv []string, flag, value string) bool {
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == flag && argv[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// nextValue returns the element immediately after the first occurrence of flag, or "".
+func nextValue(argv []string, flag string) string {
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == flag {
+			return argv[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -17,6 +17,7 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 
 	annotateCmd.ResetFlags()
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -513,6 +514,51 @@ func TestAnnotatePreservesBody(t *testing.T) {
 	got := string(data)[idx+len("\n---\n\n"):]
 	if got != body {
 		t.Errorf("body modified.\ngot:\n%q\nwant:\n%q", got, body)
+	}
+}
+
+func TestAnnotateMaxCharsTruncates(t *testing.T) {
+	body := strings.Repeat("a", 5000)
+	root, ref := noteWithOnlyBody(t, body)
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
+
+	_, err := runAnnotate(t, root, ref, "--max-chars", "100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	// The body is the final positional argv entry.
+	sentBody := argv[len(argv)-1]
+	if len(sentBody) != 100 {
+		t.Errorf("expected body truncated to 100 chars, got %d: %q", len(sentBody), sentBody)
+	}
+}
+
+func TestAnnotateMaxCharsZeroLeavesBodyUntouched(t *testing.T) {
+	body := strings.Repeat("a", 5000)
+	root, ref := noteWithOnlyBody(t, body)
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
+
+	_, err := runAnnotate(t, root, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	sentBody := argv[len(argv)-1]
+	if len(sentBody) != len(body) {
+		t.Errorf("expected full body (%d chars) sent, got %d", len(body), len(sentBody))
 	}
 }
 

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -124,11 +124,8 @@ func TestAnnotateCommandRegistered(t *testing.T) {
 	}
 }
 
-// annotateSampleEnvelope is the JSON shape observed in Task 2.
-// NOTE: Task 2 could not run the live probe (sandbox-blocked); this fixture
-// is based on the documented claude -p --output-format json shape. If the
-// actual CLI shape differs, adjust this fixture AND the annotateEnvelope /
-// parseAnnotation implementation together.
+// annotateSampleEnvelope mirrors the stdout of
+// `claude -p --output-format json --json-schema ...`.
 const annotateSampleEnvelope = `{
   "type": "result",
   "subtype": "success",

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -222,5 +225,74 @@ func TestMergeAnnotationPreservesFilledFields(t *testing.T) {
 	}
 	if !equalStrings(merged.Tags, []string{"keep"}) {
 		t.Errorf("tags overwritten: %v", merged.Tags)
+	}
+}
+
+// writeFakeClaude writes a shell script named "claude" into a temp dir
+// that echoes the given JSON envelope to stdout. Returns the script path.
+func writeFakeClaude(t *testing.T, envelope string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	body := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\n", envelope)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+// noteWithOnlyBody writes a fresh note file in a temp root and returns the root + ref.
+// The resulting note has no frontmatter — just body text.
+func noteWithOnlyBody(t *testing.T, body string) (root, ref string) {
+	t.Helper()
+	root = t.TempDir()
+	dir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "20260418_9000.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, "9000"
+}
+
+func withClaudeBinary(t *testing.T, path string) {
+	t.Helper()
+	old := claudeBinary
+	claudeBinary = path
+	t.Cleanup(func() { claudeBinary = old })
+}
+
+func TestAnnotateFillsEmptyFields(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "# Weekly sync\n\nDiscussed Q2 roadmap, hiring, and launch dates.\n")
+	withClaudeBinary(t, writeFakeClaude(t, annotateSampleEnvelope))
+
+	out, err := runAnnotate(t, root, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/04/20260418_9000.md")
+	if out != want {
+		t.Errorf("stdout path = %q, want %q", out, want)
+	}
+
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, s := range []string{
+		"title: Weekly sync",
+		"description: Notes from the weekly team sync.",
+		"tags: [meeting, weekly]",
+	} {
+		if !strings.Contains(content, s) {
+			t.Errorf("expected %q in file, got:\n%s", s, content)
+		}
+	}
+	if !strings.Contains(content, "# Weekly sync\n\nDiscussed Q2 roadmap") {
+		t.Errorf("body missing or modified, got:\n%s", content)
 	}
 }

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -130,7 +130,8 @@ const annotateSampleEnvelope = `{
   "type": "result",
   "subtype": "success",
   "is_error": false,
-  "result": "{\"title\":\"Weekly sync\",\"description\":\"Notes from the weekly team sync.\",\"tags\":[\"meeting\",\"weekly\"]}"
+  "result": "Metadata generated.",
+  "structured_output": {"title": "Weekly sync", "description": "Notes from the weekly team sync.", "tags": ["meeting", "weekly"]}
 }`
 
 func TestParseAnnotationHappyPath(t *testing.T) {
@@ -156,11 +157,14 @@ func TestParseAnnotationInvalidEnvelope(t *testing.T) {
 	}
 }
 
-func TestParseAnnotationInvalidInnerJSON(t *testing.T) {
-	bad := `{"type":"result","subtype":"success","is_error":false,"result":"not json"}`
+func TestParseAnnotationMissingStructuredOutput(t *testing.T) {
+	bad := `{"type":"result","subtype":"success","is_error":false,"result":"Metadata generated."}`
 	_, err := parseAnnotation([]byte(bad))
 	if err == nil {
-		t.Fatal("expected error for invalid inner JSON")
+		t.Fatal("expected error when structured_output is absent")
+	}
+	if !strings.Contains(err.Error(), "structured_output") {
+		t.Errorf("error should name structured_output: %v", err)
 	}
 }
 
@@ -459,7 +463,7 @@ func TestAnnotateSchemaOnlyContainsEmptyFields(t *testing.T) {
 	root, ref := noteWithFrontmatter(t, fm, "body for schema test")
 	argsPath := filepath.Join(t.TempDir(), "args.txt")
 	// Envelope only needs to supply the two empty fields.
-	env := `{"type":"result","subtype":"success","is_error":false,"result":"{\"description\":\"d\",\"tags\":[\"t\"]}"}`
+	env := `{"type":"result","subtype":"success","is_error":false,"result":"ok","structured_output":{"description":"d","tags":["t"]}}`
 	withClaudeBinary(t, writeFakeClaudeRecording(t, env, argsPath))
 
 	if _, err := runAnnotate(t, root, ref); err != nil {

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -358,3 +358,59 @@ func TestAnnotateNoBodyErrors(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestAnnotateClaudeNotFound(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+	withClaudeBinary(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error when claude binary missing")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAnnotateClaudeNonZeroExit(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho bad things happened >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withClaudeBinary(t, script)
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "bad things happened") {
+		t.Errorf("stderr not surfaced: %v", err)
+	}
+
+	// File must be untouched.
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	if string(data) != "body text here" {
+		t.Errorf("file was modified: %q", string(data))
+	}
+}
+
+func TestAnnotateMalformedJSON(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+	withClaudeBinary(t, writeFakeClaude(t, `not valid json`))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "claude response") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
+	if string(data) != "body text here" {
+		t.Errorf("file was modified: %q", string(data))
+	}
+}

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
+	annotateCmd.ResetFlags()
+	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"annotate", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func TestAnnotateCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"annotate"})
+	if err != nil {
+		t.Fatalf("annotate command not registered: %v", err)
+	}
+	if cmd.Use == "" || !strings.HasPrefix(cmd.Use, "annotate") {
+		t.Errorf("expected annotate Use, got %q", cmd.Use)
+	}
+}

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -120,3 +120,57 @@ func TestAnnotateCommandRegistered(t *testing.T) {
 		t.Errorf("expected annotate Use, got %q", cmd.Use)
 	}
 }
+
+// annotateSampleEnvelope is the JSON shape observed in Task 2.
+// NOTE: Task 2 could not run the live probe (sandbox-blocked); this fixture
+// is based on the documented claude -p --output-format json shape. If the
+// actual CLI shape differs, adjust this fixture AND the annotateEnvelope /
+// parseAnnotation implementation together.
+const annotateSampleEnvelope = `{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "result": "{\"title\":\"Weekly sync\",\"description\":\"Notes from the weekly team sync.\",\"tags\":[\"meeting\",\"weekly\"]}"
+}`
+
+func TestParseAnnotationHappyPath(t *testing.T) {
+	res, err := parseAnnotation([]byte(annotateSampleEnvelope))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Title != "Weekly sync" {
+		t.Errorf("title = %q, want %q", res.Title, "Weekly sync")
+	}
+	if res.Description != "Notes from the weekly team sync." {
+		t.Errorf("description = %q", res.Description)
+	}
+	if !equalStrings(res.Tags, []string{"meeting", "weekly"}) {
+		t.Errorf("tags = %v", res.Tags)
+	}
+}
+
+func TestParseAnnotationInvalidEnvelope(t *testing.T) {
+	_, err := parseAnnotation([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid envelope")
+	}
+}
+
+func TestParseAnnotationInvalidInnerJSON(t *testing.T) {
+	bad := `{"type":"result","subtype":"success","is_error":false,"result":"not json"}`
+	_, err := parseAnnotation([]byte(bad))
+	if err == nil {
+		t.Fatal("expected error for invalid inner JSON")
+	}
+}
+
+func TestParseAnnotationErrorFlag(t *testing.T) {
+	bad := `{"type":"result","subtype":"error","is_error":true,"result":"something broke"}`
+	_, err := parseAnnotation([]byte(bad))
+	if err == nil {
+		t.Fatal("expected error when is_error=true")
+	}
+	if !strings.Contains(err.Error(), "something broke") {
+		t.Errorf("error message should include server-side message: %v", err)
+	}
+}

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -296,3 +296,65 @@ func TestAnnotateFillsEmptyFields(t *testing.T) {
 		t.Errorf("body missing or modified, got:\n%s", content)
 	}
 }
+
+// noteWithFrontmatter writes a note with the given frontmatter + body and returns (root, ref).
+func noteWithFrontmatter(t *testing.T, fm, body string) (root, ref string) {
+	t.Helper()
+	root = t.TempDir()
+	dir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "20260418_9001.md")
+	if err := os.WriteFile(path, []byte(fm+body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root, "9001"
+}
+
+// fakeClaudeSentinel writes a fake claude script that fails if ever invoked.
+// Used to assert the command never called claude.
+func fakeClaudeSentinel(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho SHOULD NOT BE CALLED >&2\nexit 99\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestAnnotateNoOpWhenAllFieldsFilled(t *testing.T) {
+	fm := "---\ntitle: Existing\ndescription: Already here\ntags: [x, y]\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "body content")
+	withClaudeBinary(t, fakeClaudeSentinel(t))
+
+	out, err := runAnnotate(t, root, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/04/20260418_9001.md")
+	if out != want {
+		t.Errorf("stdout = %q, want %q", out, want)
+	}
+
+	data, _ := os.ReadFile(want)
+	if string(data) != fm+"body content" {
+		t.Errorf("file modified; got:\n%s", string(data))
+	}
+}
+
+func TestAnnotateNoBodyErrors(t *testing.T) {
+	fm := "---\ntitle: only title\n---\n\n"
+	root, ref := noteWithFrontmatter(t, fm, "")
+	withClaudeBinary(t, fakeClaudeSentinel(t))
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error for empty body")
+	}
+	if !strings.Contains(err.Error(), "no body content") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `notes annotate <ref>` — fills empty `title`, `description`, and `tags` frontmatter by shelling out to the Claude Code CLI (`-p --output-format json --json-schema ...`). Non-destructive: already-filled fields are never overwritten.
- `--model <name>` overrides the default (`claude-haiku-4-5`).
- `--max-chars N` truncates the note body before sending (default `0` = no limit). Emits a one-line stderr notice when truncation bites.
- Tags capped at 3 in both the schema (`maxItems: 3`) and the system prompt.
- File is rewritten in-place via tmp+rename (same pattern as `notes update`); body bytes are preserved.

## References

- closes #105

## Test plan

- [x] `go test ./...` passes (18 new annotate tests)
- [x] `make lint` clean
- [x] Envelope verified against a live `claude -p` invocation; schema-validated payload lives in the envelope's `structured_output` field (`result` holds Claude's narrative text)
- [x] Manual E2E: ran `./notes annotate 9663` on a real note; frontmatter populated with title/description/tags, body preserved byte-identical