### PR TITLE
Refactor frontmatter API: ParseNote/FormatNote with real errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Changed
 
-- Replace `ParseFrontmatterFields` / `BuildFrontmatter` trio with error-returning `ParseNote` / `FormatNote` pair; rename `FrontmatterFields` → `Frontmatter` with `IsZero`. Single-note writers (`update`, `annotate`) now surface frontmatter parse errors; bulk readers (`FilterByTags`, `ExtractTags`) log per-note warnings and continue. Body is returned as a sub-slice of the input (no copy), and CRLF interior bytes round-trip through parsing. `ExtractTags` concurrency now uses `errgroup` ([#112])
+- `notes update` and `notes annotate` now fail with a clear error when the target note has malformed frontmatter, instead of silently dropping bad fields and rewriting the file ([#112])
+- `notes ls --tag` and `notes tags` log a per-note warning to stderr for any note with unparseable frontmatter and skip it, instead of silently treating it as tagless ([#112])
+- Stricter frontmatter parsing: duplicate keys, non-mapping top-level documents, control characters, and type mismatches are now rejected at the document level; previously the parser preserved siblings of a bad field ([#112])
+- CRLF line endings inside the note body are now preserved verbatim through read/write round-trips ([#112])
 
 ## [0.1.71] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.72] - 2026-04-19
+
+### Changed
+
+- Replace `ParseFrontmatterFields` / `BuildFrontmatter` trio with error-returning `ParseNote` / `FormatNote` pair; rename `FrontmatterFields` → `Frontmatter` with `IsZero`. Single-note writers (`update`, `annotate`) now surface frontmatter parse errors; bulk readers (`FilterByTags`, `ExtractTags`) log per-note warnings and continue. Body is returned as a sub-slice of the input (no copy), and CRLF interior bytes round-trip through parsing. `ExtractTags` concurrency now uses `errgroup` ([#112])
+
 ## [0.1.71] - 2026-04-19
 
 ### Changed
@@ -441,3 +447,4 @@
 [#108]: https://github.com/dreikanter/notes-cli/pull/108
 [#109]: https://github.com/dreikanter/notes-cli/pull/109
 [#110]: https://github.com/dreikanter/notes-cli/issues/110
+[#112]: https://github.com/dreikanter/notes-cli/issues/112

--- a/docs/superpowers/plans/2026-04-19-frontmatter-refactor.md
+++ b/docs/superpowers/plans/2026-04-19-frontmatter-refactor.md
@@ -1,0 +1,1097 @@
+# Frontmatter API Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ParseFrontmatterFields` / `BuildFrontmatter` / `StripFrontmatter` trio with an error-returning `ParseNote` / `FormatNote` pair, rename `FrontmatterFields` → `Frontmatter`, add `Frontmatter.IsZero`, collapse call-site boilerplate, and clean up adjacent code (`ExtractTags` concurrency, CRLF handling, `frontmatterDelim` constness).
+
+**Architecture:** The `note` package gains a focused `ParseNote(data) (Frontmatter, body, error)` primitive built on `yaml.Unmarshal` into the struct directly (no field switch, no per-field tolerance). `FormatNote(f, body) []byte` pairs it. Bulk readers (`FilterByTags`, `ExtractTags`) log warn-and-continue via `log.Printf` on a note-level parse error; single-note writers (`update`, `annotate`) surface the error. `StripFrontmatter` is kept for `read -F` (body-only, no parse needed). The existing `findFrontmatterBlock` is replaced by an offset-returning helper that slices `data` directly, preserving CRLF interior bytes. `ExtractTags` is rewritten using `golang.org/x/sync/errgroup`.
+
+**Tech Stack:** Go 1.25, `gopkg.in/yaml.v3`, `golang.org/x/sync/errgroup` (already in indirect deps — needs to become direct), `log` (stdlib).
+
+---
+
+## File Structure
+
+- `note/frontmatter.go` — full rewrite: `Frontmatter`, `IsZero`, `ParseNote`, `FormatNote`, `StripFrontmatter`, internal `frontmatterEnd`.
+- `note/frontmatter_test.go` — consolidated table tests; one byte-exact snapshot; round-trip tests; CRLF coverage; adversarial kept.
+- `note/store.go` — `FilterByTags` switches to `ParseNote`, logs warn on per-note parse error, continues.
+- `note/tags.go` — `ExtractTags` rewritten using `errgroup`; switches to `ParseNote`, logs warn on per-note parse error, continues.
+- `internal/cli/update.go` — call-site collapsed to `ParseNote` / `FormatNote`; surfaces parse error.
+- `internal/cli/annotate.go` — same collapse; surfaces parse error; `annotateEmptyFields` and `mergeAnnotation` take `note.Frontmatter`.
+- `internal/cli/create.go` — `createNote` uses `FormatNote` directly.
+- `internal/cli/read.go` — unchanged; still uses `StripFrontmatter`.
+- `internal/cli/annotate_test.go` — `FrontmatterFields` → `Frontmatter`.
+- `CHANGELOG.md` — entry for v0.1.72.
+- `go.mod` — promote `golang.org/x/sync` to a direct require.
+
+---
+
+## Proposed Public API
+
+```go
+// Frontmatter holds optional fields for note frontmatter.
+type Frontmatter struct {
+    Title       string   `yaml:"title,omitempty"`
+    Slug        string   `yaml:"slug,omitempty"`
+    Tags        []string `yaml:"tags,omitempty"`
+    Description string   `yaml:"description,omitempty"`
+    Public      bool     `yaml:"public,omitempty"`
+}
+
+// IsZero reports whether f has no fields set.
+func (f Frontmatter) IsZero() bool {
+    return reflect.ValueOf(f).IsZero()
+}
+
+// ParseNote splits a note file into its frontmatter and body.
+func ParseNote(data []byte) (Frontmatter, []byte, error)
+
+// FormatNote serialises frontmatter followed by body.
+func FormatNote(f Frontmatter, body []byte) []byte
+
+// StripFrontmatter returns the body portion only; used by `read -F`.
+func StripFrontmatter(data []byte) []byte
+```
+
+Semantics:
+- `ParseNote` returns `(zero, data, nil)` when no frontmatter block is present.
+- `ParseNote` returns `(zero, nil, err)` when a frontmatter block is present but malformed (delimiter pair mismatch, non-mapping document, yaml-unmarshal error, type mismatch).
+- `FormatNote` emits `"---\n<yaml>---\n\n" + body` when `!f.IsZero()`, else just `body`.
+- `StripFrontmatter` keeps its existing contract: if no valid frontmatter block, returns `data`; else returns `data[bodyStart:]`.
+
+---
+
+## Task 1: New frontmatter.go API with failing tests first
+
+**Files:**
+- Modify: `note/frontmatter.go`
+- Modify: `note/frontmatter_test.go`
+
+- [ ] **Step 1: Write failing tests for `Frontmatter.IsZero`**
+
+Append to `note/frontmatter_test.go`:
+
+```go
+func TestFrontmatterIsZero(t *testing.T) {
+    tests := []struct {
+        name string
+        f    Frontmatter
+        want bool
+    }{
+        {"empty", Frontmatter{}, true},
+        {"title set", Frontmatter{Title: "T"}, false},
+        {"slug set", Frontmatter{Slug: "s"}, false},
+        {"tags empty slice counts as zero", Frontmatter{Tags: []string{}}, false},
+        {"tags with value", Frontmatter{Tags: []string{"a"}}, false},
+        {"description set", Frontmatter{Description: "d"}, false},
+        {"public true", Frontmatter{Public: true}, false},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if got := tt.f.IsZero(); got != tt.want {
+                t.Errorf("IsZero() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+Note: `reflect.ValueOf(Frontmatter{Tags: []string{}}).IsZero()` is false because a non-nil empty slice is not the zero value. That is acceptable — call sites build slices as nil, not empty. The test pins this.
+
+- [ ] **Step 2: Write failing tests for `ParseNote` error return**
+
+Add to `note/frontmatter_test.go`:
+
+```go
+func TestParseNoteErrors(t *testing.T) {
+    cases := []struct {
+        name  string
+        input string
+    }{
+        {"unclosed flow sequence", "---\ntags: [a, b\n---\n\nbody\n"},
+        {"control character", "---\ntitle: \"A\x00B\"\n---\n\nbody\n"},
+        {"non-mapping top level", "---\n[1, 2, 3]\n---\n\nbody\n"},
+        {"type mismatch on public", "---\npublic: maybe\n---\n\nbody\n"},
+        {"type mismatch on tags", "---\ntags: not a list\n---\n\nbody\n"},
+    }
+    for _, tt := range cases {
+        t.Run(tt.name, func(t *testing.T) {
+            f, body, err := ParseNote([]byte(tt.input))
+            if err == nil {
+                t.Fatalf("expected error, got f=%+v body=%q", f, string(body))
+            }
+            if !f.IsZero() {
+                t.Errorf("expected zero Frontmatter, got %+v", f)
+            }
+            if body != nil {
+                t.Errorf("expected nil body, got %q", string(body))
+            }
+        })
+    }
+}
+
+func TestParseNoteNoFrontmatter(t *testing.T) {
+    input := []byte("# Heading\n\nbody text\n")
+    f, body, err := ParseNote(input)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if !f.IsZero() {
+        t.Errorf("expected zero Frontmatter, got %+v", f)
+    }
+    if string(body) != string(input) {
+        t.Errorf("body = %q, want full input", string(body))
+    }
+}
+
+func TestParseNoteHappyPath(t *testing.T) {
+    input := []byte("---\ntitle: T\ntags: [a, b]\n---\n\n# Body\n")
+    f, body, err := ParseNote(input)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if f.Title != "T" {
+        t.Errorf("Title = %q", f.Title)
+    }
+    if len(f.Tags) != 2 || f.Tags[0] != "a" || f.Tags[1] != "b" {
+        t.Errorf("Tags = %v", f.Tags)
+    }
+    if string(body) != "# Body\n" {
+        t.Errorf("body = %q", string(body))
+    }
+}
+
+func TestParseNoteBodyIsSliceOfInput(t *testing.T) {
+    input := []byte("---\ntitle: T\n---\n\nhello\n")
+    _, body, err := ParseNote(input)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    // body must point into input, not be a separate allocation.
+    if len(body) == 0 {
+        t.Fatal("body is empty")
+    }
+    if &body[0] != &input[len(input)-len(body)] {
+        t.Error("body is not a sub-slice of input (extra allocation)")
+    }
+}
+```
+
+- [ ] **Step 3: Write failing tests for `FormatNote`**
+
+```go
+func TestFormatNoteEmptyFrontmatter(t *testing.T) {
+    out := FormatNote(Frontmatter{}, []byte("body\n"))
+    if string(out) != "body\n" {
+        t.Errorf("got %q, want %q", string(out), "body\n")
+    }
+}
+
+func TestFormatNoteWithFrontmatter(t *testing.T) {
+    out := FormatNote(Frontmatter{Title: "T"}, []byte("body\n"))
+    want := "---\ntitle: T\n---\n\nbody\n"
+    if string(out) != want {
+        t.Errorf("got %q, want %q", string(out), want)
+    }
+}
+
+func TestFormatNoteRoundtrip(t *testing.T) {
+    cases := []Frontmatter{
+        {},
+        {Title: "T"},
+        {Tags: []string{"a", "b"}},
+        {Title: "Re: Project", Tags: []string{"go", "rust, elixir"}, Description: "D", Public: true},
+        {Slug: "my-slug", Public: true},
+    }
+    for i, fm := range cases {
+        t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+            out := FormatNote(fm, []byte("body\n"))
+            gotF, gotBody, err := ParseNote(out)
+            if err != nil {
+                t.Fatalf("parse failed: %v", err)
+            }
+            if !reflect.DeepEqual(gotF, fm) {
+                t.Errorf("frontmatter: got %+v, want %+v", gotF, fm)
+            }
+            if string(gotBody) != "body\n" {
+                t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
+            }
+        })
+    }
+}
+```
+
+Add imports for `fmt` and `reflect` to the test file.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./note/... -run 'TestFrontmatterIsZero|TestParseNote|TestFormatNote'`
+Expected: compilation errors (types don't exist yet), which is a valid failure.
+
+- [ ] **Step 5: Rewrite `note/frontmatter.go`**
+
+Replace the entire file contents with:
+
+```go
+package note
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+const frontmatterDelim = "---"
+
+// Frontmatter holds optional fields for note frontmatter.
+// Adding a field is a one-line struct addition — no other changes required.
+type Frontmatter struct {
+	Title       string   `yaml:"title,omitempty"`
+	Slug        string   `yaml:"slug,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Public      bool     `yaml:"public,omitempty"`
+}
+
+// IsZero reports whether f has no fields set.
+func (f Frontmatter) IsZero() bool {
+	return reflect.ValueOf(f).IsZero()
+}
+
+// ParseNote splits a note file into its frontmatter and body.
+// If no frontmatter block is present, the zero Frontmatter is returned along
+// with the full input as body and a nil error.
+// If the frontmatter block is present but malformed, a non-nil error is
+// returned along with the zero Frontmatter and a nil body.
+// The returned body is a sub-slice of the input — no allocation.
+func ParseNote(data []byte) (Frontmatter, []byte, error) {
+	bodyStart, fmEnd, ok := frontmatterEnd(data)
+	if !ok {
+		return Frontmatter{}, data, nil
+	}
+	var f Frontmatter
+	if err := yaml.Unmarshal(data[len(frontmatterDelim)+1:fmEnd], &f); err != nil {
+		return Frontmatter{}, nil, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	return f, data[bodyStart:], nil
+}
+
+// FormatNote serialises frontmatter followed by body. Omits the frontmatter
+// block entirely when f.IsZero(). yaml.Marshal cannot fail for this struct,
+// so marshal errors are treated as impossible and cause a panic.
+func FormatNote(f Frontmatter, body []byte) []byte {
+	if f.IsZero() {
+		return body
+	}
+	out, err := yaml.Marshal(f)
+	if err != nil {
+		panic(fmt.Sprintf("yaml.Marshal Frontmatter: %v", err))
+	}
+	buf := make([]byte, 0, len(out)+len(body)+8)
+	buf = append(buf, "---\n"...)
+	buf = append(buf, out...)
+	buf = append(buf, "---\n\n"...)
+	buf = append(buf, body...)
+	return buf
+}
+
+// StripFrontmatter returns data with any leading frontmatter block removed.
+// If no valid frontmatter block is present, data is returned unchanged.
+// This is a convenience for callers that want the body without parsing
+// (e.g. `notes read --no-frontmatter`).
+func StripFrontmatter(data []byte) []byte {
+	bodyStart, _, ok := frontmatterEnd(data)
+	if !ok {
+		return data
+	}
+	return data[bodyStart:]
+}
+
+// frontmatterEnd locates the YAML frontmatter block at the start of data.
+// Returns bodyStart (index after the closing delimiter line and optional
+// blank line), fmEnd (index of the newline terminating the closing "---"
+// line), and ok=true if a valid block was found. ok=false means data does
+// not begin with a well-formed frontmatter block.
+//
+// Interior CRLF sequences inside the YAML body are preserved in the slice
+// yaml.Unmarshal sees; only the opening and closing delimiter lines are
+// trimmed of trailing \r for comparison.
+func frontmatterEnd(data []byte) (bodyStart, fmEnd int, ok bool) {
+	delim := []byte(frontmatterDelim)
+	if !bytes.HasPrefix(data, delim) {
+		return 0, 0, false
+	}
+	rest := data[len(delim):]
+	firstNL := bytes.IndexByte(rest, '\n')
+	if firstNL < 0 {
+		return 0, 0, false
+	}
+	// Characters on the opening delimiter line after "---" (other than a
+	// trailing \r) disqualify the block.
+	if len(bytes.TrimRight(rest[:firstNL], "\r")) > 0 {
+		return 0, 0, false
+	}
+	// Scan subsequent lines for the closing "---" delimiter.
+	offset := len(delim) + firstNL + 1
+	for offset < len(data) {
+		nl := bytes.IndexByte(data[offset:], '\n')
+		var line []byte
+		var lineEnd int
+		if nl < 0 {
+			line = data[offset:]
+			lineEnd = len(data)
+		} else {
+			line = data[offset : offset+nl]
+			lineEnd = offset + nl
+		}
+		if bytes.Equal(bytes.TrimRight(line, "\r"), delim) {
+			fmEnd = lineEnd
+			bodyStart = lineEnd
+			if bodyStart < len(data) && data[bodyStart] == '\n' {
+				bodyStart++
+			} else if bodyStart+1 < len(data) && data[bodyStart] == '\r' && data[bodyStart+1] == '\n' {
+				bodyStart += 2
+			}
+			return bodyStart, fmEnd, true
+		}
+		if nl < 0 {
+			return 0, 0, false
+		}
+		offset += nl + 1
+	}
+	return 0, 0, false
+}
+```
+
+- [ ] **Step 6: Run new tests to verify they pass**
+
+Run: `go test ./note/... -run 'TestFrontmatterIsZero|TestParseNote|TestFormatNote'`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full `note` package test suite — expect failures in old tests**
+
+Run: `go test ./note/...`
+Expected: compilation errors in old test functions that reference `FrontmatterFields`, `ParseFrontmatterFields`, `BuildFrontmatter`. This is expected — we will migrate them in Task 2.
+
+- [ ] **Step 8: Commit the new API and its tests**
+
+Stop. Don't commit yet — tests in the file still reference the old API, and the package won't compile. Proceed straight to Task 2, which migrates the tests. Commit at the end of Task 2.
+
+---
+
+## Task 2: Migrate `frontmatter_test.go` to the new API
+
+**Files:**
+- Modify: `note/frontmatter_test.go`
+
+- [ ] **Step 1: Rename helpers and consolidate the two `TestParseFrontmatterFields*` tables**
+
+Replace the whole file with a consolidated version that:
+
+1. Has a single happy-path + adversarial table combined, checked against `ParseNote`.
+2. Splits error cases (into `TestParseNoteErrors`, already written in Task 1) from success cases.
+3. Keeps `TestBuildFrontmatter` as `TestFormatNoteSnapshot` with **one** canonical snapshot (all fields set); the other snapshot cases become round-trip assertions.
+4. Keeps `TestStripFrontmatter` as-is but uses `FormatNote` where it used `BuildFrontmatter`.
+
+Final test file:
+
+```go
+package note
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// --- Frontmatter.IsZero ---
+
+func TestFrontmatterIsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		f    Frontmatter
+		want bool
+	}{
+		{"empty", Frontmatter{}, true},
+		{"title set", Frontmatter{Title: "T"}, false},
+		{"slug set", Frontmatter{Slug: "s"}, false},
+		{"tags empty slice not zero", Frontmatter{Tags: []string{}}, false},
+		{"tags with value", Frontmatter{Tags: []string{"a"}}, false},
+		{"description set", Frontmatter{Description: "d"}, false},
+		{"public true", Frontmatter{Public: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.f.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ParseNote: success cases ---
+
+func TestParseNoteSuccess(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Frontmatter
+		body  string
+	}{
+		{"empty input", "", Frontmatter{}, ""},
+		{"no frontmatter", "# Hello\n\nBody text.\n", Frontmatter{}, "# Hello\n\nBody text.\n"},
+		{"title only", "---\ntitle: My Note\n---\n\n# Content\n", Frontmatter{Title: "My Note"}, "# Content\n"},
+		{"slug only", "---\nslug: my-slug\n---\n\n# Content\n", Frontmatter{Slug: "my-slug"}, "# Content\n"},
+		{"tags only", "---\ntags: [work, planning]\n---\n\n# Content\n", Frontmatter{Tags: []string{"work", "planning"}}, "# Content\n"},
+		{"description only", "---\ndescription: Quick thought\n---\n\n# Content\n", Frontmatter{Description: "Quick thought"}, "# Content\n"},
+		{"public true", "---\npublic: true\n---\n\n# Content\n", Frontmatter{Public: true}, "# Content\n"},
+		{"public absent false", "---\ntitle: T\n---\n\n# Content\n", Frontmatter{Title: "T"}, "# Content\n"},
+		{"all fields", "---\ntitle: T\nslug: s\ntags: [a]\ndescription: D\npublic: true\n---\n\n# Content\n",
+			Frontmatter{Title: "T", Slug: "s", Tags: []string{"a"}, Description: "D", Public: true}, "# Content\n"},
+		{"unclosed frontmatter treated as no frontmatter", "---\ntitle: Oops\n# Content\n", Frontmatter{}, "---\ntitle: Oops\n# Content\n"},
+		{"duplicate keys: last wins", "---\ntitle: A\ntitle: B\n---\n", Frontmatter{Title: "B"}, ""},
+		{"merge key applied with later override", "---\n<<: {title: X}\ntitle: Y\n---\n", Frontmatter{Title: "Y"}, ""},
+		{"int coerced to string", "---\ntitle: 12345\n---\n", Frontmatter{Title: "12345"}, ""},
+		{"null leaves field empty", "---\ntitle: null\nslug: s\n---\n", Frontmatter{Slug: "s"}, ""},
+		{"unknown keys ignored", "---\ntitle: T\nrandom: whatever\nnested: {a: 1}\n---\n", Frontmatter{Title: "T"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, body, err := ParseNote([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(f, tt.want) {
+				t.Errorf("frontmatter: got %+v, want %+v", f, tt.want)
+			}
+			if string(body) != tt.body {
+				t.Errorf("body: got %q, want %q", string(body), tt.body)
+			}
+		})
+	}
+}
+
+// --- ParseNote: error cases ---
+
+func TestParseNoteErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"unclosed flow sequence", "---\ntitle: T\ntags: [a, b\n---\n\n# Content\n"},
+		{"invalid bool value", "---\npublic: maybe\n---\n\n# Content\n"},
+		{"bad field alongside good", "---\ntitle: T\npublic: maybe\ntags: [a, b]\n---\n\n# Content\n"},
+		{"control character", "---\ntitle: \"A\x00B\"\nslug: s\n---\n"},
+		{"non-mapping top level", "---\n[1, 2, 3]\n---\n"},
+		{"alias bomb", "---\n" +
+			"a: &a [x]\n" +
+			"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
+			"c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b,*b]\n" +
+			"tags: *c\n" +
+			"title: T\n" +
+			"---\n"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			f, body, err := ParseNote([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error, got f=%+v body=%q", f, string(body))
+			}
+			if !f.IsZero() {
+				t.Errorf("expected zero Frontmatter on error, got %+v", f)
+			}
+			if body != nil {
+				t.Errorf("expected nil body on error, got %q", string(body))
+			}
+		})
+	}
+}
+
+// --- ParseNote: body is a sub-slice (zero-allocation body) ---
+
+func TestParseNoteBodyIsSliceOfInput(t *testing.T) {
+	input := []byte("---\ntitle: T\n---\n\nhello\n")
+	_, body, err := ParseNote(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("body is empty")
+	}
+	if &body[0] != &input[len(input)-len(body)] {
+		t.Error("body is not a sub-slice of input (extra allocation)")
+	}
+}
+
+// --- FormatNote: canonical snapshot (one, to pin output style) ---
+
+func TestFormatNoteSnapshotAllFields(t *testing.T) {
+	f := Frontmatter{
+		Title:       "T",
+		Slug:        "s",
+		Tags:        []string{"a"},
+		Description: "D",
+		Public:      true,
+	}
+	want := "---\ntitle: T\nslug: s\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
+	got := string(FormatNote(f, []byte("body\n")))
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFormatNoteEmptyFrontmatter(t *testing.T) {
+	if got := string(FormatNote(Frontmatter{}, []byte("body\n"))); got != "body\n" {
+		t.Errorf("got %q, want %q", got, "body\n")
+	}
+}
+
+// --- ParseNote / FormatNote round-trip ---
+
+func TestRoundtrip(t *testing.T) {
+	cases := []Frontmatter{
+		{},
+		{Title: "T"},
+		{Tags: []string{"a", "b"}},
+		{Tags: []string{"go", "rust, elixir"}},
+		{Tags: []string{"foo: bar", "baz]"}},
+		{Title: "Re: Project update"},
+		{Title: "T", Slug: "s", Tags: []string{"a"}, Public: true},
+		{Title: "T", Slug: "s", Tags: []string{"a"}, Description: "D", Public: true},
+	}
+	for i, fm := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			out := FormatNote(fm, []byte("body\n"))
+			gotF, gotBody, err := ParseNote(out)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if !reflect.DeepEqual(gotF, fm) {
+				t.Errorf("frontmatter: got %+v, want %+v", gotF, fm)
+			}
+			if string(gotBody) != "body\n" {
+				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
+			}
+		})
+	}
+}
+
+// --- StripFrontmatter ---
+
+func TestStripFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no frontmatter", "# Hello\n\nBody text.\n", "# Hello\n\nBody text.\n"},
+		{"with frontmatter", "---\nslug: todo\ntags: [journal]\n---\n\n# Hello\n\nBody text.\n", "# Hello\n\nBody text.\n"},
+		{"frontmatter only", "---\nslug: todo\n---\n", ""},
+		{"empty input", "", ""},
+		{"unclosed frontmatter", "---\nslug: todo\n# Hello\n", "---\nslug: todo\n# Hello\n"},
+		{"triple dash in body not at start", "# Hello\n\n---\n\nFooter.\n", "# Hello\n\n---\n\nFooter.\n"},
+		{"preserves multiple blank lines after frontmatter", "---\nslug: todo\n---\n\n\n\nContent\n", "\n\nContent\n"},
+		{"opening delimiter with trailing text", "---extra\nslug: x\n---\n\nBody\n", "---extra\nslug: x\n---\n\nBody\n"},
+		{"opening delimiter only no newline", "---", "---"},
+		{"opening delimiter only with newline", "---\nstuff\n", "---\nstuff\n"},
+		{"empty frontmatter block", "---\n---\n\nBody\n", "Body\n"},
+		{"malformed yaml still stripped", "---\n[bad: yaml\n---\n\nBody\n", "Body\n"},
+		{"multiple closing delimiters", "---\na\n---\nb\n---\n\nBody\n", "b\n---\n\nBody\n"},
+		{"roundtrip with FormatNote", string(FormatNote(Frontmatter{Tags: []string{"journal"}, Description: "A note"}, []byte("# Content\n"))), "# Content\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(StripFrontmatter([]byte(tt.input)))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- CRLF handling: documented as "LF-only on write; LF-normalised on parse of delimiter lines;
+//     CRLF interior bytes preserved through Unmarshal" ---
+
+func TestParseNoteCRLFInteriorPreserved(t *testing.T) {
+	// Note with CRLF line endings throughout: delimiters, fields, body.
+	input := []byte("---\r\ntitle: T\r\ntags:\r\n  - a\r\n  - b\r\n---\r\n\r\nbody line\r\nsecond\r\n")
+	f, body, err := ParseNote(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Title != "T" {
+		t.Errorf("Title = %q", f.Title)
+	}
+	if len(f.Tags) != 2 || f.Tags[0] != "a" || f.Tags[1] != "b" {
+		t.Errorf("Tags = %v", f.Tags)
+	}
+	// Body must preserve CRLF bytes that appeared inside it.
+	want := "body line\r\nsecond\r\n"
+	if string(body) != want {
+		t.Errorf("body: got %q, want %q", string(body), want)
+	}
+}
+
+func TestFormatNoteWritesLFOnly(t *testing.T) {
+	// FormatNote always emits LF, regardless of the body's line endings.
+	out := FormatNote(Frontmatter{Title: "T"}, []byte("hello\r\nworld\r\n"))
+	// Delimiter lines are LF.
+	if string(out[:18]) != "---\ntitle: T\n---\n\n" {
+		t.Errorf("delimiter lines not LF-only: %q", string(out[:18]))
+	}
+	// Body bytes pass through unchanged — preserves whatever the caller gave us.
+	if string(out[18:]) != "hello\r\nworld\r\n" {
+		t.Errorf("body modified: %q", string(out[18:]))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./note/...`
+Expected: all `note` package tests pass. Callers in `internal/cli/...` will still fail to compile — we address those in later tasks.
+
+- [ ] **Step 3: Commit**
+
+Don't commit yet. `internal/cli` still fails to compile. Proceed to Task 3.
+
+---
+
+## Task 3: Migrate `internal/cli/create.go` and `createNote`
+
+**Files:**
+- Modify: `internal/cli/create.go`
+
+- [ ] **Step 1: Rewrite `createNote` to use `FormatNote`**
+
+Replace the body of `createNote` so that the content is built via `FormatNote`. New code:
+
+```go
+func createNote(p createNoteParams) (string, error) {
+	today := time.Now().Format("20060102")
+
+	id, err := note.NextID(p.Root)
+	if err != nil {
+		return "", err
+	}
+
+	filename := note.NoteFilename(today, id, p.Slug, p.Type)
+	dir := note.NoteDirPath(p.Root, today)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("cannot create directory %s: %w", dir, err)
+	}
+
+	fullPath := filepath.Join(dir, filename)
+
+	fm := note.Frontmatter{
+		Title:       p.Title,
+		Slug:        p.Slug,
+		Tags:        p.Tags,
+		Description: p.Description,
+		Public:      p.Public,
+	}
+	content := note.FormatNote(fm, []byte(p.Body))
+
+	if err := os.WriteFile(fullPath, content, 0o644); err != nil {
+		return "", fmt.Errorf("cannot write note: %w", err)
+	}
+
+	return fullPath, nil
+}
+```
+
+- [ ] **Step 2: Run tests (still won't fully compile)**
+
+Run: `go test ./internal/cli/... -run TestNew`
+Expected: compilation errors in `update.go` / `annotate.go` — those are migrated next.
+
+---
+
+## Task 4: Migrate `internal/cli/update.go`
+
+**Files:**
+- Modify: `internal/cli/update.go:62-117`
+
+- [ ] **Step 1: Collapse the parse/strip/build dance**
+
+Replace the block from the `oldPath := ...` line through `newContent := ...` with:
+
+```go
+		oldPath := filepath.Join(root, n.RelPath)
+		data, err := os.ReadFile(oldPath)
+		if err != nil {
+			return fmt.Errorf("cannot read note: %w", err)
+		}
+
+		updated, body, err := note.ParseNote(data)
+		if err != nil {
+			return fmt.Errorf("%s: %w", oldPath, err)
+		}
+
+		if cmd.Flags().Changed("title") {
+			updated.Title = updateTitle
+		}
+		if cmd.Flags().Changed("description") {
+			updated.Description = updateDescription
+		}
+		if updateNoTags {
+			updated.Tags = nil
+		} else if cmd.Flags().Changed("tag") {
+			updated.Tags = updateTags
+		}
+
+		// Determine new slug.
+		newSlug := n.Slug
+		if updateNoSlug {
+			newSlug = ""
+		} else if cmd.Flags().Changed("slug") {
+			newSlug = updateSlug
+		}
+		if updateNoSlug || cmd.Flags().Changed("slug") {
+			updated.Slug = newSlug
+		}
+		if updatePrivate {
+			updated.Public = false
+		} else if cmd.Flags().Changed("public") {
+			updated.Public = true
+		}
+
+		// Determine new type.
+		newType := n.Type
+		if updateNoType {
+			newType = ""
+		} else if cmd.Flags().Changed("type") {
+			newType = updateType
+		}
+
+		// n.ID is guaranteed to be a non-empty digit string by ParseFilename.
+		id, _ := strconv.Atoi(n.ID)
+
+		newFilename := note.NoteFilename(n.Date, id, newSlug, newType)
+		dir := filepath.Dir(oldPath)
+		newPath := filepath.Join(dir, newFilename)
+
+		newContent := note.FormatNote(updated, body)
+```
+
+Then change the tmpfile write:
+
+```go
+		if err := os.WriteFile(tmpPath, newContent, 0o644); err != nil {
+```
+
+(remove the `[]byte(...)` cast since `newContent` is already `[]byte`).
+
+- [ ] **Step 2: Run update tests**
+
+Run: `go test ./internal/cli/... -run TestUpdate`
+Expected: all update tests pass.
+
+---
+
+## Task 5: Migrate `internal/cli/annotate.go` and `annotate_test.go`
+
+**Files:**
+- Modify: `internal/cli/annotate.go`
+- Modify: `internal/cli/annotate_test.go`
+
+- [ ] **Step 1: Replace parse/strip dance with ParseNote**
+
+In `annotate.go`, replace lines ~63-101 (read-through-writeback) with:
+
+```go
+	fullPath := filepath.Join(root, n.RelPath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return fmt.Errorf("cannot read note: %w", err)
+	}
+
+	existing, body, err := note.ParseNote(data)
+	if err != nil {
+		return fmt.Errorf("%s: %w", fullPath, err)
+	}
+
+	empty := annotateEmptyFields(existing)
+	if len(empty) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+		return nil
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return errors.New("note has no body content to annotate")
+	}
+
+	prompt := string(body)
+	if maxChars > 0 {
+		if runes := []rune(prompt); len(runes) > maxChars {
+			prompt = string(runes[:maxChars])
+			fmt.Fprintf(cmd.ErrOrStderr(), "truncated note body to %d chars for annotation\n", maxChars)
+		}
+	}
+
+	schema := buildAnnotateSchema(empty)
+	out, err := runClaude(model, schema, prompt)
+	if err != nil {
+		return err
+	}
+
+	gen, err := parseAnnotation(out)
+	if err != nil {
+		return err
+	}
+
+	merged := mergeAnnotation(existing, gen)
+	newContent := note.FormatNote(merged, body)
+
+	tmpPath := fullPath + ".tmp"
+	if err := os.WriteFile(tmpPath, newContent, 0o644); err != nil {
+		return fmt.Errorf("cannot write note: %w", err)
+	}
+```
+
+Also update the function signatures:
+
+```go
+func annotateEmptyFields(f note.Frontmatter) []string {
+    // unchanged body
+}
+
+func mergeAnnotation(existing note.Frontmatter, gen annotateResult) note.Frontmatter {
+    // unchanged body
+}
+```
+
+- [ ] **Step 2: Update annotate_test.go to use `note.Frontmatter`**
+
+In `internal/cli/annotate_test.go`, globally replace `note.FrontmatterFields` with `note.Frontmatter`. Six references at lines ~32, 40, 49, 184, 210.
+
+- [ ] **Step 3: Run annotate tests**
+
+Run: `go test ./internal/cli/... -run TestAnnotate`
+Expected: all pass.
+
+---
+
+## Task 6: Migrate `note/store.go` with warn-on-error
+
+**Files:**
+- Modify: `note/store.go`
+
+- [ ] **Step 1: Update `FilterByTags` to use ParseNote with warn-and-continue**
+
+Replace the `FilterByTags` function with:
+
+```go
+// FilterByTags returns notes that contain all of the given tags in their frontmatter.
+// Per-note frontmatter parse errors are logged via log.Printf and the note is skipped.
+func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
+	var results []Note
+	for _, n := range notes {
+		path := filepath.Join(root, n.RelPath)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		fm, _, parseErr := ParseNote(data)
+		if parseErr != nil {
+			log.Printf("warn: %s: %v", path, parseErr)
+			continue
+		}
+		if hasAllTags(fm.Tags, tags) {
+			results = append(results, n)
+		}
+	}
+	return results, nil
+}
+```
+
+Add `"log"` to the imports.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./note/...`
+Expected: all pass.
+
+---
+
+## Task 7: Rewrite `ExtractTags` using errgroup; switch to ParseNote
+
+**Files:**
+- Modify: `note/tags.go`
+- Modify: `go.mod`
+
+- [ ] **Step 1: Promote `golang.org/x/sync` to a direct require**
+
+Run: `go get golang.org/x/sync@v0.12.0`
+This moves the existing indirect dep to direct.
+
+- [ ] **Step 2: Rewrite `ExtractTags`**
+
+Replace the `ExtractTags` function body (lines 17-91) with an errgroup-based version:
+
+```go
+// ExtractTags scans the note store under root and returns a sorted,
+// deduplicated list of tags. Sources: frontmatter `tags:` fields and body
+// hashtags (#word) in the prose. File reads run concurrently across
+// runtime.NumCPU() workers. Returns a nil slice for an empty store.
+// A per-note frontmatter parse error is logged via log.Printf and the
+// note's frontmatter tags are skipped (body hashtags are still collected).
+// Any file-read error aborts the scan.
+func ExtractTags(root string) ([]string, error) {
+	notes, err := Scan(root)
+	if err != nil {
+		return nil, err
+	}
+	if len(notes) == 0 {
+		return nil, nil
+	}
+
+	workers := runtime.NumCPU()
+	if workers > len(notes) {
+		workers = len(notes)
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+	jobs := make(chan Note)
+	var mu sync.Mutex
+	merged := make(map[string]struct{})
+
+	g.Go(func() error {
+		defer close(jobs)
+		for _, n := range notes {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case jobs <- n:
+			}
+		}
+		return nil
+	})
+
+	for i := 0; i < workers; i++ {
+		g.Go(func() error {
+			local := make(map[string]struct{})
+			for n := range jobs {
+				path := filepath.Join(root, n.RelPath)
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				fm, body, parseErr := ParseNote(data)
+				if parseErr != nil {
+					log.Printf("warn: %s: %v", path, parseErr)
+					body = StripFrontmatter(data)
+				} else {
+					for _, t := range fm.Tags {
+						if t != "" {
+							local[t] = struct{}{}
+						}
+					}
+				}
+				for _, t := range extractHashtags(body) {
+					local[t] = struct{}{}
+				}
+			}
+			mu.Lock()
+			for t := range local {
+				merged[t] = struct{}{}
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(merged))
+	for t := range merged {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+```
+
+Update imports: add `context`, `log`, `golang.org/x/sync/errgroup`. Keep `runtime`, `sort`, `sync`, `os`, `path/filepath`, `bytes` (for extractHashtags).
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./note/...`
+Expected: all pass.
+
+---
+
+## Task 8: Verify full build and lint
+
+**Files:** n/a
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: all pass.
+
+- [ ] **Step 2: Run lint**
+
+Run: `make lint`
+Expected: no errors.
+
+- [ ] **Step 3: Verify no remaining references to old API**
+
+Run via Grep tool: `FrontmatterFields|ParseFrontmatterFields|BuildFrontmatter` across `**/*.go`.
+Expected: zero matches.
+
+---
+
+## Task 9: Changelog and commit
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add v0.1.72 entry at the top**
+
+Insert above the `## [0.1.71]` heading:
+
+```markdown
+## [0.1.72] - 2026-04-19
+
+### Changed
+
+- Replace `ParseFrontmatterFields` / `BuildFrontmatter` trio with error-returning `ParseNote` / `FormatNote` pair; rename `FrontmatterFields` → `Frontmatter` with `IsZero`. Single-note writers (`update`, `annotate`) now surface frontmatter parse errors; bulk readers (`FilterByTags`, `ExtractTags`) log per-note warnings and continue. Body is returned as a sub-slice of the input (no copy), and CRLF interior bytes round-trip through parsing. `ExtractTags` concurrency now uses `errgroup`. ([#112])
+```
+
+Then add the reference at the bottom of the file:
+
+```markdown
+[#112]: https://github.com/dreikanter/notes-cli/pull/112
+```
+
+- [ ] **Step 2: Commit all changes**
+
+```bash
+git add -A
+git commit -m "Refactor frontmatter API: ParseNote/FormatNote with real errors (#112)"
+```
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "Refactor frontmatter API: ParseNote/FormatNote with real errors" --body "$(cat <<'EOF'
+## Summary
+
+- Replace `ParseFrontmatterFields` / `BuildFrontmatter` trio with `ParseNote` / `FormatNote` pair that returns real errors
+- Rename `FrontmatterFields` → `Frontmatter`; add `IsZero` method; body is a zero-copy sub-slice of input
+- Surface parse errors in single-note writers (`update`, `annotate`); log warn-and-continue in bulk readers (`FilterByTags`, `ExtractTags`)
+- Rewrite `ExtractTags` concurrency using `errgroup`
+
+## References
+
+- closes #112
+EOF
+)"
+```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.7
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -181,7 +182,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -719,8 +719,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -65,8 +65,10 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot read note: %w", err)
 	}
 
-	existing := note.ParseFrontmatterFields(data)
-	body := note.StripFrontmatter(data)
+	existing, body, err := note.ParseNote(data)
+	if err != nil {
+		return fmt.Errorf("%s: %w", fullPath, err)
+	}
 
 	empty := annotateEmptyFields(existing)
 	if len(empty) == 0 {
@@ -98,10 +100,10 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	merged := mergeAnnotation(existing, gen)
-	newContent := note.BuildFrontmatter(merged) + string(body)
+	newContent := note.FormatNote(merged, body)
 
 	tmpPath := fullPath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(newContent), 0o644); err != nil {
+	if err := os.WriteFile(tmpPath, newContent, 0o644); err != nil {
 		return fmt.Errorf("cannot write note: %w", err)
 	}
 	if err := os.Rename(tmpPath, fullPath); err != nil {
@@ -146,7 +148,7 @@ func runClaude(model, schema, prompt string) ([]byte, error) {
 
 // annotateEmptyFields returns the empty fields among {title, description, tags}
 // in a deterministic order. "tags" counts as empty when the slice is empty.
-func annotateEmptyFields(f note.FrontmatterFields) []string {
+func annotateEmptyFields(f note.Frontmatter) []string {
 	var empty []string
 	if f.Title == "" {
 		empty = append(empty, "title")
@@ -226,7 +228,7 @@ func snippet(s string, n int) string {
 
 // mergeAnnotation fills empty fields in existing from gen.
 // Non-empty fields in existing are preserved.
-func mergeAnnotation(existing note.FrontmatterFields, gen annotateResult) note.FrontmatterFields {
+func mergeAnnotation(existing note.Frontmatter, gen annotateResult) note.Frontmatter {
 	merged := existing
 	if merged.Title == "" {
 		merged.Title = gen.Title

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -29,7 +29,7 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 }
 
 func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
-	got := annotateEmptyFields(note.FrontmatterFields{})
+	got := annotateEmptyFields(note.Frontmatter{})
 	want := []string{"title", "description", "tags"}
 	if !equalStrings(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -37,7 +37,7 @@ func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
 }
 
 func TestAnnotateEmptyFieldsPartial(t *testing.T) {
-	f := note.FrontmatterFields{Title: "Existing"}
+	f := note.Frontmatter{Title: "Existing"}
 	got := annotateEmptyFields(f)
 	want := []string{"description", "tags"}
 	if !equalStrings(got, want) {
@@ -46,7 +46,7 @@ func TestAnnotateEmptyFieldsPartial(t *testing.T) {
 }
 
 func TestAnnotateEmptyFieldsAllFilled(t *testing.T) {
-	f := note.FrontmatterFields{Title: "T", Description: "D", Tags: []string{"x"}}
+	f := note.Frontmatter{Title: "T", Description: "D", Tags: []string{"x"}}
 	got := annotateEmptyFields(f)
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty", got)
@@ -181,7 +181,7 @@ func TestParseAnnotationErrorFlag(t *testing.T) {
 }
 
 func TestMergeAnnotationFillsEmpty(t *testing.T) {
-	existing := note.FrontmatterFields{Slug: "meeting", Public: true}
+	existing := note.Frontmatter{Slug: "meeting", Public: true}
 	gen := annotateResult{
 		Title:       "New",
 		Description: "Generated desc",
@@ -207,7 +207,7 @@ func TestMergeAnnotationFillsEmpty(t *testing.T) {
 }
 
 func TestMergeAnnotationPreservesFilledFields(t *testing.T) {
-	existing := note.FrontmatterFields{
+	existing := note.Frontmatter{
 		Title:       "Existing title",
 		Description: "Existing desc",
 		Tags:        []string{"keep"},

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -40,16 +40,16 @@ func createNote(p createNoteParams) (string, error) {
 
 	fullPath := filepath.Join(dir, filename)
 
-	content := note.BuildFrontmatter(note.FrontmatterFields{
+	fm := note.Frontmatter{
 		Title:       p.Title,
 		Slug:        p.Slug,
 		Tags:        p.Tags,
 		Description: p.Description,
 		Public:      p.Public,
-	})
-	content += p.Body
+	}
+	content := note.FormatNote(fm, []byte(p.Body))
 
-	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(fullPath, content, 0o644); err != nil {
 		return "", fmt.Errorf("cannot write note: %w", err)
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -65,11 +65,10 @@ var updateCmd = &cobra.Command{
 			return fmt.Errorf("cannot read note: %w", err)
 		}
 
-		existing := note.ParseFrontmatterFields(data)
-		body := note.StripFrontmatter(data)
-
-		// Merge frontmatter updates.
-		updated := existing
+		updated, body, err := note.ParseNote(data)
+		if err != nil {
+			return fmt.Errorf("%s: %w", oldPath, err)
+		}
 
 		if cmd.Flags().Changed("title") {
 			updated.Title = updateTitle
@@ -114,10 +113,10 @@ var updateCmd = &cobra.Command{
 		dir := filepath.Dir(oldPath)
 		newPath := filepath.Join(dir, newFilename)
 
-		newContent := note.BuildFrontmatter(updated) + string(body)
+		newContent := note.FormatNote(updated, body)
 
 		tmpPath := newPath + ".tmp"
-		if err := os.WriteFile(tmpPath, []byte(newContent), 0o644); err != nil {
+		if err := os.WriteFile(tmpPath, newContent, 0o644); err != nil {
 			return fmt.Errorf("cannot write note: %w", err)
 		}
 		if err := os.Rename(tmpPath, newPath); err != nil {

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -2,14 +2,17 @@ package note
 
 import (
 	"bytes"
+	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
 
-var frontmatterDelim = []byte("---")
+const frontmatterDelim = "---"
 
-// FrontmatterFields holds optional fields for note frontmatter.
-type FrontmatterFields struct {
+// Frontmatter holds optional fields for note frontmatter.
+// Adding a field is a one-line struct addition — no other changes required.
+type Frontmatter struct {
 	Title       string   `yaml:"title,omitempty"`
 	Slug        string   `yaml:"slug,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
@@ -17,111 +20,105 @@ type FrontmatterFields struct {
 	Public      bool     `yaml:"public,omitempty"`
 }
 
-// BuildFrontmatter generates YAML frontmatter from the given fields.
-// Returns empty string if no fields are provided.
-func BuildFrontmatter(f FrontmatterFields) string {
-	if f.Title == "" && f.Slug == "" && len(f.Tags) == 0 && f.Description == "" && !f.Public {
-		return ""
-	}
+// IsZero reports whether f has no fields set.
+func (f Frontmatter) IsZero() bool {
+	return reflect.ValueOf(f).IsZero()
+}
 
+// ParseNote splits a note file into its frontmatter and body.
+// If no frontmatter block is present, the zero Frontmatter is returned along
+// with the full input as body and a nil error.
+// If the frontmatter block is present but malformed, a non-nil error is
+// returned along with the zero Frontmatter and a nil body.
+// The returned body is a sub-slice of the input — no allocation.
+func ParseNote(data []byte) (Frontmatter, []byte, error) {
+	bodyStart, fmEnd, ok := frontmatterEnd(data)
+	if !ok {
+		return Frontmatter{}, data, nil
+	}
+	yamlStart := len(frontmatterDelim) + 1
+	var f Frontmatter
+	if err := yaml.Unmarshal(data[yamlStart:fmEnd], &f); err != nil {
+		return Frontmatter{}, nil, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	return f, data[bodyStart:], nil
+}
+
+// FormatNote serialises frontmatter followed by body. Omits the frontmatter
+// block entirely when f.IsZero(). yaml.Marshal cannot fail for this struct,
+// so marshal errors are treated as impossible and cause a panic.
+func FormatNote(f Frontmatter, body []byte) []byte {
+	if f.IsZero() {
+		return body
+	}
 	out, err := yaml.Marshal(f)
 	if err != nil {
-		return ""
+		panic(fmt.Sprintf("yaml.Marshal Frontmatter: %v", err))
 	}
-	return "---\n" + string(out) + "---\n\n"
+	buf := make([]byte, 0, len(out)+len(body)+8)
+	buf = append(buf, "---\n"...)
+	buf = append(buf, out...)
+	buf = append(buf, "---\n\n"...)
+	buf = append(buf, body...)
+	return buf
 }
 
-// ParseFrontmatterFields extracts all frontmatter fields from data.
-// Returns zero-value FrontmatterFields if no valid frontmatter block is
-// present or if the YAML inside the block is not a mapping.
-//
-// Per-field errors are tolerated: a single field whose value cannot be
-// decoded into its target type (e.g. `public: maybe`) is skipped, and the
-// remaining fields still parse. This matches the old line-based parser's
-// graceful degradation on partially malformed notes.
-func ParseFrontmatterFields(data []byte) FrontmatterFields {
-	body, _, ok := findFrontmatterBlock(data)
-	if !ok {
-		return FrontmatterFields{}
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(body, &doc); err != nil {
-		return FrontmatterFields{}
-	}
-	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
-		return FrontmatterFields{}
-	}
-	mapping := doc.Content[0]
-	if mapping.Kind != yaml.MappingNode {
-		return FrontmatterFields{}
-	}
-
-	var f FrontmatterFields
-	for i := 0; i+1 < len(mapping.Content); i += 2 {
-		key, value := mapping.Content[i], mapping.Content[i+1]
-		switch key.Value {
-		case "title":
-			_ = value.Decode(&f.Title)
-		case "slug":
-			_ = value.Decode(&f.Slug)
-		case "tags":
-			_ = value.Decode(&f.Tags)
-		case "description":
-			_ = value.Decode(&f.Description)
-		case "public":
-			_ = value.Decode(&f.Public)
-		}
-	}
-	return f
-}
-
-// StripFrontmatter removes YAML frontmatter from the beginning of data.
-// Frontmatter must start on the first line with "---" and end with a
-// subsequent "---" line. Exactly one blank line after the closing
-// delimiter is also consumed.
+// StripFrontmatter returns data with any leading frontmatter block removed.
+// If no valid frontmatter block is present, data is returned unchanged.
+// Convenience for callers that want the body without parsing (e.g.
+// `notes read --no-frontmatter`).
 func StripFrontmatter(data []byte) []byte {
-	_, after, ok := findFrontmatterBlock(data)
+	bodyStart, _, ok := frontmatterEnd(data)
 	if !ok {
 		return data
 	}
-	if len(after) > 0 && after[0] == '\n' {
-		return after[1:]
-	}
-	if len(after) > 1 && after[0] == '\r' && after[1] == '\n' {
-		return after[2:]
-	}
-	return after
+	return data[bodyStart:]
 }
 
-// findFrontmatterBlock locates the YAML frontmatter block at the start of data.
-// Returns the body between the opening/closing "---" delimiter lines and the
-// remaining data after the closing delimiter's newline.
-func findFrontmatterBlock(data []byte) (body, after []byte, ok bool) {
-	if !bytes.HasPrefix(data, frontmatterDelim) {
-		return nil, nil, false
+// frontmatterEnd locates the YAML frontmatter block at the start of data.
+// Returns fmEnd (end of the YAML content — i.e. start of the closing "---"
+// line, exclusive), bodyStart (index after the closing delimiter line and
+// one optional blank line), and ok=true if a valid block was found.
+func frontmatterEnd(data []byte) (bodyStart, fmEnd int, ok bool) {
+	delim := []byte(frontmatterDelim)
+	if !bytes.HasPrefix(data, delim) {
+		return 0, 0, false
 	}
-	rest := data[len(frontmatterDelim):]
-	idx := bytes.IndexByte(rest, '\n')
-	if idx < 0 {
-		return nil, nil, false
+	rest := data[len(delim):]
+	firstNL := bytes.IndexByte(rest, '\n')
+	if firstNL < 0 {
+		return 0, 0, false
 	}
-	if len(bytes.TrimRight(rest[:idx], "\r")) > 0 {
-		return nil, nil, false
+	if len(bytes.TrimRight(rest[:firstNL], "\r")) > 0 {
+		return 0, 0, false
 	}
-	rest = rest[idx+1:]
-
-	var bodyBuf []byte
-	for {
-		line, remainder, found := bytes.Cut(rest, []byte("\n"))
-		if bytes.Equal(bytes.TrimRight(line, "\r"), frontmatterDelim) {
-			return bodyBuf, remainder, true
+	offset := len(delim) + firstNL + 1
+	for offset < len(data) {
+		nl := bytes.IndexByte(data[offset:], '\n')
+		var line []byte
+		if nl < 0 {
+			line = data[offset:]
+		} else {
+			line = data[offset : offset+nl]
 		}
-		if !found {
-			return nil, nil, false
+		if bytes.Equal(bytes.TrimRight(line, "\r"), delim) {
+			fmEnd = offset
+			if nl < 0 {
+				bodyStart = len(data)
+			} else {
+				bodyStart = offset + nl + 1
+			}
+			if bodyStart < len(data) && data[bodyStart] == '\n' {
+				bodyStart++
+			} else if bodyStart+1 < len(data) && data[bodyStart] == '\r' && data[bodyStart+1] == '\n' {
+				bodyStart += 2
+			}
+			return bodyStart, fmEnd, true
 		}
-		bodyBuf = append(bodyBuf, line...)
-		bodyBuf = append(bodyBuf, '\n')
-		rest = remainder
+		if nl < 0 {
+			return 0, 0, false
+		}
+		offset += nl + 1
 	}
+	return 0, 0, false
 }

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -29,8 +29,9 @@ func (f Frontmatter) IsZero() bool {
 // If no frontmatter block is present, the zero Frontmatter is returned along
 // with the full input as body and a nil error.
 // If the frontmatter block is present but malformed, a non-nil error is
-// returned along with the zero Frontmatter and a nil body.
-// The returned body is a sub-slice of the input — no allocation.
+// returned along with the zero Frontmatter; the body is still returned as
+// a sub-slice so bulk readers can fall back to body-only processing.
+// The returned body is always a sub-slice of the input — no allocation.
 func ParseNote(data []byte) (Frontmatter, []byte, error) {
 	bodyStart, fmEnd, ok := frontmatterEnd(data)
 	if !ok {
@@ -39,7 +40,7 @@ func ParseNote(data []byte) (Frontmatter, []byte, error) {
 	yamlStart := len(frontmatterDelim) + 1
 	var f Frontmatter
 	if err := yaml.Unmarshal(data[yamlStart:fmEnd], &f); err != nil {
-		return Frontmatter{}, nil, fmt.Errorf("parse frontmatter: %w", err)
+		return Frontmatter{}, data[bodyStart:], fmt.Errorf("parse frontmatter: %w", err)
 	}
 	return f, data[bodyStart:], nil
 }
@@ -55,10 +56,12 @@ func FormatNote(f Frontmatter, body []byte) []byte {
 	if err != nil {
 		panic(fmt.Sprintf("yaml.Marshal Frontmatter: %v", err))
 	}
-	buf := make([]byte, 0, len(out)+len(body)+8)
-	buf = append(buf, "---\n"...)
+	const prefix = "---\n"
+	const suffix = "---\n\n"
+	buf := make([]byte, 0, len(prefix)+len(out)+len(suffix)+len(body))
+	buf = append(buf, prefix...)
 	buf = append(buf, out...)
-	buf = append(buf, "---\n\n"...)
+	buf = append(buf, suffix...)
 	buf = append(buf, body...)
 	return buf
 }

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -96,17 +96,27 @@ func TestParseNoteErrors(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			f, body, err := ParseNote([]byte(tt.input))
+			f, _, err := ParseNote([]byte(tt.input))
 			if err == nil {
-				t.Fatalf("expected error, got f=%+v body=%q", f, string(body))
+				t.Fatalf("expected error, got f=%+v", f)
 			}
 			if !f.IsZero() {
 				t.Errorf("expected zero Frontmatter on error, got %+v", f)
 			}
-			if body != nil {
-				t.Errorf("expected nil body on error, got %q", string(body))
-			}
 		})
+	}
+}
+
+// On parse error the body is still returned as a sub-slice so bulk readers
+// can fall back to body-only processing (e.g. body hashtags still collected).
+func TestParseNoteErrorStillReturnsBody(t *testing.T) {
+	input := []byte("---\npublic: maybe\n---\n\n# Content\n")
+	_, body, err := ParseNote(input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if string(body) != "# Content\n" {
+		t.Errorf("body = %q, want %q", string(body), "# Content\n")
 	}
 }
 

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -1,162 +1,90 @@
 package note
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 )
 
-func TestParseFrontmatterFields(t *testing.T) {
+func TestFrontmatterIsZero(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  FrontmatterFields
+		name string
+		f    Frontmatter
+		want bool
 	}{
-		{
-			name:  "empty input",
-			input: "",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "no frontmatter",
-			input: "# Hello\n\nBody text.\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "title only",
-			input: "---\ntitle: My Note\n---\n\n# Content\n",
-			want:  FrontmatterFields{Title: "My Note"},
-		},
-		{
-			name:  "tags only",
-			input: "---\ntags: [work, planning]\n---\n\n# Content\n",
-			want:  FrontmatterFields{Tags: []string{"work", "planning"}},
-		},
-		{
-			name:  "description only",
-			input: "---\ndescription: Quick thought\n---\n\n# Content\n",
-			want:  FrontmatterFields{Description: "Quick thought"},
-		},
-		{
-			name:  "all fields",
-			input: "---\ntitle: Weekly Review\ntags: [review, work]\ndescription: Week 10\n---\n\n# Content\n",
-			want: FrontmatterFields{
-				Title:       "Weekly Review",
-				Tags:        []string{"review", "work"},
-				Description: "Week 10",
-			},
-		},
-		{
-			name:  "unclosed frontmatter",
-			input: "---\ntitle: Oops\n# Content\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "roundtrip with BuildFrontmatter",
-			input: BuildFrontmatter(FrontmatterFields{Title: "T", Tags: []string{"a", "b"}, Description: "D"}) + "body\n",
-			want:  FrontmatterFields{Title: "T", Tags: []string{"a", "b"}, Description: "D"},
-		},
-		{
-			name:  "slug only",
-			input: "---\nslug: my-slug\n---\n\n# Content\n",
-			want:  FrontmatterFields{Slug: "my-slug"},
-		},
-		{
-			name:  "public true",
-			input: "---\npublic: true\n---\n\n# Content\n",
-			want:  FrontmatterFields{Public: true},
-		},
-		{
-			name:  "public absent means false",
-			input: "---\ntitle: T\n---\n\n# Content\n",
-			want:  FrontmatterFields{Title: "T"},
-		},
-		{
-			name:  "invalid bool value rejected",
-			input: "---\npublic: maybe\n---\n\n# Content\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "bad field does not drop siblings",
-			input: "---\ntitle: T\npublic: maybe\ntags: [a, b]\n---\n\n# Content\n",
-			want:  FrontmatterFields{Title: "T", Tags: []string{"a", "b"}},
-		},
-		{
-			name:  "unclosed flow sequence drops frontmatter",
-			input: "---\ntitle: T\ntags: [a, b\n---\n\n# Content\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "all fields including slug and public",
-			input: "---\ntitle: T\nslug: s\ntags: [a]\ndescription: D\npublic: true\n---\n\n# Content\n",
-			want: FrontmatterFields{
-				Title:       "T",
-				Slug:        "s",
-				Tags:        []string{"a"},
-				Description: "D",
-				Public:      true,
-			},
-		},
-		{
-			name: "roundtrip with slug and public",
-			input: BuildFrontmatter(FrontmatterFields{
-				Title:  "T",
-				Slug:   "s",
-				Tags:   []string{"a"},
-				Public: true,
-			}) + "body\n",
-			want: FrontmatterFields{Title: "T", Slug: "s", Tags: []string{"a"}, Public: true},
-		},
-		{
-			name:  "roundtrip preserves tag with comma",
-			input: BuildFrontmatter(FrontmatterFields{Tags: []string{"go", "rust, elixir"}}) + "body\n",
-			want:  FrontmatterFields{Tags: []string{"go", "rust, elixir"}},
-		},
-		{
-			name:  "roundtrip preserves tag with bracket and colon",
-			input: BuildFrontmatter(FrontmatterFields{Tags: []string{"foo: bar", "baz]"}}) + "body\n",
-			want:  FrontmatterFields{Tags: []string{"foo: bar", "baz]"}},
-		},
-		{
-			name:  "roundtrip preserves title with colon",
-			input: BuildFrontmatter(FrontmatterFields{Title: "Re: Project update"}) + "body\n",
-			want:  FrontmatterFields{Title: "Re: Project update"},
-		},
+		{"empty", Frontmatter{}, true},
+		{"title set", Frontmatter{Title: "T"}, false},
+		{"slug set", Frontmatter{Slug: "s"}, false},
+		{"tags empty slice not zero", Frontmatter{Tags: []string{}}, false},
+		{"tags with value", Frontmatter{Tags: []string{"a"}}, false},
+		{"description set", Frontmatter{Description: "d"}, false},
+		{"public true", Frontmatter{Public: true}, false},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseFrontmatterFields([]byte(tt.input))
-			if got.Title != tt.want.Title {
-				t.Errorf("Title = %q, want %q", got.Title, tt.want.Title)
-			}
-			if got.Description != tt.want.Description {
-				t.Errorf("Description = %q, want %q", got.Description, tt.want.Description)
-			}
-			if len(got.Tags) != len(tt.want.Tags) {
-				t.Fatalf("Tags = %v, want %v", got.Tags, tt.want.Tags)
-			}
-			for i := range tt.want.Tags {
-				if got.Tags[i] != tt.want.Tags[i] {
-					t.Errorf("Tags[%d] = %q, want %q", i, got.Tags[i], tt.want.Tags[i])
-				}
-			}
-			if got.Slug != tt.want.Slug {
-				t.Errorf("Slug = %q, want %q", got.Slug, tt.want.Slug)
-			}
-			if got.Public != tt.want.Public {
-				t.Errorf("Public = %v, want %v", got.Public, tt.want.Public)
+			if got := tt.f.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseFrontmatterFieldsAdversarial(t *testing.T) {
+func TestParseNoteSuccess(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
-		want  FrontmatterFields
+		want  Frontmatter
+		body  string
 	}{
+		{"empty input", "", Frontmatter{}, ""},
+		{"no frontmatter", "# Hello\n\nBody text.\n", Frontmatter{}, "# Hello\n\nBody text.\n"},
+		{"title only", "---\ntitle: My Note\n---\n\n# Content\n", Frontmatter{Title: "My Note"}, "# Content\n"},
+		{"slug only", "---\nslug: my-slug\n---\n\n# Content\n", Frontmatter{Slug: "my-slug"}, "# Content\n"},
+		{"tags only", "---\ntags: [work, planning]\n---\n\n# Content\n", Frontmatter{Tags: []string{"work", "planning"}}, "# Content\n"},
+		{"description only", "---\ndescription: Quick thought\n---\n\n# Content\n", Frontmatter{Description: "Quick thought"}, "# Content\n"},
+		{"public true", "---\npublic: true\n---\n\n# Content\n", Frontmatter{Public: true}, "# Content\n"},
+		{"public absent false", "---\ntitle: T\n---\n\n# Content\n", Frontmatter{Title: "T"}, "# Content\n"},
 		{
-			name: "alias bomb targeting tags is rejected",
+			name:  "all fields",
+			input: "---\ntitle: T\nslug: s\ntags: [a]\ndescription: D\npublic: true\n---\n\n# Content\n",
+			want:  Frontmatter{Title: "T", Slug: "s", Tags: []string{"a"}, Description: "D", Public: true},
+			body:  "# Content\n",
+		},
+		{"unclosed frontmatter treated as no frontmatter", "---\ntitle: Oops\n# Content\n", Frontmatter{}, "---\ntitle: Oops\n# Content\n"},
+		{"int coerced to string", "---\ntitle: 12345\n---\n", Frontmatter{Title: "12345"}, ""},
+		{"null leaves field empty", "---\ntitle: null\nslug: s\n---\n", Frontmatter{Slug: "s"}, ""},
+		{"unknown keys ignored", "---\ntitle: T\nrandom: whatever\nnested: {a: 1}\n---\n", Frontmatter{Title: "T"}, ""},
+		{"empty frontmatter block", "---\n---\n\nBody\n", Frontmatter{}, "Body\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, body, err := ParseNote([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(f, tt.want) {
+				t.Errorf("frontmatter: got %+v, want %+v", f, tt.want)
+			}
+			if string(body) != tt.body {
+				t.Errorf("body: got %q, want %q", string(body), tt.body)
+			}
+		})
+	}
+}
+
+func TestParseNoteErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"unclosed flow sequence", "---\ntitle: T\ntags: [a, b\n---\n\n# Content\n"},
+		{"invalid bool value", "---\npublic: maybe\n---\n\n# Content\n"},
+		{"bad field alongside good", "---\ntitle: T\npublic: maybe\ntags: [a, b]\n---\n\n# Content\n"},
+		{"control character", "---\ntitle: \"A\x00B\"\nslug: s\n---\n"},
+		{"non-mapping top level", "---\n[1, 2, 3]\n---\n"},
+		{"duplicate keys rejected", "---\ntitle: A\ntitle: B\n---\n"},
+		{
+			name: "alias bomb",
 			input: "---\n" +
 				"a: &a [x]\n" +
 				"b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a,*a]\n" +
@@ -164,136 +92,82 @@ func TestParseFrontmatterFieldsAdversarial(t *testing.T) {
 				"tags: *c\n" +
 				"title: T\n" +
 				"---\n",
-			want: FrontmatterFields{Title: "T"},
-		},
-		{
-			name:  "duplicate keys: last value wins",
-			input: "---\ntitle: A\ntitle: B\n---\n",
-			want:  FrontmatterFields{Title: "B"},
-		},
-		{
-			name:  "control characters rejected, siblings dropped",
-			input: "---\ntitle: \"A\x00B\"\nslug: s\n---\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "merge key applied with later override",
-			input: "---\n<<: {title: X}\ntitle: Y\n---\n",
-			want:  FrontmatterFields{Title: "Y"},
-		},
-		{
-			name:  "int value coerced to string for title",
-			input: "---\ntitle: 12345\n---\n",
-			want:  FrontmatterFields{Title: "12345"},
-		},
-		{
-			name:  "null value leaves field empty",
-			input: "---\ntitle: null\nslug: s\n---\n",
-			want:  FrontmatterFields{Slug: "s"},
-		},
-		{
-			name:  "tag list is not a mapping",
-			input: "---\n[1, 2, 3]\n---\n",
-			want:  FrontmatterFields{},
-		},
-		{
-			name:  "unknown keys are ignored",
-			input: "---\ntitle: T\nrandom: whatever\nnested: {a: 1}\n---\n",
-			want:  FrontmatterFields{Title: "T"},
 		},
 	}
-
-	for _, tt := range tests {
+	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseFrontmatterFields([]byte(tt.input))
-			if got.Title != tt.want.Title {
-				t.Errorf("Title = %q, want %q", got.Title, tt.want.Title)
+			f, body, err := ParseNote([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error, got f=%+v body=%q", f, string(body))
 			}
-			if got.Slug != tt.want.Slug {
-				t.Errorf("Slug = %q, want %q", got.Slug, tt.want.Slug)
+			if !f.IsZero() {
+				t.Errorf("expected zero Frontmatter on error, got %+v", f)
 			}
-			if len(got.Tags) != len(tt.want.Tags) {
-				t.Errorf("Tags = %v, want %v", got.Tags, tt.want.Tags)
-			}
-			if got.Public != tt.want.Public {
-				t.Errorf("Public = %v, want %v", got.Public, tt.want.Public)
+			if body != nil {
+				t.Errorf("expected nil body on error, got %q", string(body))
 			}
 		})
 	}
 }
 
-func TestBuildFrontmatter(t *testing.T) {
-	tests := []struct {
-		name   string
-		fields FrontmatterFields
-		want   string
-	}{
-		{
-			name: "empty",
-			want: "",
-		},
-		{
-			name:   "tags only",
-			fields: FrontmatterFields{Tags: []string{"journal", "idea"}},
-			want:   "---\ntags:\n    - journal\n    - idea\n---\n\n",
-		},
-		{
-			name:   "description only",
-			fields: FrontmatterFields{Description: "Quick thought"},
-			want:   "---\ndescription: Quick thought\n---\n\n",
-		},
-		{
-			name: "all fields",
-			fields: FrontmatterFields{
-				Title:       "Weekly Review",
-				Tags:        []string{"review"},
-				Description: "Week 10",
-			},
-			want: "---\ntitle: Weekly Review\ntags:\n    - review\ndescription: Week 10\n---\n\n",
-		},
-		{
-			name:   "single tag",
-			fields: FrontmatterFields{Tags: []string{"journal"}},
-			want:   "---\ntags:\n    - journal\n---\n\n",
-		},
-		{
-			name:   "title only",
-			fields: FrontmatterFields{Title: "My Note"},
-			want:   "---\ntitle: My Note\n---\n\n",
-		},
-		{
-			name:   "slug only",
-			fields: FrontmatterFields{Slug: "my-slug"},
-			want:   "---\nslug: my-slug\n---\n\n",
-		},
-		{
-			name:   "public true",
-			fields: FrontmatterFields{Public: true},
-			want:   "---\npublic: true\n---\n\n",
-		},
-		{
-			name:   "public false omitted",
-			fields: FrontmatterFields{Title: "T"},
-			want:   "---\ntitle: T\n---\n\n",
-		},
-		{
-			name: "all fields including slug and public",
-			fields: FrontmatterFields{
-				Title:       "T",
-				Slug:        "s",
-				Tags:        []string{"a"},
-				Description: "D",
-				Public:      true,
-			},
-			want: "---\ntitle: T\nslug: s\ntags:\n    - a\ndescription: D\npublic: true\n---\n\n",
-		},
+func TestParseNoteBodyIsSliceOfInput(t *testing.T) {
+	input := []byte("---\ntitle: T\n---\n\nhello\n")
+	_, body, err := ParseNote(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+	if len(body) == 0 {
+		t.Fatal("body is empty")
+	}
+	if &body[0] != &input[len(input)-len(body)] {
+		t.Error("body is not a sub-slice of input (extra allocation)")
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := BuildFrontmatter(tt.fields)
-			if got != tt.want {
-				t.Errorf("BuildFrontmatter(%+v) =\n%q\nwant:\n%q", tt.fields, got, tt.want)
+func TestFormatNoteSnapshotAllFields(t *testing.T) {
+	f := Frontmatter{
+		Title:       "T",
+		Slug:        "s",
+		Tags:        []string{"a"},
+		Description: "D",
+		Public:      true,
+	}
+	want := "---\ntitle: T\nslug: s\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
+	got := string(FormatNote(f, []byte("body\n")))
+	if got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFormatNoteEmptyFrontmatter(t *testing.T) {
+	if got := string(FormatNote(Frontmatter{}, []byte("body\n"))); got != "body\n" {
+		t.Errorf("got %q, want %q", got, "body\n")
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	cases := []Frontmatter{
+		{},
+		{Title: "T"},
+		{Tags: []string{"a", "b"}},
+		{Tags: []string{"go", "rust, elixir"}},
+		{Tags: []string{"foo: bar", "baz]"}},
+		{Title: "Re: Project update"},
+		{Title: "T", Slug: "s", Tags: []string{"a"}, Public: true},
+		{Title: "T", Slug: "s", Tags: []string{"a"}, Description: "D", Public: true},
+	}
+	for i, fm := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			out := FormatNote(fm, []byte("body\n"))
+			gotF, gotBody, err := ParseNote(out)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if !reflect.DeepEqual(gotF, fm) {
+				t.Errorf("frontmatter: got %+v, want %+v", gotF, fm)
+			}
+			if string(gotBody) != "body\n" {
+				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
 			}
 		})
 	}
@@ -305,84 +179,62 @@ func TestStripFrontmatter(t *testing.T) {
 		input string
 		want  string
 	}{
+		{"no frontmatter", "# Hello\n\nBody text.\n", "# Hello\n\nBody text.\n"},
+		{"with frontmatter", "---\nslug: todo\ntags: [journal]\n---\n\n# Hello\n\nBody text.\n", "# Hello\n\nBody text.\n"},
+		{"frontmatter only", "---\nslug: todo\n---\n", ""},
+		{"empty input", "", ""},
+		{"unclosed frontmatter", "---\nslug: todo\n# Hello\n", "---\nslug: todo\n# Hello\n"},
+		{"triple dash in body not at start", "# Hello\n\n---\n\nFooter.\n", "# Hello\n\n---\n\nFooter.\n"},
+		{"preserves multiple blank lines after frontmatter", "---\nslug: todo\n---\n\n\n\nContent\n", "\n\nContent\n"},
+		{"opening delimiter with trailing text", "---extra\nslug: x\n---\n\nBody\n", "---extra\nslug: x\n---\n\nBody\n"},
+		{"opening delimiter only no newline", "---", "---"},
+		{"opening delimiter only with newline", "---\nstuff\n", "---\nstuff\n"},
+		{"empty frontmatter block", "---\n---\n\nBody\n", "Body\n"},
+		{"malformed yaml still stripped", "---\n[bad: yaml\n---\n\nBody\n", "Body\n"},
+		{"multiple closing delimiters", "---\na\n---\nb\n---\n\nBody\n", "b\n---\n\nBody\n"},
 		{
-			name:  "no frontmatter",
-			input: "# Hello\n\nBody text.\n",
-			want:  "# Hello\n\nBody text.\n",
-		},
-		{
-			name:  "with frontmatter",
-			input: "---\nslug: todo\ntags: [journal]\n---\n\n# Hello\n\nBody text.\n",
-			want:  "# Hello\n\nBody text.\n",
-		},
-		{
-			name:  "frontmatter only",
-			input: "---\nslug: todo\n---\n",
-			want:  "",
-		},
-		{
-			name:  "empty input",
-			input: "",
-			want:  "",
-		},
-		{
-			name:  "unclosed frontmatter",
-			input: "---\nslug: todo\n# Hello\n",
-			want:  "---\nslug: todo\n# Hello\n",
-		},
-		{
-			name:  "triple dash in body not at start",
-			input: "# Hello\n\n---\n\nFooter.\n",
-			want:  "# Hello\n\n---\n\nFooter.\n",
-		},
-		{
-			name:  "preserves multiple blank lines after frontmatter",
-			input: "---\nslug: todo\n---\n\n\n\nContent\n",
-			want:  "\n\nContent\n",
-		},
-		{
-			name:  "opening delimiter with trailing text",
-			input: "---extra\nslug: x\n---\n\nBody\n",
-			want:  "---extra\nslug: x\n---\n\nBody\n",
-		},
-		{
-			name:  "opening delimiter only no newline",
-			input: "---",
-			want:  "---",
-		},
-		{
-			name:  "opening delimiter only with newline",
-			input: "---\nstuff\n",
-			want:  "---\nstuff\n",
-		},
-		{
-			name:  "empty frontmatter block",
-			input: "---\n---\n\nBody\n",
-			want:  "Body\n",
-		},
-		{
-			name:  "malformed yaml in frontmatter",
-			input: "---\n[bad: yaml\n---\n\nBody\n",
-			want:  "Body\n",
-		},
-		{
-			name:  "multiple closing delimiters",
-			input: "---\na\n---\nb\n---\n\nBody\n",
-			want:  "b\n---\n\nBody\n",
-		},
-		{
-			name:  "roundtrip with BuildFrontmatter",
-			input: BuildFrontmatter(FrontmatterFields{Tags: []string{"journal"}, Description: "A note"}) + "# Content\n",
+			name:  "roundtrip with FormatNote",
+			input: string(FormatNote(Frontmatter{Tags: []string{"journal"}, Description: "A note"}, []byte("# Content\n"))),
 			want:  "# Content\n",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := string(StripFrontmatter([]byte(tt.input)))
 			if got != tt.want {
-				t.Errorf("StripFrontmatter(%q) =\n%q\nwant:\n%q", tt.input, got, tt.want)
+				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// CRLF: interior body bytes must round-trip through ParseNote. Delimiter
+// lines are LF-only on write; CRLF delimiter lines on read are tolerated.
+func TestParseNoteCRLFInteriorPreserved(t *testing.T) {
+	input := []byte("---\r\ntitle: T\r\ntags:\r\n  - a\r\n  - b\r\n---\r\n\r\nbody line\r\nsecond\r\n")
+	f, body, err := ParseNote(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Title != "T" {
+		t.Errorf("Title = %q", f.Title)
+	}
+	if len(f.Tags) != 2 || f.Tags[0] != "a" || f.Tags[1] != "b" {
+		t.Errorf("Tags = %v", f.Tags)
+	}
+	want := "body line\r\nsecond\r\n"
+	if string(body) != want {
+		t.Errorf("body: got %q, want %q", string(body), want)
+	}
+}
+
+func TestFormatNoteWritesLFOnly(t *testing.T) {
+	out := FormatNote(Frontmatter{Title: "T"}, []byte("hello\r\nworld\r\n"))
+	wantPrefix := "---\ntitle: T\n---\n\n"
+	if string(out[:len(wantPrefix)]) != wantPrefix {
+		t.Errorf("delimiter lines not LF-only: %q", string(out[:len(wantPrefix)]))
+	}
+	if string(out[len(wantPrefix):]) != "hello\r\nworld\r\n" {
+		t.Errorf("body modified: %q", string(out[len(wantPrefix):]))
 	}
 }

--- a/note/store.go
+++ b/note/store.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -169,15 +170,21 @@ func Filter(notes []Note, fragment string) []Note {
 }
 
 // FilterByTags returns notes that contain all of the given tags in their frontmatter.
+// Per-note frontmatter parse errors are logged via log.Printf and the note is skipped.
 func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 	var results []Note
 	for _, n := range notes {
-		data, err := os.ReadFile(filepath.Join(root, n.RelPath))
+		path := filepath.Join(root, n.RelPath)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		noteTags := ParseFrontmatterFields(data).Tags
-		if hasAllTags(noteTags, tags) {
+		fm, _, parseErr := ParseNote(data)
+		if parseErr != nil {
+			log.Printf("warn: %s: %v", path, parseErr)
+			continue
+		}
+		if hasAllTags(fm.Tags, tags) {
 			results = append(results, n)
 		}
 	}

--- a/note/tags.go
+++ b/note/tags.go
@@ -2,18 +2,24 @@ package note
 
 import (
 	"bytes"
+	"context"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // ExtractTags scans the note store under root and returns a sorted,
 // deduplicated list of tags. Sources: frontmatter `tags:` fields and body
 // hashtags (#word) in the prose. File reads run concurrently across
-// runtime.NumCPU() workers. Returns a nil slice for an empty store. If any
-// file read fails, the first such error is returned after all workers drain.
+// runtime.NumCPU() workers. Returns a nil slice for an empty store.
+// A per-note frontmatter parse error is logged via log.Printf and the
+// note's frontmatter tags are skipped (body hashtags are still collected).
+// Any file-read error aborts the scan.
 func ExtractTags(root string) ([]string, error) {
 	notes, err := Scan(root)
 	if err != nil {
@@ -28,58 +34,58 @@ func ExtractTags(root string) ([]string, error) {
 		workers = len(notes)
 	}
 
+	g, ctx := errgroup.WithContext(context.Background())
 	jobs := make(chan Note)
-	results := make(chan map[string]struct{}, workers)
-	errCh := make(chan error, workers)
-	var wg sync.WaitGroup
+	var mu sync.Mutex
+	merged := make(map[string]struct{})
+
+	g.Go(func() error {
+		defer close(jobs)
+		for _, n := range notes {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case jobs <- n:
+			}
+		}
+		return nil
+	})
 
 	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		g.Go(func() error {
 			local := make(map[string]struct{})
-			var workerErr error
 			for n := range jobs {
-				data, err := os.ReadFile(filepath.Join(root, n.RelPath))
+				path := filepath.Join(root, n.RelPath)
+				data, err := os.ReadFile(path)
 				if err != nil {
-					if workerErr == nil {
-						workerErr = err
-					}
-					continue
+					return err
 				}
-				for _, t := range ParseFrontmatterFields(data).Tags {
-					if t != "" {
-						local[t] = struct{}{}
+				fm, body, parseErr := ParseNote(data)
+				if parseErr != nil {
+					log.Printf("warn: %s: %v", path, parseErr)
+					body = StripFrontmatter(data)
+				} else {
+					for _, t := range fm.Tags {
+						if t != "" {
+							local[t] = struct{}{}
+						}
 					}
 				}
-				for _, t := range extractHashtags(StripFrontmatter(data)) {
+				for _, t := range extractHashtags(body) {
 					local[t] = struct{}{}
 				}
 			}
-			results <- local
-			errCh <- workerErr
-		}()
+			mu.Lock()
+			for t := range local {
+				merged[t] = struct{}{}
+			}
+			mu.Unlock()
+			return nil
+		})
 	}
 
-	for _, n := range notes {
-		jobs <- n
-	}
-	close(jobs)
-	wg.Wait()
-	close(results)
-	close(errCh)
-
-	for err := range errCh {
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	merged := make(map[string]struct{})
-	for local := range results {
-		for t := range local {
-			merged[t] = struct{}{}
-		}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	out := make([]string, 0, len(merged))

--- a/note/tags.go
+++ b/note/tags.go
@@ -63,12 +63,10 @@ func ExtractTags(root string) ([]string, error) {
 				fm, body, parseErr := ParseNote(data)
 				if parseErr != nil {
 					log.Printf("warn: %s: %v", path, parseErr)
-					body = StripFrontmatter(data)
-				} else {
-					for _, t := range fm.Tags {
-						if t != "" {
-							local[t] = struct{}{}
-						}
+				}
+				for _, t := range fm.Tags {
+					if t != "" {
+						local[t] = struct{}{}
 					}
 				}
 				for _, t := range extractHashtags(body) {

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -174,8 +174,8 @@ func TestExtractTagsMergedAndDeduped(t *testing.T) {
 
 func TestExtractTagsFrontmatterUniqueAcrossStore(t *testing.T) {
 	// The unique tag comes only from frontmatter; body hashtag coverage
-	// differs. A regression in ParseFrontmatterFields integration would
-	// drop fm-unique and fail this test.
+	// differs. A regression in ParseNote integration would drop fm-unique
+	// and fail this test.
 	root := t.TempDir()
 	writeNote(t, root, "2026/01/20260101_1001.md",
 		"---\ntags: [fm-unique]\n---\n\nbody mentions #body-unique only.\n")

--- a/note/todo.go
+++ b/note/todo.go
@@ -118,10 +118,8 @@ func RolloverTasks(prevLines []string) RolloverResult {
 
 // FormatTodoContent formats carried tasks into the new todo file content.
 func FormatTodoContent(tasks []Task) string {
-	fm := BuildFrontmatter(FrontmatterFields{})
-
 	if len(tasks) == 0 {
-		return fm
+		return ""
 	}
 
 	var lines []string
@@ -130,7 +128,7 @@ func FormatTodoContent(tasks []Task) string {
 		lines = append(lines, t.Reassembled(" "))
 	}
 
-	return fm + strings.Join(lines, "\n\n") + "\n"
+	return strings.Join(lines, "\n\n") + "\n"
 }
 
 // FindLatestTodo finds the most recent todo note strictly before the given date.


### PR DESCRIPTION
## Summary

- Replace `ParseFrontmatterFields` / `BuildFrontmatter` / `StripFrontmatter` trio with error-returning `ParseNote` / `FormatNote` pair (plus `StripFrontmatter` kept for `read -F`). Rename `FrontmatterFields` → `Frontmatter`; add `IsZero` method using `reflect.Value.IsZero` so new fields need no parallel edits.
- Surface parse errors in single-note writers (`update`, `annotate`); log warn-and-continue in bulk readers (`FilterByTags`, `ExtractTags`). Duplicate keys, non-mapping top-level, type mismatches, and malformed YAML now all return real errors instead of silently dropping fields.
- Body is returned as a zero-copy sub-slice of the input; CRLF interior bytes round-trip through parsing; `FormatNote` emits LF-only delimiter lines. `frontmatterDelim` is now a real `const`.
- Rewrite `ExtractTags` concurrency using `golang.org/x/sync/errgroup` (~70 lines → ~50). A per-note frontmatter parse error downgrades to body-hashtag-only, logs a warning, and the scan continues.
- Consolidate `note/frontmatter_test.go`: single success table, single error table, one canonical `FormatNote` snapshot, the rest as round-trip assertions; add CRLF coverage.

## References

- closes #112