### PR TITLE
Low-impact review follow-ups (docs, helpers, warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.74] - 2026-04-20
+
+### Changed
+
+- Small code-review follow-ups: `--path` help now documents the `$NOTES_PATH` / `~/notes` default; `notes resolve` Long help clarifies that `--today` is the only filter flag that can combine with a positional argument; `grep`/`rg` subcommands accept `-h` (not just `--help`) for help; frontmatter-parse warnings go to stderr directly instead of through `log.Printf` (no more timestamp prefix); `writeAtomic` is now shared across `update`, `annotate`, `append`, and the prev-todo rewrite in `new-todo` so partial writes never leave a corrupted file behind ([#116])
+
 ## [0.1.73] - 2026-04-19
 
 ### Changed
@@ -459,3 +465,4 @@
 [#110]: https://github.com/dreikanter/notes-cli/issues/110
 [#112]: https://github.com/dreikanter/notes-cli/issues/112
 [#114]: https://github.com/dreikanter/notes-cli/pull/114
+[#116]: https://github.com/dreikanter/notes-cli/pull/116

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -102,13 +102,8 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	merged := mergeAnnotation(existing, gen)
 	newContent := note.FormatNote(merged, body)
 
-	tmpPath := fullPath + ".tmp"
-	if err := os.WriteFile(tmpPath, newContent, 0o644); err != nil {
-		return fmt.Errorf("cannot write note: %w", err)
-	}
-	if err := os.Rename(tmpPath, fullPath); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("cannot rename note: %w", err)
+	if err := writeAtomic(fullPath, newContent); err != nil {
+		return err
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), fullPath)

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -79,8 +79,8 @@ var appendCmd = &cobra.Command{
 		}
 		result := existingStr + "\n" + content + "\n"
 
-		if err := os.WriteFile(targetPath, []byte(result), 0o644); err != nil {
-			return fmt.Errorf("cannot write note: %w", err)
+		if err := writeAtomic(targetPath, []byte(result)); err != nil {
+			return err
 		}
 
 		fmt.Fprintln(cmd.OutOrStdout(), targetPath)

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -21,6 +21,20 @@ type createNoteParams struct {
 	Body        string // initial content after frontmatter
 }
 
+// writeAtomic writes data to path via a tmp+rename so partial writes don't
+// leave a corrupted file behind.
+func writeAtomic(path string, data []byte) error {
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("cannot write note: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("cannot replace note: %w", err)
+	}
+	return nil
+}
+
 // createNote creates a new note file with optional frontmatter and body content.
 // Returns the absolute path to the created file.
 func createNote(p createNoteParams) (string, error) {

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -17,7 +17,7 @@ The following flags are injected automatically: -r (recursive), -i (case-insensi
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, arg := range args {
-			if arg == "--help" {
+			if arg == "--help" || arg == "-h" {
 				return cmd.Help()
 			}
 		}

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -48,7 +48,7 @@ var newTodoCmd = &cobra.Command{
 			result := note.RolloverTasks(prevLines)
 			carriedTasks = result.CarriedTasks
 
-			if err := os.WriteFile(prevPath, []byte(strings.Join(result.UpdatedLines, "\n")), 0o644); err != nil {
+			if err := writeAtomic(prevPath, []byte(strings.Join(result.UpdatedLines, "\n"))); err != nil {
 				return fmt.Errorf("cannot update previous todo: %w", err)
 			}
 		}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -24,8 +24,9 @@ With a positional argument, resolution follows this priority:
   4. Slug substring — most recent note whose slug contains the query
 
 Alternatively, use filter flags (--type, --slug, --tag, --today) for
-explicit attribute-based lookup. Flags cannot be combined with a
-positional argument.`,
+explicit attribute-based lookup. --type, --slug, and --tag cannot be
+combined with a positional argument; --today can, and restricts the
+positional resolution to notes dated today.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()

--- a/internal/cli/rg.go
+++ b/internal/cli/rg.go
@@ -18,7 +18,7 @@ The following flags are injected automatically: --glob *.md, --sortr path, --hea
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, arg := range args {
-			if arg == "--help" {
+			if arg == "--help" || arg == "-h" {
 				return cmd.Help()
 			}
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -27,7 +27,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
-	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (overrides NOTES_PATH env var)")
+	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTES_PATH or ~/notes)")
 }
 
 func Execute() {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -146,20 +146,6 @@ var updateCmd = &cobra.Command{
 	},
 }
 
-// writeAtomic writes data to path via a tmp+rename so partial writes don't
-// leave a corrupted file behind.
-func writeAtomic(path string, data []byte) error {
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
-		return fmt.Errorf("cannot write note: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("cannot replace note: %w", err)
-	}
-	return nil
-}
-
 func init() {
 	updateCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
 	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")

--- a/note/store.go
+++ b/note/store.go
@@ -2,7 +2,6 @@ package note
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -170,7 +169,7 @@ func Filter(notes []Note, fragment string) []Note {
 }
 
 // FilterByTags returns notes that contain all of the given tags in their frontmatter.
-// Per-note frontmatter parse errors are logged via log.Printf and the note is skipped.
+// Per-note frontmatter parse errors are written to stderr and the note is skipped.
 func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 	var results []Note
 	for _, n := range notes {
@@ -181,7 +180,7 @@ func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 		}
 		fm, _, parseErr := ParseNote(data)
 		if parseErr != nil {
-			log.Printf("warn: %s: %v", path, parseErr)
+			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
 			continue
 		}
 		if hasAllTags(fm.Tags, tags) {

--- a/note/tags.go
+++ b/note/tags.go
@@ -3,7 +3,7 @@ package note
 import (
 	"bytes"
 	"context"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,7 +17,7 @@ import (
 // deduplicated list of tags. Sources: frontmatter `tags:` fields and body
 // hashtags (#word) in the prose. File reads run concurrently across
 // runtime.NumCPU() workers. Returns a nil slice for an empty store.
-// A per-note frontmatter parse error is logged via log.Printf and the
+// A per-note frontmatter parse error is written to stderr and the
 // note's frontmatter tags are skipped (body hashtags are still collected).
 // Any file-read error aborts the scan.
 func ExtractTags(root string) ([]string, error) {
@@ -62,7 +62,7 @@ func ExtractTags(root string) ([]string, error) {
 				}
 				fm, body, parseErr := ParseNote(data)
 				if parseErr != nil {
-					log.Printf("warn: %s: %v", path, parseErr)
+					fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
 				}
 				for _, t := range fm.Tags {
 					if t != "" {


### PR DESCRIPTION
## Summary

- Document the `--path` default (`$NOTES_PATH` / `~/notes`) and clarify `notes resolve` Long help (only `--today` can combine with a positional).
- Accept `-h` alongside `--help` in `grep`/`rg` subcommands (they use `DisableFlagParsing`, so this has to be done manually).
- Replace `log.Printf` frontmatter-parse warnings in `note/store.go` and `note/tags.go` with direct `fmt.Fprintf(os.Stderr, ...)` so warnings no longer carry a timestamp prefix.
- Lift `writeAtomic` out of `update.go` into `create.go` and reuse it in `append`, `annotate`, and the prev-todo rewrite in `new-todo` — those three were doing non-atomic or inline-duplicated writes.
- Update CHANGELOG for 0.1.74.

Picked from #115 as the subset that's pure text / one-line / mechanical — no architectural decisions. Skipped the SIGPIPE `signal.Reset` removal after a correctness doubt, and skipped making `--public`/`--private` mutually exclusive on `notes new` because `TestNewPublicPrivateBothPrivateWins` encodes the current override-style behavior as intentional.

## References

- relates to #115