### PR TITLE
Remove no-op SIGPIPE reset in main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.75] - 2026-04-20
+
+### Changed
+
+- Remove `signal.Reset(syscall.SIGPIPE)` from `main`: empirically verified a no-op on Go 1.25 (SIGPIPE behavior is identical with or without the call on both stdout and non-stdout fds), so the line and its `os/signal`/`syscall` imports are dead code. Go's default handler (terminate on fd 1/2, return EPIPE elsewhere) already provides the commented-for behavior ([#118])
+
 ## [0.1.74] - 2026-04-20
 
 ### Changed
@@ -466,3 +472,4 @@
 [#112]: https://github.com/dreikanter/notes-cli/issues/112
 [#114]: https://github.com/dreikanter/notes-cli/pull/114
 [#116]: https://github.com/dreikanter/notes-cli/pull/116
+[#118]: https://github.com/dreikanter/notes-cli/pull/118

--- a/cmd/notes/main.go
+++ b/cmd/notes/main.go
@@ -1,15 +1,9 @@
 package main
 
 import (
-	"os/signal"
-	"syscall"
-
 	"github.com/dreikanter/notes-cli/internal/cli"
 )
 
 func main() {
-	// Let the OS terminate the process on SIGPIPE (conventional
-	// behavior for CLI tools piped through head, less, etc.).
-	signal.Reset(syscall.SIGPIPE)
 	cli.Execute()
 }


### PR DESCRIPTION
## Summary

- Delete `signal.Reset(syscall.SIGPIPE)` from `cmd/notes/main.go` and its now-unused `os/signal` / `syscall` imports.
- Verified empirically on Go 1.25.7 (darwin/arm64) that the call is a no-op: SIGPIPE behavior is identical with and without it.

## Verification

Two minimal Go programs, one with the `signal.Reset` call, one without. Built and run with piped stdout and with a closed non-stdout pipe:

| Scenario | With `signal.Reset` | Without |
|---|---|---|
| Write to closed pipe on non-stdout fd | returns EPIPE, exit 0 | returns EPIPE, exit 0 |
| Write to stdout, reader closed (`./bin \| head -1`) | SIGPIPE, exit 141 | SIGPIPE, exit 141 |

Go's runtime installs its own SIGPIPE handler at startup (terminate on fd 1/2, return EPIPE on other fds). `signal.Reset` only undoes prior `signal.Notify` registrations, and the program never calls `Notify` for SIGPIPE, so there is nothing to undo. The original comment's stated intent ("let the OS terminate on SIGPIPE when piped through head/less") is already the default behavior for stdout/stderr.

This was investigated during #116, over-hedged in the follow-up note on #115, and reverted there. Now re-landed after empirical verification.

## Test plan

- [x] `make build`
- [x] `make lint`
- [x] `make test`

## References

- relates to #115