### PR TITLE
Improve hashtag extraction to avoid URL fragments and chained tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.76] - 2026-04-20
+
+### Changed
+
+- Tighter inline hashtag matching: a `#` preceded by a URL-path byte (`/`, `:`, `.`, `?`, `=`, `&`, `~`, `#`) no longer starts a tag, so fragments like `example.com/#anchor` are left alone; and a tag immediately followed by another `#` (e.g. `#one#two`) is rejected to avoid mid-word false positives ([#119])
+
 ## [0.1.75] - 2026-04-20
 
 ### Changed
@@ -473,3 +479,4 @@
 [#114]: https://github.com/dreikanter/notes-cli/pull/114
 [#116]: https://github.com/dreikanter/notes-cli/pull/116
 [#118]: https://github.com/dreikanter/notes-cli/pull/118
+[#119]: https://github.com/dreikanter/notes-cli/issues/119

--- a/note/tags.go
+++ b/note/tags.go
@@ -103,11 +103,14 @@ func ExtractTags(root string) ([]string, error) {
 //     are not recognised.
 //   - Inline backtick spans on a single line are skipped. An unclosed
 //     backtick suppresses hashtags for the remainder of its line.
-//   - A '#' preceded by a word byte ([A-Za-z0-9_]) is not a tag. The check is
-//     byte-level, so hashtags adjacent to non-ASCII prose (e.g. `café#bar`)
-//     may still be extracted.
+//   - A '#' preceded by a word byte ([A-Za-z0-9_]) or a URL-path byte
+//     (`/`, `:`, `.`, `?`, `=`, `&`, `~`, `#`) is not a tag. This prevents
+//     matches inside URLs (`example.com/#anchor`) and inline chains
+//     (`#one#two`). The check is byte-level, so hashtags adjacent to
+//     non-ASCII prose (e.g. `café#bar`) may still be extracted.
 //   - Tag characters are [A-Za-z0-9_-]; other bytes terminate a tag. A bare
-//     '#' with no following tag byte produces no output.
+//     '#' with no following tag byte produces no output. A tag immediately
+//     followed by another '#' (e.g. `#one#two`) is rejected.
 func extractHashtags(body []byte) []string {
 	var out []string
 	inFence := false
@@ -158,14 +161,14 @@ func extractHashtags(body []byte) []string {
 			if c != '#' || inInline {
 				continue
 			}
-			if j > 0 && isWordByte(line[j-1]) {
+			if j > 0 && !isHashtagBoundaryByte(line[j-1]) {
 				continue
 			}
 			k := j + 1
 			for k < len(line) && isTagByte(line[k]) {
 				k++
 			}
-			if k > j+1 {
+			if k > j+1 && (k == len(line) || line[k] != '#') {
 				out = append(out, string(line[j+1:k]))
 			}
 			j = k - 1
@@ -182,4 +185,18 @@ func isTagByte(c byte) bool {
 func isWordByte(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
 		(c >= '0' && c <= '9') || c == '_'
+}
+
+// isHashtagBoundaryByte reports whether c may legally precede a '#' that
+// starts a hashtag. Word bytes (so `foo#bar` is not a tag) and URL-path
+// bytes (so `example.com/#anchor` is not a tag) are excluded.
+func isHashtagBoundaryByte(c byte) bool {
+	if isWordByte(c) {
+		return false
+	}
+	switch c {
+	case '/', ':', '.', '?', '=', '&', '~', '#':
+		return false
+	}
+	return true
 }

--- a/note/tags.go
+++ b/note/tags.go
@@ -161,7 +161,7 @@ func extractHashtags(body []byte) []string {
 			if c != '#' || inInline {
 				continue
 			}
-			if j > 0 && !isHashtagBoundaryByte(line[j-1]) {
+			if j > 0 && !isHashtagLeadingByte(line[j-1]) {
 				continue
 			}
 			k := j + 1
@@ -187,10 +187,10 @@ func isWordByte(c byte) bool {
 		(c >= '0' && c <= '9') || c == '_'
 }
 
-// isHashtagBoundaryByte reports whether c may legally precede a '#' that
+// isHashtagLeadingByte reports whether c may legally precede a '#' that
 // starts a hashtag. Word bytes (so `foo#bar` is not a tag) and URL-path
 // bytes (so `example.com/#anchor` is not a tag) are excluded.
-func isHashtagBoundaryByte(c byte) bool {
+func isHashtagLeadingByte(c byte) bool {
 	if isWordByte(c) {
 		return false
 	}

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -42,6 +42,12 @@ func TestExtractHashtagsNegative(t *testing.T) {
 		{"word-prefixed", "foo#bar baz"},
 		{"bare hash", "look here: # not-tag"},
 		{"lone hash", "just # alone"},
+		{"url anchor", "https://www.teamviewer.com/en/#screenshotsAnchor"},
+		{"url anchor bare", "see example.com/path/#section for more"},
+		{"backticked tag", "prose `#hashtag` continues"},
+		{"chained hashes", "#one#two"},
+		{"chained three", "prefix #one#two#three suffix"},
+		{"domain anchor", "visit foo.bar/#frag here"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Tighten hashtag matching logic to prevent false positives in URLs and chained hashtag sequences. A `#` preceded by URL-path bytes (`/`, `:`, `.`, `?`, `=`, `&`, `~`, `#`) no longer starts a tag, and tags immediately followed by another `#` are rejected.

This prevents extracting hashtags from:
- URL fragments (e.g., `example.com/#anchor`)
- Chained hashtag sequences (e.g., `#one#two`)

## Changes

- Introduced `isHashtagBoundaryByte()` function to consolidate boundary checking logic for characters that should not precede a hashtag
- Updated hashtag extraction to reject tags followed immediately by another `#`
- Updated documentation to reflect the new behavior
- Added test cases covering URL anchors, chained hashes, and domain fragments

## References

- closes #119

https://claude.ai/code/session_01NrKMUfNntrucmfdrcwFcFn