### PR TITLE
Make tag extraction and filtering case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.77] - 2026-04-20
+
+### Changed
+
+- `notes tags` output and `--tag` filter comparisons are now case-insensitive: tags are lowercased when extracted from frontmatter and body hashtags, and both sides are lowercased when matching `--tag` values against note frontmatter. On-disk frontmatter is left unchanged ([#120])
+
 ## [0.1.76] - 2026-04-20
 
 ### Changed
@@ -480,3 +486,4 @@
 [#116]: https://github.com/dreikanter/notes-cli/pull/116
 [#118]: https://github.com/dreikanter/notes-cli/pull/118
 [#119]: https://github.com/dreikanter/notes-cli/issues/119
+[#120]: https://github.com/dreikanter/notes-cli/issues/120

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -49,6 +49,18 @@ func TestLsWithTag(t *testing.T) {
 	}
 }
 
+func TestLsWithTagMixedCase(t *testing.T) {
+	out, err := runLs(t, "--tag", "WORK")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), out)
+	}
+}
+
 func TestLsTagNoMatch(t *testing.T) {
 	out, err := runLs(t, "--tag", "nonexistent")
 	if err != nil {

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -65,6 +65,27 @@ func TestTagsMergedSourcesSorted(t *testing.T) {
 	}
 }
 
+func TestTagsLowercased(t *testing.T) {
+	root := t.TempDir()
+	writeTagsTestNote(t, root, "2026/01/20260101_1001.md",
+		"---\ntags: [Work, PLANNING]\n---\n\nbody with #Coffee and #WORK.\n")
+
+	out, err := runTags(t, root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.Split(out, "\n")
+	want := []string{"coffee", "planning", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d:\n%s", len(got), len(want), out)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestTagsIgnoresCodeBlocks(t *testing.T) {
 	root := t.TempDir()
 	writeTagsTestNote(t, root, "2026/01/20260101_1001.md",

--- a/note/archive_test.go
+++ b/note/archive_test.go
@@ -173,6 +173,8 @@ func TestFilterByTags(t *testing.T) {
 		{"two tags AND meeting", []string{"work", "meeting"}, 1, []string{"8818"}},
 		{"no match", []string{"nonexistent"}, 0, nil},
 		{"one matching one not", []string{"work", "nonexistent"}, 0, nil},
+		{"uppercase query matches lowercase fm", []string{"WORK"}, 3, []string{"8823", "8818", "8814"}},
+		{"mixed-case query matches", []string{"Meeting"}, 1, []string{"8818"}},
 	}
 
 	for _, tt := range tests {

--- a/note/store.go
+++ b/note/store.go
@@ -168,7 +168,9 @@ func Filter(notes []Note, fragment string) []Note {
 	return results
 }
 
-// FilterByTags returns notes that contain all of the given tags in their frontmatter.
+// FilterByTags returns notes that contain all of the given tags in their
+// frontmatter. Comparison is case-insensitive: both required tags and note
+// frontmatter tags are lowercased before matching.
 // Per-note frontmatter parse errors are written to stderr and the note is skipped.
 func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 	var results []Note
@@ -193,10 +195,10 @@ func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 func hasAllTags(noteTags []string, required []string) bool {
 	set := make(map[string]struct{}, len(noteTags))
 	for _, t := range noteTags {
-		set[t] = struct{}{}
+		set[strings.ToLower(t)] = struct{}{}
 	}
 	for _, r := range required {
-		if _, ok := set[r]; !ok {
+		if _, ok := set[strings.ToLower(r)]; !ok {
 			return false
 		}
 	}

--- a/note/tags.go
+++ b/note/tags.go
@@ -8,14 +8,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
 
 // ExtractTags scans the note store under root and returns a sorted,
-// deduplicated list of tags. Sources: frontmatter `tags:` fields and body
-// hashtags (#word) in the prose. File reads run concurrently across
+// deduplicated, lowercased list of tags. Sources: frontmatter `tags:` fields
+// and body hashtags (#word) in the prose. File reads run concurrently across
 // runtime.NumCPU() workers. Returns a nil slice for an empty store.
 // A per-note frontmatter parse error is written to stderr and the
 // note's frontmatter tags are skipped (body hashtags are still collected).
@@ -66,11 +67,11 @@ func ExtractTags(root string) ([]string, error) {
 				}
 				for _, t := range fm.Tags {
 					if t != "" {
-						local[t] = struct{}{}
+						local[strings.ToLower(t)] = struct{}{}
 					}
 				}
 				for _, t := range extractHashtags(body) {
-					local[t] = struct{}{}
+					local[strings.ToLower(t)] = struct{}{}
 				}
 			}
 			mu.Lock()

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -211,6 +211,23 @@ func TestExtractTagsIgnoresCodeBlocks(t *testing.T) {
 	}
 }
 
+func TestExtractTagsLowercasesMixedCase(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1001.md",
+		"---\ntags: [Work, PLANNING]\n---\n\nbody #Coffee and #coffee.\n")
+	writeNote(t, root, "2026/01/20260102_1002.md",
+		"no fm, #WORK here.\n")
+
+	got, err := ExtractTags(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"coffee", "planning", "work"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
 func TestExtractTagsNonexistentRoot(t *testing.T) {
 	_, err := ExtractTags(filepath.Join(t.TempDir(), "does-not-exist"))
 	if err == nil {


### PR DESCRIPTION
## Summary

Tags are now extracted and compared case-insensitively. When extracting tags from frontmatter and body hashtags, all tags are lowercased. When filtering notes by tag using the `--tag` flag, the comparison is case-insensitive on both sides. On-disk frontmatter remains unchanged.

## References

- closes #120

## Details

### Changes Made

- **`note/tags.go`**: Modified `ExtractTags()` to lowercase tags from both frontmatter and body hashtags using `strings.ToLower()`. Updated docstring to reflect that returned tags are lowercased.

- **`note/store.go`**: Modified `hasAllTags()` to perform case-insensitive tag matching by lowercasing both the note's frontmatter tags and the required filter tags before comparison. Updated `FilterByTags()` docstring to document the case-insensitive behavior.

- **Tests**: Added comprehensive test coverage:
  - `TestTagsLowercased()` in `internal/cli/tags_test.go`: Verifies that mixed-case tags from frontmatter and body hashtags are lowercased in output
  - `TestExtractTagsLowercasesMixedCase()` in `note/tags_test.go`: Tests tag extraction with mixed-case inputs
  - `TestLsWithTagMixedCase()` in `internal/cli/ls_test.go`: Verifies that uppercase tag filters match notes correctly
  - Updated `TestFilterByTags()` in `note/archive_test.go` with test cases for uppercase and mixed-case queries

- **CHANGELOG.md**: Added entry for version 0.1.77 documenting the case-insensitive tag behavior.

### Test Plan

All new unit tests pass and verify the case-insensitive behavior across tag extraction and filtering operations.

https://claude.ai/code/session_01AH6cVYSr1T2UQoPEiQ7i5T