### PR TITLE
Remove hardcoded ~/notes fallback from notes store path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Drop the hardcoded `~/notes` fallback when resolving the notes store path. If neither `--path` nor `$NOTES_PATH` is set, `notes` now exits with `no notes store configured. Set $NOTES_PATH or pass --path` instead of silently scanning a `~/notes` directory that may exist for unrelated reasons. Set `NOTES_PATH` once (e.g. `export NOTES_PATH=~/notes`) to restore the previous behavior ([#117])
+- Drop the hardcoded `~/notes` fallback when resolving the notes store path. If neither `--path` nor `$NOTES_PATH` is set, `notes` now exits with `no notes store configured. Set $NOTES_PATH or pass --path` instead of silently scanning a `~/notes` directory that may exist for unrelated reasons. Set `NOTES_PATH` once (e.g. `export NOTES_PATH=~/notes`) to restore the previous behavior ([#123], [#117])
 
 ## [0.1.77] - 2026-04-20
 
@@ -494,3 +494,4 @@
 [#119]: https://github.com/dreikanter/notes-cli/issues/119
 [#120]: https://github.com/dreikanter/notes-cli/issues/120
 [#117]: https://github.com/dreikanter/notes-cli/issues/117
+[#123]: https://github.com/dreikanter/notes-cli/pull/123

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.78] - 2026-04-20
+
+### Changed
+
+- Drop the hardcoded `~/notes` fallback when resolving the notes store path. If neither `--path` nor `$NOTES_PATH` is set, `notes` now exits with `no notes store configured. Set $NOTES_PATH or pass --path` instead of silently scanning a `~/notes` directory that may exist for unrelated reasons. Set `NOTES_PATH` once (e.g. `export NOTES_PATH=~/notes`) to restore the previous behavior ([#117])
+
 ## [0.1.77] - 2026-04-20
 
 ### Changed
@@ -487,3 +493,4 @@
 [#118]: https://github.com/dreikanter/notes-cli/pull/118
 [#119]: https://github.com/dreikanter/notes-cli/issues/119
 [#120]: https://github.com/dreikanter/notes-cli/issues/120
+[#117]: https://github.com/dreikanter/notes-cli/issues/117

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ The notes store path is resolved in this order:
 
 1. `--path` flag
 2. `NOTES_PATH` environment variable
-3. `~/notes` (default)
+
+If neither is set, `notes` exits with an error. There is no implicit default —
+set `NOTES_PATH` (e.g. `export NOTES_PATH=~/notes`) or pass `--path`.
 
 ## Development
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,7 +28,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
-	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTES_PATH or ~/notes)")
+	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTES_PATH)")
 }
 
 func Execute() {
@@ -43,11 +44,7 @@ func resolveNotesPath() (string, error) {
 	if env := os.Getenv("NOTES_PATH"); env != "" {
 		return env, nil
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine home directory: %w", err)
-	}
-	return filepath.Join(home, "notes"), nil
+	return "", errors.New("no notes store configured. Set $NOTES_PATH or pass --path")
 }
 
 func mustNotesPath() string {


### PR DESCRIPTION
## Summary

Remove the implicit `~/notes` default fallback when resolving the notes store path. The application now requires explicit configuration via either the `--path` flag or `$NOTES_PATH` environment variable, exiting with a clear error message if neither is set.

## Changes

- **root.go**: Updated `resolveNotesPath()` to return an error instead of falling back to `~/notes`. Users must now explicitly set `$NOTES_PATH` or pass `--path`.
- **root.go**: Updated the `--path` flag help text to reflect the new behavior (removed mention of `~/notes` default).
- **README.md**: Updated path resolution documentation to clarify there is no implicit default.
- **CHANGELOG.md**: Added entry documenting this breaking change.

## Rationale

This change prevents the tool from silently using a `~/notes` directory that may exist for unrelated reasons. Users must now explicitly configure their notes store path, making the configuration more intentional and reducing potential confusion.

## References

- Closes #117