### PR TITLE
Refactor update command flag validation and task regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.79] - 2026-04-20
+
+### Changed
+
+- Internal cleanups from the code-review follow-up list (no user-visible behavior change): `notes update`'s "at least one flag" guard now walks `cmd.LocalFlags()` instead of a hand-maintained flag-name slice that had to stay in sync with registrations; `ParseTask`'s regex requires exactly one marker character (`[ ]`, `[x]`, …) instead of accepting zero-or-one, so stray `[]` no longer parses as a task ([#115])
+
 ## [0.1.78] - 2026-04-20
 
 ### Changed
@@ -495,3 +501,4 @@
 [#120]: https://github.com/dreikanter/notes-cli/issues/120
 [#117]: https://github.com/dreikanter/notes-cli/issues/117
 [#123]: https://github.com/dreikanter/notes-cli/pull/123
+[#115]: https://github.com/dreikanter/notes-cli/issues/115

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var updateCmd = &cobra.Command{
@@ -26,18 +27,12 @@ var updateCmd = &cobra.Command{
 		updatePrivate, _ := cmd.Flags().GetBool("private")
 		syncFilename, _ := cmd.Flags().GetBool("sync-filename")
 
-		updateFlags := []string{
-			"tag", "no-tags", "title", "description",
-			"slug", "no-slug", "type", "no-type",
-			"public", "private", "sync-filename",
-		}
 		hasFlag := false
-		for _, name := range updateFlags {
-			if cmd.Flags().Changed(name) {
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Changed {
 				hasFlag = true
-				break
 			}
-		}
+		})
 		if !hasFlag {
 			return fmt.Errorf("at least one update flag is required")
 		}

--- a/note/todo.go
+++ b/note/todo.go
@@ -6,7 +6,7 @@ import (
 )
 
 // taskRe matches lines like "  - [ ] some task" or "[ ] some task".
-var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.?)(\].*)$`)
+var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.)(\].*)$`)
 
 // Task represents a parsed task line from a todo note.
 type Task struct {


### PR DESCRIPTION
## Summary

- Replace hand-maintained flag name slice with dynamic `cmd.LocalFlags().VisitAll()` iteration in the update command's flag validation logic
- Tighten task regex pattern to require exactly one marker character instead of zero-or-one, preventing stray `[]` from parsing as tasks

## References

- relates to #115

## Details

### Update Command Flag Validation
The `notes update` command previously maintained a hardcoded slice of flag names to check if any update flags were provided. This approach was error-prone as it required manual synchronization with flag registrations. The change now uses `cmd.LocalFlags().VisitAll()` to dynamically walk all registered local flags and check their `Changed` status, eliminating the need for manual maintenance.

### Task Regex Pattern
The task regex pattern was updated from `(.?)` (zero-or-one character) to `(.)` (exactly one character) for the marker position. This prevents empty bracket pairs `[]` from incorrectly matching as valid tasks while still accepting all valid task markers like `[ ]`, `[x]`, `[-]`, etc.

Both changes are internal cleanups with no user-visible behavior changes, except that stray `[]` will no longer be parsed as tasks.

https://claude.ai/code/session_018Nemr8FfCo13X3zZfucZsy