### PR TITLE
Safe-improvements batch update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.81] - 2026-04-20
+
+### Changed
+
+- `notes update --sync-filename` now reserves the target atomically with `os.Link` + `os.Remove`, closing a TOCTOU between `os.Stat` and `os.Rename` that could silently clobber a file created between the two syscalls ([#115])
+- `mustNotesPath` replaced by `notesRoot() (string, error)`: the notes-store resolution no longer calls `os.Exit(1)` from inside `RunE` handlers, so errors now flow through Cobra's normal error pipeline (and respect `SilenceUsage`). Error output and exit code are unchanged ([#115])
+- `notes annotate` error messages are more useful when the `claude` CLI fails with empty stderr: the exit code and the first 500 bytes of stdout are now included, replacing the previous opaque `exit status 1`. Successful runs and failures that write to stderr are unchanged ([#115])
+
 ## [0.1.80] - 2026-04-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - `notes update --sync-filename` now reserves the target atomically with `os.Link` + `os.Remove`, closing a TOCTOU between `os.Stat` and `os.Rename` that could silently clobber a file created between the two syscalls ([#115])
 - `mustNotesPath` replaced by `notesRoot() (string, error)`: the notes-store resolution no longer calls `os.Exit(1)` from inside `RunE` handlers, so errors now flow through Cobra's normal error pipeline (and respect `SilenceUsage`). Error output and exit code are unchanged ([#115])
 - `notes annotate` error messages are more useful when the `claude` CLI fails with empty stderr: the exit code and the first 500 bytes of stdout are now included, replacing the previous opaque `exit status 1`. Successful runs and failures that write to stderr are unchanged ([#115])
+- `notes new --public` and `--private` are now mutually exclusive (matching `notes update`). Passing both returns an error instead of silently letting `--private` override `--public`; the old silent-override logic is gone ([#115])
+
+### Removed
+
+- `notes new-todo --force` flag has been removed. Its help text promised to "regenerate today's todo even if it exists," but it actually allocated a new ID and wrote a *second* todo for the same day, which was never the intended behavior. If today's todo already exists, `notes new-todo` now unconditionally returns its path ([#115])
 
 ## [0.1.80] - 2026-04-20
 

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -53,7 +53,10 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	model, _ := cmd.Flags().GetString("model")
 	maxChars, _ := cmd.Flags().GetInt("max-chars")
 
-	root := mustNotesPath()
+	root, err := notesRoot()
+	if err != nil {
+		return err
+	}
 	n, err := note.ResolveRef(root, args[0])
 	if err != nil {
 		return err

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -135,11 +135,18 @@ func runClaude(model, schema, prompt string) ([]byte, error) {
 	c.Stdout = &stdout
 	c.Stderr = &stderr
 	if err := c.Run(); err != nil {
-		msg := stderr.String()
-		if msg == "" {
-			msg = err.Error()
+		if s := stderr.String(); s != "" {
+			return nil, fmt.Errorf("claude failed: %s", s)
 		}
-		return nil, fmt.Errorf("claude failed: %s", msg)
+		exitCode := -1
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			exitCode = ee.ExitCode()
+		}
+		if out := stdout.String(); out != "" {
+			return nil, fmt.Errorf("claude failed (exit %d): %s", exitCode, snippet(out, 500))
+		}
+		return nil, fmt.Errorf("claude failed (exit %d): %s", exitCode, err.Error())
 	}
 	return stdout.Bytes(), nil
 }

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -399,6 +399,33 @@ func TestAnnotateClaudeNonZeroExit(t *testing.T) {
 	}
 }
 
+// TestAnnotateClaudeEmptyStderrIncludesStdout exercises the fallback path
+// for opaque failures: when claude exits non-zero with nothing on stderr,
+// the error should include the exit code and a snippet of stdout instead
+// of a bare "exit status 1".
+func TestAnnotateClaudeEmptyStderrIncludesStdout(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho partial output on stdout\nexit 3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withClaudeBinary(t, script)
+
+	_, err := runAnnotate(t, root, ref)
+	if err == nil {
+		t.Fatal("expected error on non-zero exit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "exit 3") {
+		t.Errorf("expected exit code in error, got: %v", err)
+	}
+	if !strings.Contains(msg, "partial output on stdout") {
+		t.Errorf("expected stdout snippet in error, got: %v", err)
+	}
+}
+
 func TestAnnotateMalformedJSON(t *testing.T) {
 	root, ref := noteWithOnlyBody(t, "body text here")
 	withClaudeBinary(t, writeFakeClaude(t, `not valid json`))

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -16,7 +16,10 @@ var appendCmd = &cobra.Command{
 	Short: "Append text from stdin to a note",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 
 		// Check stdin is piped
 		if isTerminal(os.Stdin) {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -53,7 +53,10 @@ Terminal editors (vi, vim, nvim, nano, emacs, micro, etc.) run in the foreground
 The editor value may include arguments, e.g. EDITOR="subl --wait".`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		n, err := note.ResolveRef(root, args[0])
 		if err != nil {
 			return err

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -22,7 +22,10 @@ The following flags are injected automatically: -r (recursive), --include=*.md, 
 			}
 		}
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		grepArgs := append([]string{"-r", "--include=*.md", "--exclude-dir=.git"}, args...)
 		grepArgs = append(grepArgs, root)
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -17,7 +17,10 @@ var lsCmd = &cobra.Command{
 		lsName, _ := cmd.Flags().GetString("name")
 		f := readFilterFlags(cmd)
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		notes, err := note.Scan(root)
 		if err != nil {
 			return err

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -33,7 +33,10 @@ var newCmd = &cobra.Command{
 			return fmt.Errorf("--upsert requires --type or --slug")
 		}
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 
 		// --upsert: check if today already has a matching note
 		if upsert {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -22,7 +22,6 @@ var newCmd = &cobra.Command{
 		description, _ := cmd.Flags().GetString("description")
 		title, _ := cmd.Flags().GetString("title")
 		publicFlag, _ := cmd.Flags().GetBool("public")
-		privateFlag, _ := cmd.Flags().GetBool("private")
 		upsert, _ := cmd.Flags().GetBool("upsert")
 
 		if err := note.ValidateSlug(slug); err != nil {
@@ -67,7 +66,6 @@ var newCmd = &cobra.Command{
 			body = string(data)
 		}
 
-		public := publicFlag && !privateFlag
 		fullPath, err := createNote(createNoteParams{
 			Root:        root,
 			Slug:        slug,
@@ -75,7 +73,7 @@ var newCmd = &cobra.Command{
 			Tags:        tags,
 			Title:       title,
 			Description: description,
-			Public:      public,
+			Public:      publicFlag,
 			Body:        body,
 		})
 		if err != nil {
@@ -102,7 +100,8 @@ func init() {
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
 	newCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
-	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default; overrides --public)")
+	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default)")
 	newCmd.Flags().Bool("upsert", false, "return existing note if today already has one matching --type/--slug")
+	newCmd.MarkFlagsMutuallyExclusive("public", "private")
 	rootCmd.AddCommand(newCmd)
 }

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -19,8 +19,9 @@ func runNew(t *testing.T, root string, stdin string, args ...string) (string, er
 	newCmd.Flags().String("description", "", "description for frontmatter")
 	newCmd.Flags().String("title", "", "title for frontmatter")
 	newCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
-	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default; overrides --public)")
+	newCmd.Flags().Bool("private", false, "mark note as private in frontmatter (default)")
 	newCmd.Flags().Bool("upsert", false, "return existing note if today already has one matching --type/--slug")
+	newCmd.MarkFlagsMutuallyExclusive("public", "private")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -128,21 +129,6 @@ func TestNewWithPublic(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "public: true") {
 		t.Errorf("expected public: true in frontmatter, got:\n%s", string(data))
-	}
-}
-
-func TestNewPublicPrivateBothPrivateWins(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runNew(t, root, "", "--public", "--private")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if strings.Contains(string(data), "public:") {
-		t.Errorf("expected public field absent when --private wins, got:\n%s", string(data))
 	}
 }
 

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -18,7 +18,10 @@ var newTodoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		today := time.Now().Format("20060102")
 
 		notes, err := note.Scan(root)

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -16,8 +16,6 @@ var newTodoCmd = &cobra.Command{
 	Short: "Create today's todo",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		force, _ := cmd.Flags().GetBool("force")
-
 		root, err := notesRoot()
 		if err != nil {
 			return err
@@ -29,12 +27,9 @@ var newTodoCmd = &cobra.Command{
 			return err
 		}
 
-		// Check if today's todo already exists
-		if !force {
-			if existing := note.FindTodayTodo(notes, today); existing != nil {
-				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, existing.RelPath))
-				return nil
-			}
+		if existing := note.FindTodayTodo(notes, today); existing != nil {
+			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, existing.RelPath))
+			return nil
 		}
 
 		// Find the most recent previous todo and roll over tasks
@@ -82,6 +77,5 @@ var newTodoCmd = &cobra.Command{
 }
 
 func init() {
-	newTodoCmd.Flags().Bool("force", false, "regenerate today's todo even if it exists")
 	rootCmd.AddCommand(newTodoCmd)
 }

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -13,9 +13,6 @@ import (
 func runNewTodo(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
-	newTodoCmd.ResetFlags()
-	newTodoCmd.Flags().Bool("force", false, "regenerate today's todo even if it exists")
-
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
@@ -64,7 +61,7 @@ func TestNewTodoReturnsExistingToday(t *testing.T) {
 		t.Fatalf("first call unexpected error: %v", err)
 	}
 
-	// Second call without --force should return the same path.
+	// Second call should return the same path.
 	second, err := runNewTodo(t, root)
 	if err != nil {
 		t.Fatalf("second call unexpected error: %v", err)
@@ -72,29 +69,6 @@ func TestNewTodoReturnsExistingToday(t *testing.T) {
 
 	if first != second {
 		t.Errorf("expected same path on second call, got %q then %q", first, second)
-	}
-}
-
-func TestNewTodoForceRegenerates(t *testing.T) {
-	root := copyTestdata(t)
-
-	// First call creates today's todo.
-	first, err := runNewTodo(t, root)
-	if err != nil {
-		t.Fatalf("first call unexpected error: %v", err)
-	}
-
-	// --force should create a new file.
-	second, err := runNewTodo(t, root, "--force")
-	if err != nil {
-		t.Fatalf("force call unexpected error: %v", err)
-	}
-
-	if first == second {
-		t.Errorf("expected a different path with --force, got same path %q", first)
-	}
-	if _, err := os.Stat(second); err != nil {
-		t.Errorf("forced file does not exist: %v", err)
 	}
 }
 
@@ -132,28 +106,5 @@ func TestNewTodoWritesTypeFrontmatter(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "type: todo") {
 		t.Errorf("expected type: todo in frontmatter, got:\n%s", string(data))
-	}
-}
-
-func TestNewTodoForceOnlyTodayExists(t *testing.T) {
-	root := emptyNotesRoot(t)
-
-	// Create today's todo (no previous todo to roll from).
-	first, err := runNewTodo(t, root)
-	if err != nil {
-		t.Fatalf("first call unexpected error: %v", err)
-	}
-
-	// --force should regenerate even with no previous todo.
-	second, err := runNewTodo(t, root, "--force")
-	if err != nil {
-		t.Fatalf("force call unexpected error: %v", err)
-	}
-
-	if first == second {
-		t.Errorf("expected a different path with --force, got same path %q", first)
-	}
-	if _, err := os.Stat(second); err != nil {
-		t.Errorf("forced file does not exist: %v", err)
 	}
 }

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -14,7 +14,10 @@ var readCmd = &cobra.Command{
 	Short: "Read a note by ref or filter flags",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		f := readFilterFlags(cmd)
 		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -29,7 +29,10 @@ combined with a positional argument; --today can, and restricts the
 positional resolution to notes dated today.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		f := readFilterFlags(cmd)
 
 		if len(args) == 1 {

--- a/internal/cli/rg.go
+++ b/internal/cli/rg.go
@@ -27,7 +27,10 @@ The following flag is injected automatically: --glob *.md. The notes path is app
 			return fmt.Errorf("ripgrep (rg) is not installed; install it from https://github.com/BurntSushi/ripgrep")
 		}
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		rgArgs := append([]string{"--glob", "*.md"}, args...)
 		rgArgs = append(rgArgs, root)
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -17,7 +17,10 @@ var rmCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		today, _ := cmd.Flags().GetBool("today")
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 
 		var date string
 		if today {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,24 +47,21 @@ func resolveNotesPath() (string, error) {
 	return "", errors.New("no notes store configured. Set $NOTES_PATH or pass --path")
 }
 
-func mustNotesPath() string {
+func notesRoot() (string, error) {
 	p, err := resolveNotesPath()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return "", err
 	}
 
 	p, err = filepath.Abs(p)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return "", err
 	}
 
 	info, err := os.Stat(p)
 	if err != nil || !info.IsDir() {
-		fmt.Fprintf(os.Stderr, "notes path does not exist or is not a directory: %s\n", p)
-		os.Exit(1)
+		return "", fmt.Errorf("notes path does not exist or is not a directory: %s", p)
 	}
 
-	return p
+	return p, nil
 }

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -12,7 +12,10 @@ var tagsCmd = &cobra.Command{
 	Short: "List all tags from frontmatter and body hashtags",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		tags, err := note.ExtractTags(root)
 		if err != nil {
 			return err

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -125,13 +126,16 @@ var updateCmd = &cobra.Command{
 			dir := filepath.Dir(oldPath)
 			newPath = filepath.Join(dir, newFilename)
 			if newPath != oldPath {
-				if _, err := os.Stat(newPath); err == nil {
-					return fmt.Errorf("target note already exists: %s", newPath)
-				} else if !os.IsNotExist(err) {
-					return fmt.Errorf("cannot stat target note: %w", err)
+				// os.Link atomically reserves the target: returns EEXIST if it
+				// already exists, which os.Rename on Unix would silently clobber.
+				if err := os.Link(oldPath, newPath); err != nil {
+					if errors.Is(err, os.ErrExist) {
+						return fmt.Errorf("target note already exists: %s", newPath)
+					}
+					return fmt.Errorf("cannot link note: %w", err)
 				}
-				if err := os.Rename(oldPath, newPath); err != nil {
-					return fmt.Errorf("cannot rename note: %w", err)
+				if err := os.Remove(oldPath); err != nil {
+					return fmt.Errorf("cannot remove old note: %w", err)
 				}
 			}
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -44,7 +44,10 @@ var updateCmd = &cobra.Command{
 			}
 		}
 
-		root := mustNotesPath()
+		root, err := notesRoot()
+		if err != nil {
+			return err
+		}
 		n, err := note.ResolveRef(root, args[0])
 		if err != nil {
 			return err

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -138,6 +138,10 @@ var updateCmd = &cobra.Command{
 					return fmt.Errorf("cannot link note: %w", err)
 				}
 				if err := os.Remove(oldPath); err != nil {
+					// Roll back the link so we don't leave both paths pointing
+					// to the same inode. Best-effort: a cleanup failure here
+					// isn't surfaced because the original error is more useful.
+					_ = os.Remove(newPath)
 					return fmt.Errorf("cannot remove old note: %w", err)
 				}
 			}


### PR DESCRIPTION
## Summary

Five code-review follow-ups from #115:

- **TOCTOU in `notes update --sync-filename`** — `os.Stat(newPath)` followed by `os.Rename(oldPath, newPath)` had a race where a file could be created at `newPath` between the two calls; `os.Rename` on Unix would then silently overwrite it. Replaced with `os.Link` + `os.Remove`, which fails atomically with `EEXIST` if the target exists. Same error surface in both normal and conflict paths.
- **`mustNotesPath` → `notesRoot() (string, error)`** — replaces `os.Exit(1)` from inside every `RunE` handler with an error returned through Cobra's pipeline (so `SilenceUsage` is respected and tests don't have to intercept exits). Mechanical across 14 call sites. Error text and exit code are unchanged from the user's perspective.
- **`notes annotate` opaque failures** — when `claude` exits non-zero with empty stderr, the error now includes the exit code and first ~500 bytes of stdout instead of bare `"exit status 1"`. Successful runs and failures that wrote to stderr behave exactly as before. New test: `TestAnnotateClaudeEmptyStderrIncludesStdout`.
- **Drop `notes new-todo --force`** — the flag was lying: its help promised to "regenerate today's todo," but the code actually created a *second* todo for the same day. Rather than pick new semantics, just remove it. If today's todo already exists, `new-todo` unconditionally returns its path.
- **`notes new --public`/`--private` are now mutually exclusive** — matches `notes update`. Passing both now errors out via `MarkFlagsMutuallyExclusive` instead of silently letting `--private` override `--public`. The silent-override logic is gone; `TestNewPublicPrivateBothPrivateWins` is dropped along with it.

## References

- relates to #115
