### PR TITLE
Fix concurrent ID generation, grep exit codes, and annotate timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.82] - 2026-04-20
+
+### Changed
+
+- `note.NextID` now serializes the id.json read-modify-write across processes via an exclusive `flock` on a sibling `id.json.lock`, so parallel `notes new` / `notes new-todo` runs can no longer duplicate IDs ([#115])
+- `notes grep` and `notes rg` propagate the child process's exit code instead of collapsing every failure to `1`: "no match" (exit 1) is now distinguishable from real tool errors (exit 2+) by the caller ([#115])
+- `notes annotate` now runs the `claude` CLI with a context-bound timeout (default 60s, configurable via `--timeout`), so a hung Claude binary no longer hangs the command indefinitely ([#115])
+
 ## [0.1.81] - 2026-04-20
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -19,12 +19,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
@@ -35,6 +37,8 @@ import (
 var claudeBinary = "claude"
 
 const annotateDefaultModel = "claude-haiku-4-5"
+
+const annotateDefaultTimeout = 60 * time.Second
 
 const annotateSystemPrompt = `You are annotating a personal note stored as a markdown file.
 Generate concise metadata for the provided note body, returning ONLY the fields required by the response schema.
@@ -52,6 +56,7 @@ var annotateCmd = &cobra.Command{
 func annotateRunE(cmd *cobra.Command, args []string) error {
 	model, _ := cmd.Flags().GetString("model")
 	maxChars, _ := cmd.Flags().GetInt("max-chars")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
 
 	root, err := notesRoot()
 	if err != nil {
@@ -92,7 +97,9 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	schema := buildAnnotateSchema(empty)
-	out, err := runClaude(model, schema, prompt)
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
+	out, err := runClaude(ctx, model, schema, prompt)
 	if err != nil {
 		return err
 	}
@@ -114,8 +121,9 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 }
 
 // runClaude executes the Claude Code CLI non-interactively and returns its stdout.
-// Returns a clear error if the binary is not found or exits non-zero.
-func runClaude(model, schema, prompt string) ([]byte, error) {
+// Returns a clear error if the binary is not found, the context is cancelled
+// (e.g. timeout), or the child exits non-zero.
+func runClaude(ctx context.Context, model, schema, prompt string) ([]byte, error) {
 	bin, err := exec.LookPath(claudeBinary)
 	if err != nil {
 		return nil, errors.New("claude CLI not found in PATH")
@@ -130,11 +138,14 @@ func runClaude(model, schema, prompt string) ([]byte, error) {
 		prompt,
 	}
 
-	c := exec.Command(bin, args...)
+	c := exec.CommandContext(ctx, bin, args...)
 	var stdout, stderr bytes.Buffer
 	c.Stdout = &stdout
 	c.Stderr = &stderr
 	if err := c.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, errors.New("claude timed out; pass --timeout to raise the limit")
+		}
 		if s := stderr.String(); s != "" {
 			return nil, fmt.Errorf("claude failed: %s", s)
 		}
@@ -250,5 +261,6 @@ func mergeAnnotation(existing note.Frontmatter, gen annotateResult) note.Frontma
 func init() {
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
+	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond")
 	rootCmd.AddCommand(annotateCmd)
 }

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -18,6 +18,7 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 	annotateCmd.ResetFlags()
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
+	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -371,6 +372,25 @@ func TestAnnotateClaudeNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAnnotateTimeout(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nsleep 5\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withClaudeBinary(t, script)
+
+	_, err := runAnnotate(t, root, ref, "--timeout", "100ms")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout message, got: %v", err)
 	}
 }
 

--- a/internal/cli/grep_test.go
+++ b/internal/cli/grep_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -53,6 +55,13 @@ func TestGrepNoMatch(t *testing.T) {
 	_, err := runGrep(t, "-rl", "zzz_no_match_zzz")
 	if err == nil {
 		t.Fatal("expected error for no matches, got nil")
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError so exit code can be propagated, got %T: %v", err, err)
+	}
+	if ee.ExitCode() != 1 {
+		t.Errorf("grep no-match exit code = %d, want 1", ee.ExitCode())
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 
@@ -33,6 +34,10 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
 		os.Exit(1)
 	}
 }

--- a/note/id.go
+++ b/note/id.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // IDFile represents the id.json file that tracks the last allocated note ID.
@@ -25,8 +26,16 @@ func ReadID(root string) (IDFile, error) {
 	return idf, nil
 }
 
-// NextID reads id.json, increments last_id, writes it back atomically, and returns the new ID.
+// NextID reads id.json, increments last_id, writes it back, and returns the new ID.
+// The read-modify-write is serialized across processes via an exclusive flock on
+// a sibling lockfile (id.json.lock), so concurrent callers cannot duplicate IDs.
 func NextID(root string) (int, error) {
+	unlock, err := lockIDFile(root)
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
+
 	idf, err := ReadID(root)
 	if err != nil {
 		return 0, err
@@ -66,4 +75,22 @@ func WriteID(root string, idf IDFile) error {
 		return fmt.Errorf("cannot rename temp id.json: %w", err)
 	}
 	return nil
+}
+
+// lockIDFile acquires an exclusive flock on id.json.lock in root, blocking until
+// it is available. The returned function releases the lock and closes the file.
+func lockIDFile(root string) (func(), error) {
+	path := filepath.Join(root, "id.json.lock")
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open id lockfile: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("cannot lock id.json: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
 }

--- a/note/id_test.go
+++ b/note/id_test.go
@@ -3,6 +3,8 @@ package note
 import (
 	"os"
 	"path/filepath"
+	"sort"
+	"sync"
 	"testing"
 )
 
@@ -79,6 +81,37 @@ func TestNextIDConsecutive(t *testing.T) {
 	}
 	if id2 != 102 {
 		t.Errorf("second call: got %d, want 102", id2)
+	}
+}
+
+func TestNextIDConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), []byte(`{"last_id": 0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 32
+	ids := make([]int, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id, err := NextID(dir)
+			if err != nil {
+				t.Errorf("NextID failed: %v", err)
+				return
+			}
+			ids[i] = id
+		}(i)
+	}
+	wg.Wait()
+
+	sort.Ints(ids)
+	for i, id := range ids {
+		if id != i+1 {
+			t.Fatalf("ids not contiguous after concurrent NextID calls: %v", ids)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR addresses three issues:

1. **Concurrent ID generation**: `note.NextID` now uses an exclusive `flock` on a sibling `id.json.lock` file to serialize the read-modify-write operation across processes. This prevents parallel `notes new` / `notes new-todo` runs from duplicating IDs. Added `TestNextIDConcurrent` to verify the fix.

2. **Grep exit code propagation**: `notes grep` and `notes rg` now propagate the child process's exit code instead of collapsing all failures to exit code 1. This allows callers to distinguish "no match" (exit 1) from real tool errors (exit 2+). Updated `TestGrepNoMatch` to verify exit code 1 is properly propagated.

3. **Annotate timeout handling**: `notes annotate` now runs the `claude` CLI with a context-bound timeout (default 60s, configurable via `--timeout` flag). This prevents a hung Claude binary from hanging the command indefinitely. Added `TestAnnotateTimeout` to verify timeout behavior.

## References

- #115
- https://claude.ai/code/session_01LVU8XhTic61vmgykEMFC3q

## Test Plan

- `TestNextIDConcurrent`: Spawns 32 concurrent goroutines calling `NextID` and verifies all returned IDs are contiguous (1-32)
- `TestGrepNoMatch`: Verifies grep returns exit code 1 when no matches found
- `TestAnnotateTimeout`: Verifies annotate command times out and returns appropriate error message when claude CLI exceeds timeout