### PR TITLE
Refine id.json locking and annotate --timeout 0 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.83] - 2026-04-20
+
+### Changed
+
+- `note.NextID` now flocks the store root directory instead of a sibling `id.json.lock` file, so no lockfile artifact is left behind after `notes new` / `notes new-todo` runs. Serialization semantics are unchanged ([#115])
+- `notes annotate --timeout 0` now disables the deadline (previously it caused the command to fail immediately), mirroring `--max-chars 0 = no limit` ([#115])
+
 ## [0.1.82] - 2026-04-20
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -97,8 +97,12 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	schema := buildAnnotateSchema(empty)
-	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
-	defer cancel()
+	ctx := cmd.Context()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	out, err := runClaude(ctx, model, schema, prompt)
 	if err != nil {
 		return err
@@ -261,6 +265,6 @@ func mergeAnnotation(existing note.Frontmatter, gen annotateResult) note.Frontma
 func init() {
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
-	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond")
+	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond (0 = no timeout)")
 	rootCmd.AddCommand(annotateCmd)
 }

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -18,7 +18,7 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 	annotateCmd.ResetFlags()
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
-	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond")
+	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond (0 = no timeout)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -391,6 +391,24 @@ func TestAnnotateTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("expected timeout message, got: %v", err)
+	}
+}
+
+// --timeout 0 disables the deadline, so a fake claude that sleeps briefly
+// (shorter than any reasonable default) still completes successfully.
+func TestAnnotateTimeoutZeroDisables(t *testing.T) {
+	root, ref := noteWithOnlyBody(t, "body text here")
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "claude")
+	body := fmt.Sprintf("#!/bin/sh\nsleep 0.1\ncat <<'EOF'\n%s\nEOF\n", annotateSampleEnvelope)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withClaudeBinary(t, script)
+
+	if _, err := runAnnotate(t, root, ref, "--timeout", "0"); err != nil {
+		t.Fatalf("unexpected error with --timeout 0: %v", err)
 	}
 }
 

--- a/note/id.go
+++ b/note/id.go
@@ -28,7 +28,7 @@ func ReadID(root string) (IDFile, error) {
 
 // NextID reads id.json, increments last_id, writes it back, and returns the new ID.
 // The read-modify-write is serialized across processes via an exclusive flock on
-// a sibling lockfile (id.json.lock), so concurrent callers cannot duplicate IDs.
+// the store root directory, so concurrent callers cannot duplicate IDs.
 func NextID(root string) (int, error) {
 	unlock, err := lockIDFile(root)
 	if err != nil {
@@ -77,17 +77,19 @@ func WriteID(root string, idf IDFile) error {
 	return nil
 }
 
-// lockIDFile acquires an exclusive flock on id.json.lock in root, blocking until
-// it is available. The returned function releases the lock and closes the file.
+// lockIDFile acquires an exclusive flock on the store root directory, blocking
+// until it is available. Locking the directory (rather than a sibling lockfile)
+// avoids leaving artifacts behind and sidesteps the unlink-race that cleanable
+// lockfiles suffer from. The returned function releases the lock and closes
+// the file descriptor.
 func lockIDFile(root string) (func(), error) {
-	path := filepath.Join(root, "id.json.lock")
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := os.Open(root)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open id lockfile: %w", err)
+		return nil, fmt.Errorf("cannot open notes root for locking: %w", err)
 	}
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("cannot lock id.json: %w", err)
+		return nil, fmt.Errorf("cannot lock notes root: %w", err)
 	}
 	return func() {
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)

--- a/note/id_test.go
+++ b/note/id_test.go
@@ -113,6 +113,14 @@ func TestNextIDConcurrent(t *testing.T) {
 			t.Fatalf("ids not contiguous after concurrent NextID calls: %v", ids)
 		}
 	}
+
+	// The dir should contain only id.json — no lockfile or temp files.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() != "id.json" {
+			t.Errorf("unexpected file left behind: %s", e.Name())
+		}
+	}
 }
 
 func TestWriteIDAtomic(t *testing.T) {


### PR DESCRIPTION
## Summary

- `note.NextID` now flocks the store root directory instead of a sibling `id.json.lock` file, so no lockfile artifact is left behind. Locking the directory also sidesteps the unlink-race that cleanable lockfiles suffer from (one process holds `flock` on an inode that another process has already unlinked, while a third creates a fresh inode at the same path — all three believe they hold the lock).
- `notes annotate --timeout 0` now disables the deadline instead of failing immediately with `claude timed out`. Matches the existing `--max-chars 0 = no limit` convention.
- Follows up on the refinements requested during review of #127 (merged before these commits landed).

## References

- relates to #115
- follows up #127
