### PR TITLE
Improve filter feedback and respect root directory permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.82] - 2026-04-20
+
+### Changed
+
+- `notes read`, `notes append`, and `notes resolve` now include the effective filters in the "no notes found" error (e.g. `no notes found matching filters: type=[todo] today=true`) so you can tell which filter narrowed too far ([#115])
+- `notes new` and `notes new-todo` now inherit the notes-store root's directory permissions when creating date subdirectories, instead of hardcoding `0o755`, so a `0o700` root is no longer silently widened ([#115])
+
+### Removed
+
+- `notes read --no-frontmatter` no longer has a `-F` short form. Use the long flag ([#115])
+
 ## [0.1.81] - 2026-04-20
 
 ### Changed

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -62,7 +62,7 @@ var appendCmd = &cobra.Command{
 			}
 
 			if len(notes) == 0 {
-				return fmt.Errorf("no notes found matching the given criteria")
+				return fmt.Errorf("no notes found matching filters: %s", f.describe())
 			}
 			targetPath = filepath.Join(root, notes[0].RelPath)
 		} else {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -21,6 +21,18 @@ type createNoteParams struct {
 	Body        string // initial content after frontmatter
 }
 
+// rootDirMode returns the permissions to use when creating subdirectories
+// under root. It inherits root's permissions so MkdirAll doesn't widen a
+// restrictive root (e.g. 0o700), defaulting to 0o700 if root cannot be
+// stat'd.
+func rootDirMode(root string) os.FileMode {
+	info, err := os.Stat(root)
+	if err != nil {
+		return 0o700
+	}
+	return info.Mode().Perm()
+}
+
 // writeAtomic writes data to path via a tmp+rename so partial writes don't
 // leave a corrupted file behind.
 func writeAtomic(path string, data []byte) error {
@@ -48,7 +60,7 @@ func createNote(p createNoteParams) (string, error) {
 	filename := note.NoteFilename(today, id, p.Slug, p.Type)
 	dir := note.NoteDirPath(p.Root, today)
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, rootDirMode(p.Root)); err != nil {
 		return "", fmt.Errorf("cannot create directory %s: %w", dir, err)
 	}
 

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dreikanter/notes-cli/note"
@@ -30,6 +32,25 @@ func (f filterOpts) active() bool {
 
 func (f filterOpts) hasAttributeFilters() bool {
 	return len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
+}
+
+// describe returns a human-readable summary of the active filters, e.g.
+// "type=[todo] today=true". Returns an empty string if no filters are set.
+func (f filterOpts) describe() string {
+	var parts []string
+	if len(f.Types) > 0 {
+		parts = append(parts, fmt.Sprintf("type=[%s]", strings.Join(f.Types, ",")))
+	}
+	if f.Slug != "" {
+		parts = append(parts, fmt.Sprintf("slug=%s", f.Slug))
+	}
+	if len(f.Tags) > 0 {
+		parts = append(parts, fmt.Sprintf("tag=[%s]", strings.Join(f.Tags, ",")))
+	}
+	if f.Today {
+		parts = append(parts, "today=true")
+	}
+	return strings.Join(parts, " ")
 }
 
 // applyFilters applies the common filter pipeline to a list of notes.

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -59,7 +59,7 @@ var newTodoCmd = &cobra.Command{
 
 		filename := note.NoteFilename(today, id, "", "todo")
 		dir := note.NoteDirPath(root, today)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, rootDirMode(root)); err != nil {
 			return fmt.Errorf("cannot create directory %s: %w", dir, err)
 		}
 

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -67,7 +67,7 @@ var readCmd = &cobra.Command{
 
 func registerReadFlags() {
 	addFilterFlags(readCmd)
-	readCmd.Flags().BoolP("no-frontmatter", "F", false, "exclude YAML frontmatter from output")
+	readCmd.Flags().Bool("no-frontmatter", false, "exclude YAML frontmatter from output")
 }
 
 func init() {

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -44,7 +44,7 @@ var readCmd = &cobra.Command{
 			}
 
 			if len(notes) == 0 {
-				return fmt.Errorf("no notes found matching the given criteria")
+				return fmt.Errorf("no notes found matching filters: %s", f.describe())
 			}
 			relPath = notes[0].RelPath
 		} else {

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -65,7 +65,10 @@ positional resolution to notes dated today.`,
 		}
 
 		if len(notes) == 0 {
-			return fmt.Errorf("no notes found matching the given criteria")
+			if f.active() {
+				return fmt.Errorf("no notes found matching filters: %s", f.describe())
+			}
+			return fmt.Errorf("no notes found")
 		}
 
 		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, notes[0].RelPath))


### PR DESCRIPTION
## Summary

- Add `describe()` method to `filterOpts` that generates human-readable filter summaries (e.g., "type=[todo] today=true")
- Update `read`, `append`, and `resolve` commands to include active filters in "no notes found" error messages for better debugging
- Respect root directory permissions when creating date subdirectories in `new` and `new-todo` commands instead of hardcoding `0o755`
- Remove `-F` short form from `read --no-frontmatter` flag, keeping only the long form

## References

- Relates to #115

## Test Plan

Existing tests should cover the new `describe()` method and permission inheritance logic. Manual verification:
- Run `notes read --type=todo` with no matching notes and verify the error includes the filter details
- Create a notes-store root with `0o700` permissions and verify `notes new` respects those permissions
- Verify `notes read --no-frontmatter` still works with the long flag form

https://claude.ai/code/session_01Ehk4R3SgRWvqPy4V1Dr28o