### PR TITLE
Include body hashtags in tag-based filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.85] - 2026-04-21
+
+### Changed
+
+- `notes ls --tag`, `notes read --tag`, `notes append --tag`, and `notes resolve --tag` now match body hashtags (`#tag`) in addition to frontmatter `tags:`, mirroring the sources already used by `notes tags`. Tag-based filtering no longer silently ignores inline hashtags ([#131])
+
 ## [0.1.84] - 2026-04-20
 
 ### Changed
@@ -549,3 +555,4 @@
 [#117]: https://github.com/dreikanter/notes-cli/issues/117
 [#123]: https://github.com/dreikanter/notes-cli/pull/123
 [#115]: https://github.com/dreikanter/notes-cli/issues/115
+[#131]: https://github.com/dreikanter/notes-cli/pull/131

--- a/note/store.go
+++ b/note/store.go
@@ -169,10 +169,11 @@ func Filter(notes []Note, fragment string) []Note {
 	return results
 }
 
-// FilterByTags returns notes that contain all of the given tags in their
-// frontmatter. Comparison is case-insensitive: both required tags and note
-// frontmatter tags are lowercased before matching.
-// Per-note frontmatter parse errors are written to stderr and the note is skipped.
+// FilterByTags returns notes that contain all of the given tags. Tag sources
+// mirror ExtractTags: frontmatter `tags:` fields and body hashtags (#word).
+// Comparison is case-insensitive.
+// A per-note frontmatter parse error is written to stderr and the note's
+// frontmatter tags are skipped (body hashtags are still considered).
 func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 	var results []Note
 	for _, n := range notes {
@@ -181,12 +182,15 @@ func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 		if err != nil {
 			return nil, err
 		}
-		fm, _, parseErr := ParseNote(data)
+		fm, body, parseErr := ParseNote(data)
 		if parseErr != nil {
 			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
-			continue
 		}
-		if hasAllTags(fm.Tags, tags) {
+		hashtags := extractHashtags(body)
+		noteTags := make([]string, 0, len(fm.Tags)+len(hashtags))
+		noteTags = append(noteTags, fm.Tags...)
+		noteTags = append(noteTags, hashtags...)
+		if hasAllTags(noteTags, tags) {
 			results = append(results, n)
 		}
 	}

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -195,6 +195,49 @@ func TestFilterByTags(t *testing.T) {
 	}
 }
 
+func TestFilterByTagsInlineHashtags(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1001.md",
+		"---\ntags: [work]\n---\n\nbody mentions #inline here.\n")
+	writeNote(t, root, "2026/01/20260102_1002.md",
+		"no frontmatter, just #inline body tag.\n")
+	writeNote(t, root, "2026/01/20260103_1003.md",
+		"---\ntags: [work]\n---\n\nno inline tags here.\n")
+
+	notes, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		tags    []string
+		wantIDs []string
+	}{
+		{"inline tag matches fm-only and body-only", []string{"inline"}, []string{"1002", "1001"}},
+		{"fm tag still matches", []string{"work"}, []string{"1003", "1001"}},
+		{"AND across fm and body", []string{"work", "inline"}, []string{"1001"}},
+		{"case-insensitive inline", []string{"INLINE"}, []string{"1002", "1001"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FilterByTags(notes, root, tt.tags)
+			if err != nil {
+				t.Fatalf("FilterByTags(%v) error: %v", tt.tags, err)
+			}
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("FilterByTags(%v) returned %d notes, want %d", tt.tags, len(got), len(tt.wantIDs))
+			}
+			for i, wantID := range tt.wantIDs {
+				if got[i].ID != wantID {
+					t.Errorf("FilterByTags(%v)[%d].ID = %q, want %q", tt.tags, i, got[i].ID, wantID)
+				}
+			}
+		})
+	}
+}
+
 func TestFilterBySlug(t *testing.T) {
 	notes := []Note{
 		{Slug: ""},


### PR DESCRIPTION
## Summary

Extend `FilterByTags` to match both frontmatter `tags:` fields and body hashtags (`#word`), mirroring the behavior of `ExtractTags`. This ensures that tag-based filtering commands (`notes ls --tag`, `notes read --tag`, etc.) no longer silently ignore inline hashtags.

## Changes

- Modified `FilterByTags` to extract and combine hashtags from note bodies alongside frontmatter tags
- Updated docstring to clarify that tag sources now include both frontmatter and body hashtags
- Changed error handling to skip only frontmatter parsing errors while still considering body hashtags
- Added comprehensive test coverage (`TestFilterByTagsInlineHashtags`) validating:
  - Inline hashtags are matched independently
  - Frontmatter tags continue to work
  - AND logic works across both tag sources
  - Tag matching remains case-insensitive

## References

- Closes #129
