### PR TITLE
Improve error resilience and simplify YAML marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.86] - 2026-04-21
+
+### Changed
+
+- `note.ResolveRef` and `note.ResolveRefDate` now return `(Note, error)` instead of `(*Note, error)`, matching the value-return convention of the other store APIs. Callers accessing fields (`n.RelPath`, `n.ID`, etc.) need no changes; nil-vs-zero ambiguity is gone ([#132])
+- `note.Scan` now logs a stderr warning and skips unreadable year/month subdirectories instead of aborting the whole scan. One permission glitch on a single month directory no longer breaks `ls`, `tags`, or `resolve`; root-level `ReadDir` failures still surface as hard errors ([#132])
+- `Frontmatter.MarshalYAML` builds `yaml.Node` values directly (`Tag: "!!str"` / `"!!bool"` / `"!!seq"`) instead of routing strings, bools, and string lists through `(*yaml.Node).Encode` with panic-on-error wrappers. Output is byte-identical; the four impossible-to-reach panic paths are gone ([#132])
+
 ## [0.1.85] - 2026-04-21
 
 ### Changed
@@ -556,3 +564,4 @@
 [#123]: https://github.com/dreikanter/notes-cli/pull/123
 [#115]: https://github.com/dreikanter/notes-cli/issues/115
 [#131]: https://github.com/dreikanter/notes-cli/pull/131
+[#132]: https://github.com/dreikanter/notes-cli/pull/132

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -102,45 +102,37 @@ func (f *Frontmatter) UnmarshalYAML(node *yaml.Node) error {
 func (f Frontmatter) MarshalYAML() (interface{}, error) {
 	node := &yaml.Node{Kind: yaml.MappingNode}
 
-	// Encode cannot fail for string/[]string/bool — matches the panic-on-
-	// impossible stance FormatNote takes for yaml.Marshal.
 	appendString := func(key, value string) {
 		if value == "" {
 			return
 		}
-		valNode := &yaml.Node{}
-		if err := valNode.Encode(value); err != nil {
-			panic(fmt.Sprintf("yaml encode string %q: %v", key, err))
-		}
 		node.Content = append(node.Content,
 			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
-			valNode,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
 		)
 	}
 	appendList := func(key string, value []string) {
 		if len(value) == 0 {
 			return
 		}
-		valNode := &yaml.Node{}
-		if err := valNode.Encode(value); err != nil {
-			panic(fmt.Sprintf("yaml encode list %q: %v", key, err))
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, v := range value {
+			seq.Content = append(seq.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v},
+			)
 		}
 		node.Content = append(node.Content,
 			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
-			valNode,
+			seq,
 		)
 	}
 	appendBool := func(key string, value bool) {
 		if !value {
 			return
 		}
-		valNode := &yaml.Node{}
-		if err := valNode.Encode(value); err != nil {
-			panic(fmt.Sprintf("yaml encode bool %q: %v", key, err))
-		}
 		node.Content = append(node.Content,
 			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
-			valNode,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
 		)
 	}
 

--- a/note/store.go
+++ b/note/store.go
@@ -11,6 +11,8 @@ import (
 
 // Scan enumerates notes under root using the known YYYY/MM/ directory structure.
 // Only directories matching year (all digits) and month (two-digit) patterns are visited.
+// Unreadable year/month subdirectories are logged to stderr and skipped, matching
+// the per-note parse-error behavior, so a single permission glitch can't break ls/tags/resolve.
 func Scan(root string) ([]Note, error) {
 	var notes []Note
 
@@ -27,7 +29,8 @@ func Scan(root string) ([]Note, error) {
 		yearPath := filepath.Join(root, y.Name())
 		months, err := os.ReadDir(yearPath)
 		if err != nil {
-			return nil, err
+			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", yearPath, err)
+			continue
 		}
 
 		for _, m := range months {
@@ -38,7 +41,8 @@ func Scan(root string) ([]Note, error) {
 			monthPath := filepath.Join(yearPath, m.Name())
 			files, err := os.ReadDir(monthPath)
 			if err != nil {
-				return nil, err
+				fmt.Fprintf(os.Stderr, "warn: %s: %v\n", monthPath, err)
+				continue
 			}
 
 			for _, f := range files {

--- a/note/store.go
+++ b/note/store.go
@@ -74,18 +74,18 @@ func Scan(root string) ([]Note, error) {
 //  2. Type with special behavior (todo, backlog, weekly) — most recent match
 //  3. Path — absolute or relative path with separator, exact match under root
 //  4. Slug substring — most recent note whose slug contains the query
-func ResolveRef(root, query string) (*Note, error) {
+func ResolveRef(root, query string) (Note, error) {
 	return ResolveRefDate(root, query, "")
 }
 
 // ResolveRefDate works like ResolveRef but optionally restricts candidates to
 // notes matching the given YYYYMMDD date string. Pass "" to skip date filtering.
-func ResolveRefDate(root, query, date string) (*Note, error) {
+func ResolveRefDate(root, query, date string) (Note, error) {
 	query = strings.TrimSpace(query)
 
 	notes, err := Scan(root)
 	if err != nil {
-		return nil, err
+		return Note{}, err
 	}
 
 	if date != "" {
@@ -96,17 +96,17 @@ func ResolveRefDate(root, query, date string) (*Note, error) {
 	if query != "" && isDigits(query) {
 		for i := range notes {
 			if notes[i].ID == query {
-				return &notes[i], nil
+				return notes[i], nil
 			}
 		}
-		return nil, fmt.Errorf("note not found: %s", query)
+		return Note{}, fmt.Errorf("note not found: %s", query)
 	}
 
 	// Step 2: type — most recent match
 	if HasSpecialBehavior(query) {
 		for i := range notes {
 			if notes[i].Type == query {
-				return &notes[i], nil
+				return notes[i], nil
 			}
 		}
 	}
@@ -115,24 +115,24 @@ func ResolveRefDate(root, query, date string) (*Note, error) {
 	if filepath.IsAbs(query) || strings.ContainsAny(query, "/\\") {
 		rel, err := resolveRelPath(root, query)
 		if err != nil {
-			return nil, err
+			return Note{}, err
 		}
 		for i := range notes {
 			if notes[i].RelPath == rel {
-				return &notes[i], nil
+				return notes[i], nil
 			}
 		}
-		return nil, fmt.Errorf("note not found: %s", query)
+		return Note{}, fmt.Errorf("note not found: %s", query)
 	}
 
 	// Step 4: slug substring — most recent match
 	for i := range notes {
 		if strings.Contains(notes[i].Slug, query) {
-			return &notes[i], nil
+			return notes[i], nil
 		}
 	}
 
-	return nil, fmt.Errorf("note not found: %s", query)
+	return Note{}, fmt.Errorf("note not found: %s", query)
 }
 
 // resolveRelPath converts a path-like query to a note RelPath under root.

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -62,6 +63,41 @@ func TestScanSkipsInvalidFiles(t *testing.T) {
 		if n.BaseName == "random_file" || n.BaseName == "not-a-note" {
 			t.Errorf("Scan should have skipped %q", n.BaseName)
 		}
+	}
+}
+
+// TestScanSkipsUnreadableDir verifies one unreadable month directory doesn't
+// abort the whole scan — readable siblings still enumerate successfully.
+func TestScanSkipsUnreadableDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+
+	root := t.TempDir()
+	good := filepath.Join(root, "2026", "01")
+	if err := os.MkdirAll(good, 0o755); err != nil {
+		t.Fatalf("mkdir good: %v", err)
+	}
+	goodNote := filepath.Join(good, "20260101_1_s.md")
+	if err := os.WriteFile(goodNote, []byte("body\n"), 0o644); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+
+	bad := filepath.Join(root, "2026", "02")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatalf("mkdir bad: %v", err)
+	}
+	if err := os.Chmod(bad, 0o000); err != nil {
+		t.Fatalf("chmod bad: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o755) })
+
+	notes, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan(%q) error: %v", root, err)
+	}
+	if len(notes) != 1 || notes[0].ID != "1" {
+		t.Errorf("Scan = %+v, want 1 note with ID=1", notes)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR makes three key improvements to the note store:

1. **Resilient directory scanning**: `Scan()` now logs warnings and skips unreadable year/month subdirectories instead of aborting the entire scan. This prevents a single permission issue from breaking `ls`, `tags`, or `resolve` commands. Root-level `ReadDir` failures still surface as hard errors.

2. **Simplified return types**: `ResolveRef()` and `ResolveRefDate()` now return `(Note, error)` instead of `(*Note, error)`, matching the value-return convention of other store APIs. This eliminates nil-vs-zero ambiguity while requiring no changes to field access patterns.

3. **Direct YAML node construction**: `Frontmatter.MarshalYAML()` now builds `yaml.Node` values directly with explicit tags (`"!!str"`, `"!!bool"`, `"!!seq"`) instead of routing through `(*yaml.Node).Encode()` with panic-on-error wrappers. Output is byte-identical; four impossible-to-reach panic paths are removed.

## References

- #131
- #115

## Test Plan

Added `TestScanSkipsUnreadableDir` to verify that unreadable month directories are skipped while readable siblings enumerate successfully. The test skips on root to avoid permission bypass. Existing tests continue to pass.

https://claude.ai/code/session_013JzMQQaEGjzTYNZsP2AF1L