### PR TITLE
Clean up dead code from Go quality review

### DIFF
--- a/internal/cli/rg_test.go
+++ b/internal/cli/rg_test.go
@@ -69,7 +69,6 @@ func TestRgExcludesNonMarkdown(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected no matches, got output: %q", out)
 	}
-	_ = out
 }
 
 func TestRgCaseInsensitive(t *testing.T) {

--- a/note/note.go
+++ b/note/note.go
@@ -23,12 +23,11 @@ func HasSpecialBehavior(s string) bool {
 
 // Note represents a single note file in the store.
 type Note struct {
-	RelPath  string // relative path from store root, e.g. "2026/01/20260106_8823.md"
-	Date     string // date as Y...YMMDD, e.g. "20260106"
-	ID       string // "8823"
-	Slug     string // descriptive slug, e.g. "api-redesign", or ""
-	Type     string // type reported by the filename dot-suffix; any string accepted. Frontmatter type is canonical when available.
-	BaseName string // filename without extensions, e.g. "20260106_8823" or "20260102_8814_standup"
+	RelPath string // relative path from store root, e.g. "2026/01/20260106_8823.md"
+	Date    string // date as Y...YMMDD, e.g. "20260106"
+	ID      string // "8823"
+	Slug    string // descriptive slug, e.g. "api-redesign", or ""
+	Type    string // type reported by the filename dot-suffix; any string accepted. Frontmatter type is canonical when available.
 }
 
 // isFilenameCacheSafeType reports whether a note type can round-trip through
@@ -80,11 +79,10 @@ func ParseFilename(baseName string) (Note, error) {
 	}
 
 	return Note{
-		Date:     date,
-		ID:       id,
-		Slug:     slug,
-		Type:     noteType,
-		BaseName: remaining,
+		Date: date,
+		ID:   id,
+		Slug: slug,
+		Type: noteType,
 	}, nil
 }
 

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -6,77 +6,69 @@ import (
 
 func TestParseFilename(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		wantDate     string
-		wantID       string
-		wantSlug     string
-		wantType     string
-		wantBaseName string
-		wantErr      bool
+		name     string
+		input    string
+		wantDate string
+		wantID   string
+		wantSlug string
+		wantType string
+		wantErr  bool
 	}{
 		{
-			name:         "simple without slug or type",
-			input:        "20260106_8823",
-			wantDate:     "20260106",
-			wantID:       "8823",
-			wantSlug:     "",
-			wantType:     "",
-			wantBaseName: "20260106_8823",
+			name:     "simple without slug or type",
+			input:    "20260106_8823",
+			wantDate: "20260106",
+			wantID:   "8823",
+			wantSlug: "",
+			wantType: "",
 		},
 		{
-			name:         "with slug only",
-			input:        "20241203_6973_disable-letter_opener",
-			wantDate:     "20241203",
-			wantID:       "6973",
-			wantSlug:     "disable-letter_opener",
-			wantType:     "",
-			wantBaseName: "20241203_6973_disable-letter_opener",
+			name:     "with slug only",
+			input:    "20241203_6973_disable-letter_opener",
+			wantDate: "20241203",
+			wantID:   "6973",
+			wantSlug: "disable-letter_opener",
+			wantType: "",
 		},
 		{
-			name:         "with type only",
-			input:        "20260102_8814.todo",
-			wantDate:     "20260102",
-			wantID:       "8814",
-			wantSlug:     "",
-			wantType:     "todo",
-			wantBaseName: "20260102_8814",
+			name:     "with type only",
+			input:    "20260102_8814.todo",
+			wantDate: "20260102",
+			wantID:   "8814",
+			wantSlug: "",
+			wantType: "todo",
 		},
 		{
-			name:         "with slug and type",
-			input:        "20260102_8814_standup.todo",
-			wantDate:     "20260102",
-			wantID:       "8814",
-			wantSlug:     "standup",
-			wantType:     "todo",
-			wantBaseName: "20260102_8814_standup",
+			name:     "with slug and type",
+			input:    "20260102_8814_standup.todo",
+			wantDate: "20260102",
+			wantID:   "8814",
+			wantSlug: "standup",
+			wantType: "todo",
 		},
 		{
-			name:         "backlog type",
-			input:        "20260312_9219.backlog",
-			wantDate:     "20260312",
-			wantID:       "9219",
-			wantSlug:     "",
-			wantType:     "backlog",
-			wantBaseName: "20260312_9219",
+			name:     "backlog type",
+			input:    "20260312_9219.backlog",
+			wantDate: "20260312",
+			wantID:   "9219",
+			wantSlug: "",
+			wantType: "backlog",
 		},
 		{
-			name:         "weekly type",
-			input:        "20260312_9219.weekly",
-			wantDate:     "20260312",
-			wantID:       "9219",
-			wantSlug:     "",
-			wantType:     "weekly",
-			wantBaseName: "20260312_9219",
+			name:     "weekly type",
+			input:    "20260312_9219.weekly",
+			wantDate: "20260312",
+			wantID:   "9219",
+			wantSlug: "",
+			wantType: "weekly",
 		},
 		{
-			name:         "unknown dot suffix treated as filename-reported type",
-			input:        "20260312_9219_foo.bar",
-			wantDate:     "20260312",
-			wantID:       "9219",
-			wantSlug:     "foo",
-			wantType:     "bar",
-			wantBaseName: "20260312_9219_foo",
+			name:     "unknown dot suffix treated as filename-reported type",
+			input:    "20260312_9219_foo.bar",
+			wantDate: "20260312",
+			wantID:   "9219",
+			wantSlug: "foo",
+			wantType: "bar",
 		},
 		{
 			// Multi-dot basenames can't come from NoteFilename (unsafe types
@@ -87,13 +79,12 @@ func TestParseFilename(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:         "custom type name (no registry gate)",
-			input:        "20260106_8823.meeting",
-			wantDate:     "20260106",
-			wantID:       "8823",
-			wantSlug:     "",
-			wantType:     "meeting",
-			wantBaseName: "20260106_8823",
+			name:     "custom type name (no registry gate)",
+			input:    "20260106_8823.meeting",
+			wantDate: "20260106",
+			wantID:   "8823",
+			wantSlug: "",
+			wantType: "meeting",
 		},
 		{
 			name:    "missing parts",
@@ -106,22 +97,20 @@ func TestParseFilename(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:         "short year in date",
-			input:        "2026010_1234",
-			wantDate:     "2026010",
-			wantID:       "1234",
-			wantSlug:     "",
-			wantType:     "",
-			wantBaseName: "2026010_1234",
+			name:     "short year in date",
+			input:    "2026010_1234",
+			wantDate: "2026010",
+			wantID:   "1234",
+			wantSlug: "",
+			wantType: "",
 		},
 		{
-			name:         "distant future date",
-			input:        "120260106_8823",
-			wantDate:     "120260106",
-			wantID:       "8823",
-			wantSlug:     "",
-			wantType:     "",
-			wantBaseName: "120260106_8823",
+			name:     "distant future date",
+			input:    "120260106_8823",
+			wantDate: "120260106",
+			wantID:   "8823",
+			wantSlug: "",
+			wantType: "",
 		},
 		{
 			name:    "date too short for MMDD",
@@ -168,9 +157,6 @@ func TestParseFilename(t *testing.T) {
 			}
 			if got.Type != tt.wantType {
 				t.Errorf("Type = %q, want %q", got.Type, tt.wantType)
-			}
-			if got.BaseName != tt.wantBaseName {
-				t.Errorf("BaseName = %q, want %q", got.BaseName, tt.wantBaseName)
 			}
 		})
 	}

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -3,6 +3,7 @@ package note
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,8 +61,8 @@ func TestScanSkipsInvalidFiles(t *testing.T) {
 	}
 
 	for _, n := range notes {
-		if n.BaseName == "random_file" || n.BaseName == "not-a-note" {
-			t.Errorf("Scan should have skipped %q", n.BaseName)
+		if strings.Contains(n.RelPath, "random_file") || strings.Contains(n.RelPath, "not-a-note") {
+			t.Errorf("Scan should have skipped %q", n.RelPath)
 		}
 	}
 }
@@ -162,9 +163,9 @@ func TestResolveRefDateEmptyQueryFiltersByDate(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	notes := []Note{
-		{RelPath: "2026/01/20260106_8823.md", BaseName: "20260106_8823", Type: ""},
-		{RelPath: "2026/01/20260102_8814.todo.md", BaseName: "20260102_8814", Type: "todo"},
-		{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", BaseName: "20241203_6973_disable-letter_opener", Type: ""},
+		{RelPath: "2026/01/20260106_8823.md", Type: ""},
+		{RelPath: "2026/01/20260102_8814.todo.md", Type: "todo"},
+		{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", Type: ""},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Remove the unused `Note.BaseName` field. It was assigned by `ParseFilename` but read only by two test error messages; `RelPath`/`Date`/`ID`/`Slug` already cover note identity.
- Remove a dead `_ = out` line in `TestRgExcludesNonMarkdown` — `out` is already referenced in the preceding `t.Fatalf` format string.

Both changes are atomic commits; `make test` and `make lint` stay clean.

## References

- N/A

https://claude.ai/code/session_01WmqZB81s9ZroGai8GrMKX3