### PR TITLE
Export slug and ID validation utilities for downstream consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.89] - 2026-04-22
+
+### Added
+
+- `note.ExtractHashtags` is now exported (previously unexported `extractHashtags`). Downstream tools (notes-pub, notes-view) can reuse the same body-hashtag extraction rules — fenced code blocks, inline backticks, URL anchors, chained hashes — instead of re-implementing them ([#136])
+- `note.IsID` reports whether a string is a valid notes-cli note ID (non-empty, ASCII digits only). Replaces the ad-hoc `isNoteID` / `IsUID` helpers currently duplicated in consumer projects ([#136])
+- `note.NormalizeSlug` returns an ASCII-lowercase, URL-safe form of a string (non-alphanumeric runs collapse to `-`; leading/trailing dashes stripped). Shared normalization contract for filenames and URL path segments ([#136])
+- `note.DeriveSlug` returns the normalized slug for a note using the fallback chain: frontmatter slug → stem with id prefix stripped → empty. Consolidates the slug-resolution logic that consumers were each inventing ([#136])
+
 ## [0.1.86] - 2026-04-21
 
 ### Changed
@@ -565,3 +574,4 @@
 [#115]: https://github.com/dreikanter/notes-cli/issues/115
 [#131]: https://github.com/dreikanter/notes-cli/pull/131
 [#132]: https://github.com/dreikanter/notes-cli/pull/132
+[#136]: https://github.com/dreikanter/notes-cli/pull/135

--- a/note/note.go
+++ b/note/note.go
@@ -69,7 +69,7 @@ func ParseFilename(baseName string) (Note, error) {
 	}
 
 	id := parts[1]
-	if !isDigits(id) || id == "" {
+	if !IsID(id) {
 		return Note{}, fmt.Errorf("invalid id in filename: %s", baseName)
 	}
 
@@ -107,6 +107,14 @@ func NoteDirPath(root, date string) string {
 	year := date[:len(date)-4]
 	month := date[len(date)-4 : len(date)-2]
 	return filepath.Join(root, year, month)
+}
+
+// IsID reports whether s is a valid notes-cli note ID: a non-empty string
+// consisting only of ASCII digits. Downstream tools use this to detect
+// numeric ID references (e.g. wikilinks, CLI query arguments) without
+// re-implementing the predicate.
+func IsID(s string) bool {
+	return s != "" && isDigits(s)
 }
 
 func isDigits(s string) bool {

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -162,6 +162,32 @@ func TestParseFilename(t *testing.T) {
 	}
 }
 
+func TestIsID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"0", true},
+		{"1", true},
+		{"8823", true},
+		{"0001", true},
+		{"abc", false},
+		{"12a", false},
+		{"a12", false},
+		{"12 ", false},
+		{" 12", false},
+		{"-12", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := IsID(c.in); got != c.want {
+				t.Errorf("IsID(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestHasSpecialBehavior(t *testing.T) {
 	if !HasSpecialBehavior("todo") {
 		t.Error("expected todo to have special behavior")

--- a/note/slug.go
+++ b/note/slug.go
@@ -33,3 +33,29 @@ func NormalizeSlug(s string) string {
 	}
 	return strings.TrimRight(b.String(), "-")
 }
+
+// DeriveSlug returns the normalized slug for a note. Priority:
+//  1. frontmatterSlug if non-empty.
+//  2. stem with the leading id prefix (and the following "_") stripped, when
+//     id is non-empty and stem starts with id. For notes-cli stems of the
+//     form "YYYYMMDD_NNNN[_slug]", callers typically pass the "YYYYMMDD_NNNN"
+//     UID portion as id so the residual is the slug segment.
+//  3. empty.
+//
+// The non-empty result is passed through NormalizeSlug so callers get a
+// single documented normalization contract regardless of source.
+func DeriveSlug(stem, id, frontmatterSlug string) string {
+	raw := frontmatterSlug
+	if raw == "" {
+		residue := stem
+		if id != "" && strings.HasPrefix(residue, id) {
+			residue = strings.TrimPrefix(residue, id)
+			residue = strings.TrimPrefix(residue, "_")
+		}
+		raw = residue
+	}
+	if raw == "" {
+		return ""
+	}
+	return NormalizeSlug(raw)
+}

--- a/note/slug.go
+++ b/note/slug.go
@@ -1,0 +1,35 @@
+package note
+
+import "strings"
+
+// NormalizeSlug returns an ASCII-lowercase, URL-safe form of s suitable for
+// filenames and URL path segments. Rules:
+//   - ASCII uppercase letters are folded to lowercase.
+//   - ASCII letters and digits pass through unchanged.
+//   - Any run of non-alphanumeric bytes (including underscores and non-ASCII
+//     bytes) collapses to a single '-'.
+//   - Leading dashes are dropped; trailing dashes are trimmed.
+//
+// Non-ASCII input does not transliterate — it collapses to '-'. Use this for
+// the slug portion of paths where predictability matters more than fidelity.
+func NormalizeSlug(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	lastDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}

--- a/note/slug_test.go
+++ b/note/slug_test.go
@@ -34,3 +34,72 @@ func TestNormalizeSlug(t *testing.T) {
 		})
 	}
 }
+
+func TestDeriveSlug(t *testing.T) {
+	cases := []struct {
+		name            string
+		stem            string
+		id              string
+		frontmatterSlug string
+		want            string
+	}{
+		{
+			name:            "frontmatter wins over stem",
+			stem:            "20260106_8823_old-slug",
+			id:              "20260106_8823",
+			frontmatterSlug: "New Slug!",
+			want:            "new-slug",
+		},
+		{
+			name: "uid prefix stripped from stem",
+			stem: "20260106_8823_api-redesign",
+			id:   "20260106_8823",
+			want: "api-redesign",
+		},
+		{
+			name: "stem with no trailing slug yields empty",
+			stem: "20260106_8823",
+			id:   "20260106_8823",
+			want: "",
+		},
+		{
+			name: "stem not matching id prefix used as-is",
+			stem: "meeting-notes",
+			id:   "20260106_8823",
+			want: "meeting-notes",
+		},
+		{
+			name: "empty id leaves stem untouched",
+			stem: "raw_stem",
+			id:   "",
+			want: "raw-stem",
+		},
+		{
+			name:            "frontmatter wins with empty stem",
+			stem:            "",
+			id:              "",
+			frontmatterSlug: "fm-slug",
+			want:            "fm-slug",
+		},
+		{
+			name:            "frontmatter normalized",
+			stem:            "",
+			id:              "",
+			frontmatterSlug: "Café Review",
+			want:            "caf-review",
+		},
+		{
+			name: "all inputs empty returns empty",
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DeriveSlug(c.stem, c.id, c.frontmatterSlug)
+			if got != c.want {
+				t.Errorf("DeriveSlug(%q, %q, %q) = %q, want %q",
+					c.stem, c.id, c.frontmatterSlug, got, c.want)
+			}
+		})
+	}
+}

--- a/note/slug_test.go
+++ b/note/slug_test.go
@@ -1,0 +1,36 @@
+package note
+
+import "testing"
+
+func TestNormalizeSlug(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"Hello", "hello"},
+		{"HELLO", "hello"},
+		{"hello world", "hello-world"},
+		{"hello  world", "hello-world"},
+		{"hello_world", "hello-world"},
+		{"hello-world", "hello-world"},
+		{"hello--world", "hello-world"},
+		{"hello!@#world", "hello-world"},
+		{"---leading", "leading"},
+		{"trailing---", "trailing"},
+		{"  spaces  ", "spaces"},
+		{"café", "caf"},
+		{"123abc", "123abc"},
+		{"ABC123", "abc123"},
+		{"API Redesign (v2)", "api-redesign-v2"},
+		{"___", ""},
+		{"!!!", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := NormalizeSlug(c.in); got != c.want {
+				t.Errorf("NormalizeSlug(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/note/store.go
+++ b/note/store.go
@@ -93,7 +93,7 @@ func ResolveRefDate(root, query, date string) (Note, error) {
 	}
 
 	// Step 1: numeric ID — strict, no fallthrough
-	if query != "" && isDigits(query) {
+	if IsID(query) {
 		for i := range notes {
 			if notes[i].ID == query {
 				return notes[i], nil

--- a/note/store.go
+++ b/note/store.go
@@ -190,7 +190,7 @@ func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
 		if parseErr != nil {
 			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
 		}
-		hashtags := extractHashtags(body)
+		hashtags := ExtractHashtags(body)
 		noteTags := make([]string, 0, len(fm.Tags)+len(hashtags))
 		noteTags = append(noteTags, fm.Tags...)
 		noteTags = append(noteTags, hashtags...)

--- a/note/tags.go
+++ b/note/tags.go
@@ -70,7 +70,7 @@ func ExtractTags(root string) ([]string, error) {
 						local[strings.ToLower(t)] = struct{}{}
 					}
 				}
-				for _, t := range extractHashtags(body) {
+				for _, t := range ExtractHashtags(body) {
 					local[strings.ToLower(t)] = struct{}{}
 				}
 			}
@@ -95,7 +95,7 @@ func ExtractTags(root string) ([]string, error) {
 	return out, nil
 }
 
-// extractHashtags scans body text and returns hashtag tokens (without the
+// ExtractHashtags scans body text and returns hashtag tokens (without the
 // leading '#'), preserving source order and including duplicates. Rules:
 //   - Lines whose first non-whitespace content is a run of '#' followed by
 //     whitespace or end-of-line are Markdown headings and are skipped entirely.
@@ -112,7 +112,7 @@ func ExtractTags(root string) ([]string, error) {
 //   - Tag characters are [A-Za-z0-9_-]; other bytes terminate a tag. A bare
 //     '#' with no following tag byte produces no output. A tag immediately
 //     followed by another '#' (e.g. `#one#two`) is rejected.
-func extractHashtags(body []byte) []string {
+func ExtractHashtags(body []byte) []string {
 	var out []string
 	inFence := false
 	fence := []byte("```")

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -23,7 +23,7 @@ func TestExtractHashtagsBasic(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := extractHashtags([]byte(c.in))
+			got := ExtractHashtags([]byte(c.in))
 			if !reflect.DeepEqual(got, c.want) {
 				t.Fatalf("got %v, want %v", got, c.want)
 			}
@@ -51,7 +51,7 @@ func TestExtractHashtagsNegative(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := extractHashtags([]byte(c.in))
+			got := ExtractHashtags([]byte(c.in))
 			if len(got) != 0 {
 				t.Fatalf("expected no tags, got %v", got)
 			}
@@ -62,7 +62,7 @@ func TestExtractHashtagsNegative(t *testing.T) {
 func TestExtractHashtagsInlineCode(t *testing.T) {
 	in := "real #out and `inline #in` and #back"
 	want := []string{"out", "back"}
-	got := extractHashtags([]byte(in))
+	got := ExtractHashtags([]byte(in))
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -71,7 +71,7 @@ func TestExtractHashtagsInlineCode(t *testing.T) {
 func TestExtractHashtagsFencedBlock(t *testing.T) {
 	in := "before #a\n```\n#hidden\n#also-hidden\n```\nafter #b\n"
 	want := []string{"a", "b"}
-	got := extractHashtags([]byte(in))
+	got := ExtractHashtags([]byte(in))
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -80,7 +80,7 @@ func TestExtractHashtagsFencedBlock(t *testing.T) {
 func TestExtractHashtagsFencedBlockWithInfoString(t *testing.T) {
 	in := "top #ok\n```go\n// #comment\n```\nend #done\n"
 	want := []string{"ok", "done"}
-	got := extractHashtags([]byte(in))
+	got := ExtractHashtags([]byte(in))
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -89,7 +89,7 @@ func TestExtractHashtagsFencedBlockWithInfoString(t *testing.T) {
 func TestExtractHashtagsCRLF(t *testing.T) {
 	in := "before #a\r\n```\r\n#hidden\r\n```\r\nafter #b\r\n"
 	want := []string{"a", "b"}
-	got := extractHashtags([]byte(in))
+	got := ExtractHashtags([]byte(in))
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -98,7 +98,7 @@ func TestExtractHashtagsCRLF(t *testing.T) {
 func TestExtractHashtagsBareHash(t *testing.T) {
 	cases := []string{"#", "text # and #", "line #\nnext #"}
 	for _, in := range cases {
-		got := extractHashtags([]byte(in))
+		got := ExtractHashtags([]byte(in))
 		if len(got) != 0 {
 			t.Errorf("input %q: expected no tags, got %v", in, got)
 		}


### PR DESCRIPTION
## Summary

Exports three new public utilities from the `note` package to consolidate slug handling and ID validation logic that downstream tools (notes-pub, notes-view) currently duplicate:

- `IsID(s string) bool` — validates whether a string is a valid notes-cli note ID (non-empty ASCII digits only)
- `NormalizeSlug(s string) string` — converts strings to ASCII-lowercase, URL-safe form suitable for filenames and URL segments (non-alphanumeric runs collapse to `-`, leading/trailing dashes stripped)
- `DeriveSlug(stem, id, frontmatterSlug string) string` — derives a note's slug using a priority chain: frontmatter slug → stem with ID prefix stripped → empty

Also exports `ExtractHashtags` (previously `extractHashtags`) so consumers can reuse the same body-hashtag extraction rules (fenced code blocks, inline backticks, URL anchors, chained hashes).

Updates internal call sites to use the new public APIs.

## References

- relates to #135

https://claude.ai/code/session_01FApye4V7VVa6yVZyVPQyxi