### PR TITLE
Add reserved Date field to Frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.90] - 2026-04-22
+
+### Added
+
+- `note.Frontmatter` now has a reserved `Date time.Time` field (`yaml:"date,omitempty"`). Notes whose `date:` previously landed in `Frontmatter.Extra` now populate the typed field, and consumers no longer need to decode the `yaml.Node` themselves. Round-trip preserves the input format: date-only values (midnight UTC) serialize as `YYYY-MM-DD`; values with a non-zero time-of-day serialize as RFC3339. Consumers that need a date when `date:` is absent should fall back to the UID-derived date from the filename prefix, then file mtime — see `SCHEMA.md` ([#146])
+
 ## [0.1.89] - 2026-04-22
 
 ### Added
@@ -575,3 +581,4 @@
 [#131]: https://github.com/dreikanter/notes-cli/pull/131
 [#132]: https://github.com/dreikanter/notes-cli/pull/132
 [#136]: https://github.com/dreikanter/notes-cli/pull/135
+[#146]: https://github.com/dreikanter/notes-cli/pull/146

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -33,6 +33,17 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 - **Consumers:** notes-cli (filters, rollover), notes-pub / notes-view
   (optional rendering).
 
+### date
+- **Type:** timestamp (YAML `!!timestamp`: `YYYY-MM-DD` or RFC3339)
+- **Semantics:** canonical authored date for the note. Optional; when
+  absent, consumers should fall back to the UID-derived date encoded in
+  the filename prefix (e.g. `20260422_8823.md` → 2026-04-22), and then
+  to file mtime as a last resort. Date-only values (midnight UTC)
+  round-trip as `YYYY-MM-DD`; values with a non-zero time-of-day
+  round-trip in RFC3339.
+- **Consumers:** notes-view (timeline / sidebar sort), notes-pub (feed
+  `<published>` element, archive pages).
+
 ### tags
 - **Type:** list of strings
 - **Semantics:** free-form tags, matched case-sensitively. In-body

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -32,6 +33,7 @@ type Frontmatter struct {
 	Title       string               `yaml:"title,omitempty"`
 	Slug        string               `yaml:"slug,omitempty"`
 	Type        string               `yaml:"type,omitempty"`
+	Date        time.Time            `yaml:"date,omitempty"`
 	Tags        []string             `yaml:"tags,omitempty"`
 	Description string               `yaml:"description,omitempty"`
 	Public      bool                 `yaml:"public,omitempty"`
@@ -40,8 +42,8 @@ type Frontmatter struct {
 
 // IsZero reports whether f has no fields set, including Extra.
 func (f Frontmatter) IsZero() bool {
-	return f.Title == "" && f.Slug == "" && f.Type == "" && len(f.Tags) == 0 &&
-		f.Description == "" && !f.Public && len(f.Extra) == 0
+	return f.Title == "" && f.Slug == "" && f.Type == "" && f.Date.IsZero() &&
+		len(f.Tags) == 0 && f.Description == "" && !f.Public && len(f.Extra) == 0
 }
 
 // UnmarshalYAML decodes a mapping node into f. Reserved keys populate the
@@ -73,6 +75,10 @@ func (f *Frontmatter) UnmarshalYAML(node *yaml.Node) error {
 		case "type":
 			if err := value.Decode(&f.Type); err != nil {
 				return fmt.Errorf("frontmatter type: %w", err)
+			}
+		case "date":
+			if err := value.Decode(&f.Date); err != nil {
+				return fmt.Errorf("frontmatter date: %w", err)
 			}
 		case "tags":
 			if err := value.Decode(&f.Tags); err != nil {
@@ -135,10 +141,30 @@ func (f Frontmatter) MarshalYAML() (interface{}, error) {
 			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
 		)
 	}
+	appendTime := func(key string, value time.Time) {
+		if value.IsZero() {
+			return
+		}
+		// Date-only values (midnight UTC) serialize as YYYY-MM-DD so inputs
+		// written as `date: 2026-04-22` round-trip without gaining a time
+		// component. Values with a non-zero time-of-day use RFC3339.
+		var formatted string
+		if value.Hour() == 0 && value.Minute() == 0 && value.Second() == 0 &&
+			value.Nanosecond() == 0 && value.Location() == time.UTC {
+			formatted = value.Format("2006-01-02")
+		} else {
+			formatted = value.Format(time.RFC3339)
+		}
+		node.Content = append(node.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!timestamp", Value: formatted},
+		)
+	}
 
 	appendString("title", f.Title)
 	appendString("slug", f.Slug)
 	appendString("type", f.Type)
+	appendTime("date", f.Date)
 	appendList("tags", f.Tags)
 	appendString("description", f.Description)
 	appendBool("public", f.Public)

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -21,6 +22,7 @@ func TestFrontmatterIsZero(t *testing.T) {
 		{"tags with value", Frontmatter{Tags: []string{"a"}}, false},
 		{"description set", Frontmatter{Description: "d"}, false},
 		{"public true", Frontmatter{Public: true}, false},
+		{"date set", Frontmatter{Date: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -340,5 +342,106 @@ func TestTypeFieldOrder(t *testing.T) {
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
 	if got != want {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestDateRoundTripDateOnly(t *testing.T) {
+	in := []byte("---\ntitle: T\ndate: 2026-04-22\n---\n\nbody\n")
+	fm, body, err := ParseNote(in)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	want := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	if !fm.Date.Equal(want) {
+		t.Errorf("Date = %v, want %v", fm.Date, want)
+	}
+	if _, ok := fm.Extra["date"]; ok {
+		t.Error("Date should be on the typed field, not in Extra")
+	}
+	out := string(FormatNote(fm, body))
+	wantOut := "---\ntitle: T\ndate: 2026-04-22\n---\n\nbody\n"
+	if out != wantOut {
+		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
+	}
+}
+
+func TestDateRoundTripRFC3339(t *testing.T) {
+	in := []byte("---\ntitle: T\ndate: 2026-04-22T15:30:00Z\n---\n\nbody\n")
+	fm, body, err := ParseNote(in)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	want := time.Date(2026, 4, 22, 15, 30, 0, 0, time.UTC)
+	if !fm.Date.Equal(want) {
+		t.Errorf("Date = %v, want %v", fm.Date, want)
+	}
+	out := string(FormatNote(fm, body))
+	wantOut := "---\ntitle: T\ndate: 2026-04-22T15:30:00Z\n---\n\nbody\n"
+	if out != wantOut {
+		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
+	}
+}
+
+func TestDateFieldOrder(t *testing.T) {
+	fm := Frontmatter{
+		Title: "T", Slug: "s", Type: "meeting",
+		Date: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+		Tags: []string{"a"}, Description: "D", Public: true,
+	}
+	got := string(FormatNote(fm, []byte("body\n")))
+	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
+	if got != want {
+		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// Migration check: a note whose `date:` previously landed in Extra (because
+// `date` was not a reserved key) now populates the typed Date field instead.
+func TestDateMigratesFromExtra(t *testing.T) {
+	in := []byte("---\ntitle: Old note\ndate: 2025-01-15\nfeatured: true\n---\n\nbody\n")
+	fm, _, err := ParseNote(in)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	want := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	if !fm.Date.Equal(want) {
+		t.Errorf("Date = %v, want %v", fm.Date, want)
+	}
+	if _, ok := fm.Extra["date"]; ok {
+		t.Error("date key should not be in Extra after migration")
+	}
+	if _, ok := fm.Extra["featured"]; !ok {
+		t.Error("non-reserved Extra keys should still round-trip")
+	}
+}
+
+func TestDateInvalidRejected(t *testing.T) {
+	in := []byte("---\ntitle: T\ndate: not-a-date\n---\n\nbody\n")
+	_, _, err := ParseNote(in)
+	if err == nil {
+		t.Fatal("expected error for malformed date")
+	}
+}
+
+func TestRoundtripWithDate(t *testing.T) {
+	cases := []Frontmatter{
+		{Date: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)},
+		{Title: "T", Date: time.Date(2026, 4, 22, 15, 30, 0, 0, time.UTC)},
+		{Title: "T", Slug: "s", Date: time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC), Tags: []string{"a"}},
+	}
+	for i, fm := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			out := FormatNote(fm, []byte("body\n"))
+			gotF, gotBody, err := ParseNote(out)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if !gotF.Date.Equal(fm.Date) {
+				t.Errorf("Date: got %v, want %v", gotF.Date, fm.Date)
+			}
+			if string(gotBody) != "body\n" {
+				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds a reserved `Date time.Time` field to `note.Frontmatter`, allowing notes to have a canonical authored date. Previously, `date:` values in frontmatter would land in the `Extra` map, requiring consumers to manually decode the YAML node.

The implementation:
- Adds `Date time.Time` field with `yaml:"date,omitempty"` tag
- Handles both date-only (`YYYY-MM-DD`) and RFC3339 timestamp formats
- Preserves input format on round-trip: date-only values (midnight UTC) serialize as `YYYY-MM-DD`; values with time-of-day serialize as RFC3339
- Migrates existing `date:` entries from `Extra` to the typed field during parsing
- Rejects invalid date values with clear error messages
- Updates `IsZero()` to include the Date field

## References

- Closes #146

https://claude.ai/code/session_01HknXiDrMLzPDmWCvYbvZ5Z