### PR TITLE
Add reserved Aliases field to Frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.91] - 2026-04-22
+
+### Added
+
+- `note.Frontmatter` now has a reserved `Aliases []string` field (`yaml:"aliases,omitempty"`). Notes whose `aliases:` previously landed in `Frontmatter.Extra` now populate the typed field, so downstream publishers (notes-pub permalink redirects, notes-view rename-history resolution) no longer need to decode the `yaml.Node` themselves. notes-cli does not itself consume `aliases` yet; the field is reserved to stabilize the contract and avoid future collisions — see `SCHEMA.md` ([#139])
+
 ## [0.1.90] - 2026-04-22
 
 ### Added
@@ -582,3 +588,4 @@
 [#132]: https://github.com/dreikanter/notes-cli/pull/132
 [#136]: https://github.com/dreikanter/notes-cli/pull/135
 [#146]: https://github.com/dreikanter/notes-cli/pull/146
+[#139]: https://github.com/dreikanter/notes-cli/issues/139

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -51,6 +51,17 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 - **Consumers:** notes-cli (`tags`, filters), notes-pub (tag pages,
   feed), notes-view.
 
+### aliases
+- **Type:** list of strings
+- **Semantics:** prior identifiers for the note — historical slugs,
+  legacy IDs, or alternate names that should continue to resolve to
+  this note after a rename. notes-cli itself does not yet consume this
+  field; it is reserved so downstream publishers can implement
+  permalink redirects and rename-history handling without collision
+  risk.
+- **Consumers:** notes-pub (permalink redirects), notes-view
+  (rename-history resolution).
+
 ### description
 - **Type:** string
 - **Semantics:** short summary; optional.

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -35,6 +35,7 @@ type Frontmatter struct {
 	Type        string               `yaml:"type,omitempty"`
 	Date        time.Time            `yaml:"date,omitempty"`
 	Tags        []string             `yaml:"tags,omitempty"`
+	Aliases     []string             `yaml:"aliases,omitempty"`
 	Description string               `yaml:"description,omitempty"`
 	Public      bool                 `yaml:"public,omitempty"`
 	Extra       map[string]yaml.Node `yaml:"-"`
@@ -43,7 +44,7 @@ type Frontmatter struct {
 // IsZero reports whether f has no fields set, including Extra.
 func (f Frontmatter) IsZero() bool {
 	return f.Title == "" && f.Slug == "" && f.Type == "" && f.Date.IsZero() &&
-		len(f.Tags) == 0 && f.Description == "" && !f.Public && len(f.Extra) == 0
+		len(f.Tags) == 0 && len(f.Aliases) == 0 && f.Description == "" && !f.Public && len(f.Extra) == 0
 }
 
 // UnmarshalYAML decodes a mapping node into f. Reserved keys populate the
@@ -83,6 +84,10 @@ func (f *Frontmatter) UnmarshalYAML(node *yaml.Node) error {
 		case "tags":
 			if err := value.Decode(&f.Tags); err != nil {
 				return fmt.Errorf("frontmatter tags: %w", err)
+			}
+		case "aliases":
+			if err := value.Decode(&f.Aliases); err != nil {
+				return fmt.Errorf("frontmatter aliases: %w", err)
 			}
 		case "description":
 			if err := value.Decode(&f.Description); err != nil {
@@ -166,6 +171,7 @@ func (f Frontmatter) MarshalYAML() (interface{}, error) {
 	appendString("type", f.Type)
 	appendTime("date", f.Date)
 	appendList("tags", f.Tags)
+	appendList("aliases", f.Aliases)
 	appendString("description", f.Description)
 	appendBool("public", f.Public)
 

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -20,6 +20,8 @@ func TestFrontmatterIsZero(t *testing.T) {
 		{"slug set", Frontmatter{Slug: "s"}, false},
 		{"tags empty slice is zero", Frontmatter{Tags: []string{}}, true},
 		{"tags with value", Frontmatter{Tags: []string{"a"}}, false},
+		{"aliases empty slice is zero", Frontmatter{Aliases: []string{}}, true},
+		{"aliases with value", Frontmatter{Aliases: []string{"a"}}, false},
 		{"description set", Frontmatter{Description: "d"}, false},
 		{"public true", Frontmatter{Public: true}, false},
 		{"date set", Frontmatter{Date: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)}, false},
@@ -420,6 +422,93 @@ func TestDateInvalidRejected(t *testing.T) {
 	_, _, err := ParseNote(in)
 	if err == nil {
 		t.Fatal("expected error for malformed date")
+	}
+}
+
+func TestAliasesRoundTrip(t *testing.T) {
+	in := []byte("---\ntitle: T\naliases:\n  - old-slug\n  - even-older\n---\n\nbody\n")
+	fm, body, err := ParseNote(in)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	if len(fm.Aliases) != 2 || fm.Aliases[0] != "old-slug" || fm.Aliases[1] != "even-older" {
+		t.Errorf("Aliases = %v, want [old-slug even-older]", fm.Aliases)
+	}
+	if _, ok := fm.Extra["aliases"]; ok {
+		t.Error("Aliases should be on the typed field, not in Extra")
+	}
+	out := string(FormatNote(fm, body))
+	want := "---\ntitle: T\naliases:\n    - old-slug\n    - even-older\n---\n\nbody\n"
+	if out != want {
+		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, want)
+	}
+}
+
+func TestAliasesFieldOrder(t *testing.T) {
+	fm := Frontmatter{
+		Title: "T", Slug: "s", Type: "meeting",
+		Date:        time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+		Tags:        []string{"a"},
+		Aliases:     []string{"old"},
+		Description: "D", Public: true,
+	}
+	got := string(FormatNote(fm, []byte("body\n")))
+	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\naliases:\n    - old\ndescription: D\npublic: true\n---\n\nbody\n"
+	if got != want {
+		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// Migration check: a note whose `aliases:` previously landed in Extra now
+// populates the typed Aliases field instead, and non-reserved Extra keys
+// continue to round-trip.
+func TestAliasesMigratesFromExtra(t *testing.T) {
+	in := []byte("---\ntitle: Old note\naliases:\n  - prior-slug\n  - legacy-id\nfeatured: true\n---\n\nbody\n")
+	fm, _, err := ParseNote(in)
+	if err != nil {
+		t.Fatalf("ParseNote: %v", err)
+	}
+	want := []string{"prior-slug", "legacy-id"}
+	if !reflect.DeepEqual(fm.Aliases, want) {
+		t.Errorf("Aliases = %v, want %v", fm.Aliases, want)
+	}
+	if _, ok := fm.Extra["aliases"]; ok {
+		t.Error("aliases key should not be in Extra after migration")
+	}
+	if _, ok := fm.Extra["featured"]; !ok {
+		t.Error("non-reserved Extra keys should still round-trip")
+	}
+}
+
+func TestAliasesInvalidRejected(t *testing.T) {
+	in := []byte("---\ntitle: T\naliases: not-a-list\n---\n\nbody\n")
+	_, _, err := ParseNote(in)
+	if err == nil {
+		t.Fatal("expected error for non-list aliases")
+	}
+}
+
+func TestRoundtripWithAliases(t *testing.T) {
+	cases := []Frontmatter{
+		{Aliases: []string{"a"}},
+		{Title: "T", Aliases: []string{"old-slug", "prior"}},
+		{Title: "T", Slug: "new", Aliases: []string{"old"}, Tags: []string{"x"}},
+		{Aliases: []string{"contains: colon", "brackets]"}},
+	}
+	for i, fm := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			out := FormatNote(fm, []byte("body\n"))
+			gotF, gotBody, err := ParseNote(out)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if !reflect.DeepEqual(gotF.Aliases, fm.Aliases) {
+				t.Errorf("Aliases: got %v, want %v", gotF.Aliases, fm.Aliases)
+			}
+			if string(gotBody) != "body\n" {
+				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Promote `aliases` from `Frontmatter.Extra` to a reserved `Aliases []string` field on `note.Frontmatter`, so downstream publishers (notes-pub permalink redirects, notes-view rename-history) no longer need to decode the `yaml.Node` themselves
- Cover the new field in `UnmarshalYAML` (migrates existing `aliases:` keys out of `Extra`), `MarshalYAML` (fixed field order), and `IsZero`
- Add round-trip, field-order, migration-from-`Extra`, invalid-input, and special-character tests
- Document the reserved key in `SCHEMA.md` and add a `CHANGELOG.md` entry for `0.1.91`

## References

- closes #139