### PR TITLE
Add lenient scan mode to discover notes regardless of directory layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.91] - 2026-04-22
+
+### Added
+
+- `note.ScanOptions{Strict bool}` and a variadic `Scan(root string, opts ...ScanOptions) ([]Note, error)` signature let callers opt into a lenient walk. The default (no options, or `Strict: true`) preserves the existing YYYY/MM/*.md discipline; `Strict: false` walks every `.md` file under root with `filepath.WalkDir` regardless of nesting depth or parent-directory naming, matching the layout downstream tools like notes-view consume. Existing `Scan(root)` callers are unaffected ([#141])
+
 ## [0.1.90] - 2026-04-22
 
 ### Added
@@ -582,3 +588,4 @@
 [#132]: https://github.com/dreikanter/notes-cli/pull/132
 [#136]: https://github.com/dreikanter/notes-cli/pull/135
 [#146]: https://github.com/dreikanter/notes-cli/pull/146
+[#141]: https://github.com/dreikanter/notes-cli/issues/141

--- a/note/store.go
+++ b/note/store.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,11 +10,43 @@ import (
 	"strings"
 )
 
-// Scan enumerates notes under root using the known YYYY/MM/ directory structure.
-// Only directories matching year (all digits) and month (two-digit) patterns are visited.
-// Unreadable year/month subdirectories are logged to stderr and skipped, matching
-// the per-note parse-error behavior, so a single permission glitch can't break ls/tags/resolve.
-func Scan(root string) ([]Note, error) {
+// ScanOptions configures Scan's directory traversal.
+//
+// Strict=true (the default when no options are passed) restricts discovery to
+// the canonical YYYY/MM/*.md layout used by notes-cli: only top-level directories
+// whose name is all digits are considered years, and only their two-digit
+// all-digit subdirectories are considered months. Other entries are ignored.
+//
+// Strict=false walks the entire tree under root with filepath.WalkDir and
+// considers every *.md file whose base name parses via ParseFilename, regardless
+// of nesting depth or parent directory naming. This is the layout downstream
+// tools such as notes-view consume; opt in explicitly when you need it.
+type ScanOptions struct {
+	Strict bool
+}
+
+// Scan enumerates notes under root.
+//
+// Called as Scan(root) it preserves the historical strict YYYY/MM/*.md
+// discipline. Pass ScanOptions{Strict: false} to walk every *.md file under
+// root regardless of layout. Only the first option in opts is consulted;
+// additional values are ignored.
+//
+// Unreadable subdirectories are logged to stderr and skipped in both modes,
+// matching the per-note parse-error behavior, so a single permission glitch
+// can't break ls/tags/resolve.
+func Scan(root string, opts ...ScanOptions) ([]Note, error) {
+	strict := true
+	if len(opts) > 0 {
+		strict = opts[0].Strict
+	}
+	if strict {
+		return scanStrict(root)
+	}
+	return scanLenient(root)
+}
+
+func scanStrict(root string) ([]Note, error) {
 	var notes []Note
 
 	years, err := os.ReadDir(root)
@@ -60,6 +93,50 @@ func Scan(root string) ([]Note, error) {
 				notes = append(notes, n)
 			}
 		}
+	}
+
+	sort.Slice(notes, func(i, j int) bool {
+		return notes[i].RelPath > notes[j].RelPath
+	})
+
+	return notes, nil
+}
+
+func scanLenient(root string) ([]Note, error) {
+	var notes []Note
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if path == root {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, err)
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(d.Name()) != ".md" {
+			return nil
+		}
+		base := strings.TrimSuffix(d.Name(), ".md")
+		n, parseErr := ParseFilename(base)
+		if parseErr != nil {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		n.RelPath = rel
+		notes = append(notes, n)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
 	}
 
 	sort.Slice(notes, func(i, j int) bool {

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -102,6 +102,103 @@ func TestScanSkipsUnreadableDir(t *testing.T) {
 	}
 }
 
+// TestScanStrictExplicit verifies passing ScanOptions{Strict: true} matches the
+// no-options default and continues to ignore non-YYYY layouts.
+func TestScanStrictExplicit(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "body\n")
+	writeNote(t, root, "drafts/20260102_2.md", "body\n")
+	writeNote(t, root, "inbox/2026/01/20260103_3.md", "body\n")
+
+	notes, err := Scan(root, ScanOptions{Strict: true})
+	if err != nil {
+		t.Fatalf("Scan strict error: %v", err)
+	}
+	if len(notes) != 1 || notes[0].ID != "1" {
+		t.Fatalf("Scan strict = %+v, want only ID=1", notes)
+	}
+}
+
+// TestScanLenient verifies Strict=false discovers any *.md note under root,
+// regardless of nesting depth or parent directory naming.
+func TestScanLenient(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "body\n")
+	writeNote(t, root, "drafts/20260102_2_idea.md", "body\n")
+	writeNote(t, root, "inbox/2026/01/20260103_3.md", "body\n")
+	writeNote(t, root, "20260104_4.md", "body\n")
+	writeNote(t, root, "deep/a/b/c/20260105_5_nested.md", "body\n")
+	writeNote(t, root, "drafts/not-a-note.md", "body\n")
+	writeNote(t, root, "drafts/random_file.txt", "body\n")
+
+	notes, err := Scan(root, ScanOptions{Strict: false})
+	if err != nil {
+		t.Fatalf("Scan lenient error: %v", err)
+	}
+
+	// Sort is descending lexicographic on RelPath.
+	wantIDs := []string{"3", "2", "5", "4", "1"}
+	if len(notes) != len(wantIDs) {
+		t.Fatalf("Scan lenient returned %d notes (%+v), want %d", len(notes), notes, len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if notes[i].ID != want {
+			t.Errorf("notes[%d].ID = %q, want %q", i, notes[i].ID, want)
+		}
+	}
+
+	// RelPath should be the path relative to root, preserving the discovered layout.
+	for _, n := range notes {
+		if filepath.IsAbs(n.RelPath) {
+			t.Errorf("RelPath %q is absolute, want relative", n.RelPath)
+		}
+	}
+}
+
+// TestScanLenientDefaultIsStrict guards the contract that Scan(root) without
+// options stays strict — only the canonical YYYY/MM/*.md layout is enumerated.
+func TestScanLenientDefaultIsStrict(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "body\n")
+	writeNote(t, root, "drafts/20260102_2.md", "body\n")
+
+	notes, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan default error: %v", err)
+	}
+	if len(notes) != 1 || notes[0].ID != "1" {
+		t.Fatalf("default Scan = %+v, want only ID=1 (strict)", notes)
+	}
+}
+
+// TestScanLenientSkipsUnreadableDir verifies one unreadable subdirectory is
+// logged and skipped without aborting the lenient walk.
+func TestScanLenientSkipsUnreadableDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+
+	root := t.TempDir()
+	writeNote(t, root, "drafts/20260101_1.md", "body\n")
+
+	bad := filepath.Join(root, "locked")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatalf("mkdir bad: %v", err)
+	}
+	if err := os.Chmod(bad, 0o000); err != nil {
+		t.Fatalf("chmod bad: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o755) })
+
+	notes, err := Scan(root, ScanOptions{Strict: false})
+	if err != nil {
+		t.Fatalf("Scan lenient error: %v", err)
+	}
+	if len(notes) != 1 || notes[0].ID != "1" {
+		t.Errorf("Scan lenient = %+v, want 1 note with ID=1", notes)
+	}
+}
+
 func TestResolveRef(t *testing.T) {
 	root := testdataPath(t)
 	absPath := filepath.Join(root, "2026/01/20260106_8823_999.md")


### PR DESCRIPTION
## Summary

Adds `ScanOptions` configuration and a variadic `Scan()` signature to support both strict and lenient directory traversal modes:

- **Strict mode** (default): Preserves existing behavior—only discovers notes in the canonical `YYYY/MM/*.md` layout
- **Lenient mode** (`Strict: false`): Uses `filepath.WalkDir` to discover all `*.md` files under root regardless of nesting depth or parent directory naming, matching the layout consumed by downstream tools like notes-view

The default behavior is unchanged; existing `Scan(root)` callers continue to enforce the strict YYYY/MM discipline. Callers can opt into lenient mode by passing `ScanOptions{Strict: false}`.

Both modes handle unreadable directories gracefully by logging warnings to stderr and continuing the walk, preventing permission issues from breaking operations.

## References

- closes #141

https://claude.ai/code/session_014xqEyPZf7Um4ZzgXCiXsqh