### PR TITLE
Add date resolution helpers for notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
 
-## [0.1.91] - 2026-04-22
+## [0.1.93] - 2026-04-22
+
+### Added
+
+- `note.Note.Time()` parses the UID-derived `Date` prefix (YYYYMMDD) into a `time.Time` at midnight UTC, returning `false` on malformed input. `note.ResolveEntryDate(n Note, fm Frontmatter, fi fs.FileInfo)` picks a canonical date for a note and returns its source label, walking the documented priority: UID-derived date (`"uid"`) → frontmatter `date` (`"frontmatter"`) → file mtime (`"mtime"`). Pass `fi == nil` to skip the mtime fallback. Downstream consumers (notes-pub, notes-view) no longer need to re-implement the chain ([#149])
+
+## [0.1.92] - 2026-04-22
 
 ### Added
 
 - `note.ScanOptions{Strict bool}` and a variadic `Scan(root string, opts ...ScanOptions) ([]Note, error)` signature let callers opt into a lenient walk. The default (no options, or `Strict: true`) preserves the existing YYYY/MM/*.md discipline; `Strict: false` walks every `.md` file under root with `filepath.WalkDir` regardless of nesting depth or parent-directory naming, matching the layout downstream tools like notes-view consume. Existing `Scan(root)` callers are unaffected ([#141])
+
+## [0.1.91] - 2026-04-22
+
+### Added
+
 - `note.Frontmatter` now has a reserved `Aliases []string` field (`yaml:"aliases,omitempty"`). Notes whose `aliases:` previously landed in `Frontmatter.Extra` now populate the typed field, so downstream publishers (notes-pub permalink redirects, notes-view rename-history resolution) no longer need to decode the `yaml.Node` themselves. notes-cli does not itself consume `aliases` yet; the field is reserved to stabilize the contract and avoid future collisions — see `SCHEMA.md` ([#139])
 
 ## [0.1.90] - 2026-04-22
@@ -588,6 +599,7 @@
 [#131]: https://github.com/dreikanter/notes-cli/pull/131
 [#132]: https://github.com/dreikanter/notes-cli/pull/132
 [#136]: https://github.com/dreikanter/notes-cli/pull/135
-[#146]: https://github.com/dreikanter/notes-cli/pull/146
-[#141]: https://github.com/dreikanter/notes-cli/issues/141
 [#139]: https://github.com/dreikanter/notes-cli/issues/139
+[#141]: https://github.com/dreikanter/notes-cli/issues/141
+[#146]: https://github.com/dreikanter/notes-cli/pull/146
+[#149]: https://github.com/dreikanter/notes-cli/pull/149

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -41,6 +41,10 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
   to file mtime as a last resort. Date-only values (midnight UTC)
   round-trip as `YYYY-MM-DD`; values with a non-zero time-of-day
   round-trip in RFC3339.
+- **Resolution:** `note.ResolveEntryDate` implements the canonical
+  priority — UID-derived date (`"uid"`) → frontmatter `date`
+  (`"frontmatter"`) → file mtime (`"mtime"`) — and returns the source
+  label so callers can surface or override the choice.
 - **Consumers:** notes-view (timeline / sidebar sort), notes-pub (feed
   `<published>` element, archive pages).
 

--- a/note/date.go
+++ b/note/date.go
@@ -1,0 +1,44 @@
+package note
+
+import (
+	"io/fs"
+	"time"
+)
+
+// Time parses Note.Date (the UID-derived YYYYMMDD prefix) to a time.Time at
+// midnight UTC. It returns false when Date is not a valid YYYYMMDD value;
+// values outside the canonical 8-character form (e.g. short or long years)
+// are reported as malformed even though ParseFilename accepts them.
+func (n Note) Time() (time.Time, bool) {
+	t, err := time.ParseInLocation("20060102", n.Date, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// ResolveEntryDate picks a single canonical date for a note, returning a
+// source label so callers can surface or override the choice.
+//
+// Priority (first match wins):
+//  1. UID-derived date — Note.Date parses cleanly as YYYYMMDD ("uid").
+//  2. Frontmatter date — fm.Date is non-zero ("frontmatter").
+//  3. File mtime — fi is non-nil ("mtime").
+//
+// fi may be nil to skip the mtime fallback. When no source resolves, the
+// zero time.Time and an empty source label are returned.
+//
+// The signature takes Note and Frontmatter explicitly until the Entry type
+// from #142 lands; callers will then pass entry.Note and entry.Frontmatter.
+func ResolveEntryDate(n Note, fm Frontmatter, fi fs.FileInfo) (time.Time, string) {
+	if t, ok := n.Time(); ok {
+		return t, "uid"
+	}
+	if !fm.Date.IsZero() {
+		return fm.Date, "frontmatter"
+	}
+	if fi != nil {
+		return fi.ModTime(), "mtime"
+	}
+	return time.Time{}, ""
+}

--- a/note/date_test.go
+++ b/note/date_test.go
@@ -1,0 +1,149 @@
+package note
+
+import (
+	"io/fs"
+	"testing"
+	"time"
+)
+
+func TestNoteTime(t *testing.T) {
+	cases := []struct {
+		name   string
+		date   string
+		want   time.Time
+		wantOK bool
+	}{
+		{
+			name:   "valid YYYYMMDD",
+			date:   "20260106",
+			want:   time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+			wantOK: true,
+		},
+		{
+			name:   "leap day",
+			date:   "20240229",
+			want:   time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC),
+			wantOK: true,
+		},
+		{name: "empty", date: ""},
+		{name: "too short", date: "2026010"},
+		{name: "too long", date: "120260106"},
+		{name: "non-numeric", date: "2026010a"},
+		{name: "invalid month", date: "20261301"},
+		{name: "invalid day", date: "20260230"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := Note{Date: tc.date}
+			got, ok := n.Time()
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				if !got.IsZero() {
+					t.Errorf("expected zero time on failure, got %v", got)
+				}
+				return
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("time = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeFileInfo is a minimal fs.FileInfo for mtime-priority tests.
+type fakeFileInfo struct {
+	mtime time.Time
+}
+
+func (f fakeFileInfo) Name() string       { return "" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() fs.FileMode  { return 0 }
+func (f fakeFileInfo) ModTime() time.Time { return f.mtime }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func TestResolveEntryDate(t *testing.T) {
+	uidTime := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+	fmTime := time.Date(2025, 7, 4, 12, 30, 0, 0, time.UTC)
+	mtime := time.Date(2024, 11, 11, 9, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name       string
+		note       Note
+		fm         Frontmatter
+		fi         fs.FileInfo
+		wantTime   time.Time
+		wantSource string
+	}{
+		{
+			name:       "uid wins over frontmatter and mtime",
+			note:       Note{Date: "20260106"},
+			fm:         Frontmatter{Date: fmTime},
+			fi:         fakeFileInfo{mtime: mtime},
+			wantTime:   uidTime,
+			wantSource: "uid",
+		},
+		{
+			name:       "frontmatter when uid malformed",
+			note:       Note{Date: "bogus"},
+			fm:         Frontmatter{Date: fmTime},
+			fi:         fakeFileInfo{mtime: mtime},
+			wantTime:   fmTime,
+			wantSource: "frontmatter",
+		},
+		{
+			name:       "mtime when uid malformed and frontmatter zero",
+			note:       Note{Date: ""},
+			fm:         Frontmatter{},
+			fi:         fakeFileInfo{mtime: mtime},
+			wantTime:   mtime,
+			wantSource: "mtime",
+		},
+		{
+			name:       "nil fi skips mtime fallback",
+			note:       Note{Date: "bad"},
+			fm:         Frontmatter{},
+			fi:         nil,
+			wantTime:   time.Time{},
+			wantSource: "",
+		},
+		{
+			name:       "nil fi still uses uid when valid",
+			note:       Note{Date: "20260106"},
+			fm:         Frontmatter{},
+			fi:         nil,
+			wantTime:   uidTime,
+			wantSource: "uid",
+		},
+		{
+			name:       "nil fi still uses frontmatter when uid malformed",
+			note:       Note{Date: ""},
+			fm:         Frontmatter{Date: fmTime},
+			fi:         nil,
+			wantTime:   fmTime,
+			wantSource: "frontmatter",
+		},
+		{
+			name:       "uid wins even when frontmatter is zero",
+			note:       Note{Date: "20260106"},
+			fm:         Frontmatter{},
+			fi:         fakeFileInfo{mtime: mtime},
+			wantTime:   uidTime,
+			wantSource: "uid",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src := ResolveEntryDate(tc.note, tc.fm, tc.fi)
+			if src != tc.wantSource {
+				t.Errorf("source = %q, want %q", src, tc.wantSource)
+			}
+			if !got.Equal(tc.wantTime) {
+				t.Errorf("time = %v, want %v", got, tc.wantTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add `note.Note.Time()` method to parse the UID-derived YYYYMMDD date prefix into a `time.Time`, and introduce `note.ResolveEntryDate()` function that implements a canonical priority chain for determining a note's date:

1. UID-derived date (Note.Date as YYYYMMDD)
2. Frontmatter date field
3. File modification time (optional)

The function returns both the resolved time and a source label (`"uid"`, `"frontmatter"`, `"mtime"`, or empty string) so callers can surface or override the choice. This eliminates the need for downstream consumers (notes-pub, notes-view) to re-implement this logic.

## References

- closes #147

## Test Plan

Added comprehensive unit tests covering:
- Valid and invalid YYYYMMDD parsing (including leap days)
- All priority chain scenarios with various combinations of UID, frontmatter, and file info
- Edge cases like nil file info and malformed dates

All tests pass.

https://claude.ai/code/session_01CRSuF2P2hcRUCeHy9k9YGF