### PR TITLE
Introduce note.Entry, note.Index, and note.Load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.94] - 2026-04-22
+
+### Added
+
+- `note.Entry`, `note.Index`, and `note.Load` consolidate the per-query `Scan` → `FilterByTags` → `ExtractTags` re-read chain into a single concurrent pass. `Load(root, opts...)` walks the store once, parses frontmatter in parallel (workers default to `runtime.NumCPU()`), and returns an `*Index` with `Root`, `Entries`, `ByID`, `ByRel`, `BySlug`, `ByTag`, `Tags`, and `Resolve` methods. `Entry` embeds `Note` and adds `Frontmatter`, `ModTime`, and `Size`. Options: `WithFrontmatter(bool)` (default true), `WithWorkers(int)`, and `WithScanOptions(ScanOptions)`. `Index` methods take an internal `RWMutex` and defensive-copy `Frontmatter.Tags` / `Frontmatter.Aliases` on return so future `Reload` can swap state atomically. Existing `Scan`/`ExtractTags`/`ResolveRef` APIs are unchanged ([#150])
+
 ## [0.1.93] - 2026-04-22
 
 ### Added
@@ -603,3 +609,4 @@
 [#141]: https://github.com/dreikanter/notes-cli/issues/141
 [#146]: https://github.com/dreikanter/notes-cli/pull/146
 [#149]: https://github.com/dreikanter/notes-cli/pull/149
+[#150]: https://github.com/dreikanter/notes-cli/pull/150

--- a/note/index.go
+++ b/note/index.go
@@ -294,21 +294,31 @@ func (i *Index) Tags() []string {
 // (zero, false, err) only for genuine failures (path outside root, symlink
 // resolution error). The bool-vs-error split lets callers distinguish
 // "note not found" from "I/O broke."
+//
+// The RLock covers only the snapshot of the index state; the path-resolution
+// syscalls and map/slice reads run after it's released, so a future Reload
+// writer is not blocked on filesystem round-trips. This relies on the
+// swap-only Reload discipline — the aliased slice and maps must remain
+// immutable for the lifetime of the snapshot.
 func (i *Index) Resolve(query string) (Entry, bool, error) {
 	query = strings.TrimSpace(query)
 
 	i.mu.RLock()
-	defer i.mu.RUnlock()
+	root := i.root
+	entries := i.entries
+	byID := i.byID
+	byRel := i.byRel
+	i.mu.RUnlock()
 
 	if query == "" {
-		if len(i.entries) == 0 {
+		if len(entries) == 0 {
 			return Entry{}, false, nil
 		}
-		return cloneEntry(i.entries[0]), true, nil
+		return cloneEntry(entries[0]), true, nil
 	}
 
 	if IsID(query) {
-		e, ok := i.byID[query]
+		e, ok := byID[query]
 		if !ok {
 			return Entry{}, false, nil
 		}
@@ -316,7 +326,7 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 	}
 
 	if HasSpecialBehavior(query) {
-		for _, e := range i.entries {
+		for _, e := range entries {
 			if e.Type == query {
 				return cloneEntry(e), true, nil
 			}
@@ -324,18 +334,18 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 	}
 
 	if filepath.IsAbs(query) || strings.ContainsAny(query, `/\`) {
-		rel, err := resolveRelPath(i.root, query)
+		rel, err := resolveRelPath(root, query)
 		if err != nil {
 			return Entry{}, false, err
 		}
-		e, ok := i.byRel[rel]
+		e, ok := byRel[rel]
 		if !ok {
 			return Entry{}, false, nil
 		}
 		return cloneEntry(e), true, nil
 	}
 
-	for _, e := range i.entries {
+	for _, e := range entries {
 		if e.Slug != "" && strings.Contains(e.Slug, query) {
 			return cloneEntry(e), true, nil
 		}

--- a/note/index.go
+++ b/note/index.go
@@ -1,0 +1,364 @@
+package note
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Entry is a fully-hydrated note record: the filename-derived Note plus
+// frontmatter and file stat metadata. It is the unit Index exposes to
+// downstream consumers (notes-view, notes-pub) that previously maintained
+// their own in-memory indexes.
+type Entry struct {
+	Note
+	Frontmatter Frontmatter
+	ModTime     time.Time
+	Size        int64
+}
+
+// Index is an in-memory, read-only snapshot of a notes store. Build one with
+// Load; future reload semantics will swap state atomically under the RWMutex,
+// so all read methods already take RLock today.
+type Index struct {
+	root string
+
+	mu      sync.RWMutex
+	entries []Entry
+	byID    map[string]Entry
+	byRel   map[string]Entry
+	bySlug  map[string][]Entry
+	byTag   map[string][]Entry
+	allTags []string
+}
+
+type loadConfig struct {
+	frontmatter bool
+	workers     int
+	scanOpts    ScanOptions
+}
+
+// LoadOption configures Load. All options are optional; pass zero or more.
+type LoadOption func(*loadConfig)
+
+// WithFrontmatter controls whether Load parses YAML frontmatter for each
+// note. Default true. Setting false skips the file read entirely — Size and
+// ModTime still populate via stat, but Frontmatter is zero and tag indexes
+// are empty.
+func WithFrontmatter(b bool) LoadOption {
+	return func(c *loadConfig) { c.frontmatter = b }
+}
+
+// WithWorkers sets the number of concurrent file-parsing workers. Default
+// runtime.NumCPU(). Values <=0 fall back to the default; the effective worker
+// count is capped at the number of notes.
+func WithWorkers(n int) LoadOption {
+	return func(c *loadConfig) { c.workers = n }
+}
+
+// WithScanOptions forwards directory-traversal options to the underlying
+// Scan. Default is the zero value (Strict: true), matching Scan(root).
+func WithScanOptions(o ScanOptions) LoadOption {
+	return func(c *loadConfig) { c.scanOpts = o }
+}
+
+// Load walks root once, parses frontmatter concurrently, and returns a
+// populated Index. A single concurrent pass replaces the Scan → FilterByTags
+// → ExtractTags re-read chain that duplicated I/O for each query.
+//
+// Per-note frontmatter parse errors are logged to stderr (matching ParseNote's
+// existing behavior) and leave that entry's Frontmatter zero; they never abort
+// the load. Any file-read or stat error aborts the load.
+func Load(root string, opts ...LoadOption) (*Index, error) {
+	cfg := loadConfig{
+		frontmatter: true,
+		workers:     runtime.NumCPU(),
+		scanOpts:    ScanOptions{Strict: true},
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.workers <= 0 {
+		cfg.workers = runtime.NumCPU()
+	}
+
+	notes, err := Scan(root, cfg.scanOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]Entry, len(notes))
+	for i, n := range notes {
+		entries[i] = Entry{Note: n}
+	}
+
+	if len(entries) > 0 {
+		workers := cfg.workers
+		if workers > len(entries) {
+			workers = len(entries)
+		}
+
+		g, ctx := errgroup.WithContext(context.Background())
+		jobs := make(chan int)
+
+		g.Go(func() error {
+			defer close(jobs)
+			for i := range entries {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case jobs <- i:
+				}
+			}
+			return nil
+		})
+
+		for w := 0; w < workers; w++ {
+			g.Go(func() error {
+				for i := range jobs {
+					path := filepath.Join(root, entries[i].RelPath)
+					info, err := os.Stat(path)
+					if err != nil {
+						return err
+					}
+					entries[i].ModTime = info.ModTime()
+					entries[i].Size = info.Size()
+					if cfg.frontmatter {
+						data, err := os.ReadFile(path)
+						if err != nil {
+							return err
+						}
+						fm, _, parseErr := ParseNote(data)
+						if parseErr != nil {
+							fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
+							continue
+						}
+						entries[i].Frontmatter = fm
+					}
+				}
+				return nil
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+	}
+
+	idx := &Index{
+		root:    root,
+		entries: entries,
+		byID:    make(map[string]Entry, len(entries)),
+		byRel:   make(map[string]Entry, len(entries)),
+		bySlug:  make(map[string][]Entry),
+		byTag:   make(map[string][]Entry),
+	}
+
+	tagSet := make(map[string]struct{})
+	for _, e := range entries {
+		if e.ID != "" {
+			if _, dup := idx.byID[e.ID]; !dup {
+				idx.byID[e.ID] = e
+			}
+		}
+		idx.byRel[e.RelPath] = e
+		if e.Slug != "" {
+			idx.bySlug[e.Slug] = append(idx.bySlug[e.Slug], e)
+		}
+		for _, t := range e.Frontmatter.Tags {
+			if t == "" {
+				continue
+			}
+			lower := strings.ToLower(t)
+			idx.byTag[lower] = append(idx.byTag[lower], e)
+			tagSet[lower] = struct{}{}
+		}
+	}
+
+	idx.allTags = make([]string, 0, len(tagSet))
+	for t := range tagSet {
+		idx.allTags = append(idx.allTags, t)
+	}
+	sort.Strings(idx.allTags)
+
+	return idx, nil
+}
+
+// Root returns the absolute path the index was built from.
+func (i *Index) Root() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.root
+}
+
+// Entries returns all entries, newest first (descending RelPath). The slice
+// is a fresh copy; Tags and Aliases slices on each entry are also copied so
+// callers may mutate the result without affecting the index.
+func (i *Index) Entries() []Entry {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	out := make([]Entry, len(i.entries))
+	for j, e := range i.entries {
+		out[j] = cloneEntry(e)
+	}
+	return out
+}
+
+// ByID returns the entry with the given numeric ID, or false. When multiple
+// entries share an ID the newest wins.
+func (i *Index) ByID(id string) (Entry, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	e, ok := i.byID[id]
+	if !ok {
+		return Entry{}, false
+	}
+	return cloneEntry(e), true
+}
+
+// ByRel returns the entry whose RelPath exactly matches rel, or false. rel
+// must be the forward- or OS-slash path used during the walk (filepath.Join
+// of year, month, basename under strict scan).
+func (i *Index) ByRel(rel string) (Entry, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	e, ok := i.byRel[rel]
+	if !ok {
+		return Entry{}, false
+	}
+	return cloneEntry(e), true
+}
+
+// BySlug returns all entries whose Slug exactly matches slug, newest first.
+// A nil return means no match; the returned slice is a fresh copy.
+func (i *Index) BySlug(slug string) []Entry {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	src := i.bySlug[slug]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]Entry, len(src))
+	for j, e := range src {
+		out[j] = cloneEntry(e)
+	}
+	return out
+}
+
+// ByTag returns all entries whose frontmatter tags contain tag, newest first.
+// Comparison is case-insensitive; body hashtags are not indexed here (use
+// ExtractHashtags or FilterByTags for that source). A nil return means no
+// match.
+func (i *Index) ByTag(tag string) []Entry {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	src := i.byTag[strings.ToLower(tag)]
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]Entry, len(src))
+	for j, e := range src {
+		out[j] = cloneEntry(e)
+	}
+	return out
+}
+
+// Tags returns the sorted, lowercased, deduplicated set of frontmatter tags
+// in the index. The returned slice is freshly allocated.
+func (i *Index) Tags() []string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	out := make([]string, len(i.allTags))
+	copy(out, i.allTags)
+	return out
+}
+
+// Resolve mirrors ResolveRef's priority chain against the cached index —
+// no rescan, no re-read:
+//  1. empty query → most recent entry
+//  2. numeric ID → exact ByID match (strict; never falls through)
+//  3. type with special behavior → most recent entry with that Type
+//  4. path-like query (absolute or contains a separator) → ByRel after
+//     filesystem resolution; errors on paths outside root or missing files
+//  5. slug substring → most recent entry whose Slug contains the query
+//
+// Returns (entry, true, nil) on match, (zero, false, nil) on no match, and
+// (zero, false, err) only for genuine failures (path outside root, symlink
+// resolution error). The bool-vs-error split lets callers distinguish
+// "note not found" from "I/O broke."
+func (i *Index) Resolve(query string) (Entry, bool, error) {
+	query = strings.TrimSpace(query)
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	if query == "" {
+		if len(i.entries) == 0 {
+			return Entry{}, false, nil
+		}
+		return cloneEntry(i.entries[0]), true, nil
+	}
+
+	if IsID(query) {
+		e, ok := i.byID[query]
+		if !ok {
+			return Entry{}, false, nil
+		}
+		return cloneEntry(e), true, nil
+	}
+
+	if HasSpecialBehavior(query) {
+		for _, e := range i.entries {
+			if e.Type == query {
+				return cloneEntry(e), true, nil
+			}
+		}
+	}
+
+	if filepath.IsAbs(query) || strings.ContainsAny(query, `/\`) {
+		rel, err := resolveRelPath(i.root, query)
+		if err != nil {
+			return Entry{}, false, err
+		}
+		e, ok := i.byRel[rel]
+		if !ok {
+			return Entry{}, false, nil
+		}
+		return cloneEntry(e), true, nil
+	}
+
+	for _, e := range i.entries {
+		if e.Slug != "" && strings.Contains(e.Slug, query) {
+			return cloneEntry(e), true, nil
+		}
+	}
+
+	return Entry{}, false, nil
+}
+
+// cloneEntry returns e with Tags and Aliases deep-copied so callers can
+// mutate the returned value without racing other readers of the same index
+// entry. Frontmatter.Extra is shared by reference — callers treating Extra
+// as mutable should copy it themselves.
+func cloneEntry(e Entry) Entry {
+	e.Frontmatter.Tags = cloneStrings(e.Frontmatter.Tags)
+	e.Frontmatter.Aliases = cloneStrings(e.Frontmatter.Aliases)
+	return e
+}
+
+func cloneStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -1,0 +1,289 @@
+package note
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTestdata(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load(%q) error: %v", root, err)
+	}
+	if idx.Root() != root {
+		t.Errorf("Root = %q, want %q", idx.Root(), root)
+	}
+	entries := idx.Entries()
+	if len(entries) != 4 {
+		t.Fatalf("Entries = %d, want 4", len(entries))
+	}
+	if entries[0].ID != "8823" {
+		t.Errorf("entries[0].ID = %q, want 8823 (newest first)", entries[0].ID)
+	}
+	if entries[3].ID != "6973" {
+		t.Errorf("entries[3].ID = %q, want 6973 (oldest last)", entries[3].ID)
+	}
+
+	// Frontmatter is parsed once during Load.
+	e, ok := idx.ByID("8814")
+	if !ok {
+		t.Fatalf("ByID(8814) not found")
+	}
+	if len(e.Frontmatter.Tags) != 2 || e.Frontmatter.Tags[0] != "work" {
+		t.Errorf("entry 8814 tags = %v, want [work planning]", e.Frontmatter.Tags)
+	}
+	// Stat fields are populated.
+	if e.Size == 0 {
+		t.Errorf("entry 8814 Size = 0, want >0")
+	}
+	if e.ModTime.IsZero() {
+		t.Errorf("entry 8814 ModTime is zero")
+	}
+}
+
+func TestLoadEmpty(t *testing.T) {
+	root := t.TempDir()
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load empty root error: %v", err)
+	}
+	if len(idx.Entries()) != 0 {
+		t.Errorf("Entries on empty root = %d, want 0", len(idx.Entries()))
+	}
+	if tags := idx.Tags(); len(tags) != 0 {
+		t.Errorf("Tags on empty root = %v, want []", tags)
+	}
+	if _, ok := idx.ByID("1"); ok {
+		t.Errorf("ByID on empty root should miss")
+	}
+}
+
+func TestLoadWithoutFrontmatter(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root, WithFrontmatter(false))
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	e, ok := idx.ByID("8814")
+	if !ok {
+		t.Fatalf("ByID(8814) not found")
+	}
+	if len(e.Frontmatter.Tags) != 0 {
+		t.Errorf("Frontmatter.Tags = %v on WithFrontmatter(false), want empty", e.Frontmatter.Tags)
+	}
+	if e.Size == 0 || e.ModTime.IsZero() {
+		t.Errorf("stat fields unset with WithFrontmatter(false)")
+	}
+	if tags := idx.Tags(); len(tags) != 0 {
+		t.Errorf("Tags = %v with WithFrontmatter(false), want empty", tags)
+	}
+}
+
+func TestLoadWithScanOptionsLenient(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "---\ntags: [a]\n---\n\nbody\n")
+	writeNote(t, root, "drafts/20260102_2.md", "---\ntags: [b]\n---\n\nbody\n")
+
+	strict, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load strict error: %v", err)
+	}
+	if len(strict.Entries()) != 1 {
+		t.Fatalf("strict Entries = %d, want 1", len(strict.Entries()))
+	}
+
+	lenient, err := Load(root, WithScanOptions(ScanOptions{Strict: false}))
+	if err != nil {
+		t.Fatalf("Load lenient error: %v", err)
+	}
+	if len(lenient.Entries()) != 2 {
+		t.Fatalf("lenient Entries = %d, want 2", len(lenient.Entries()))
+	}
+}
+
+func TestIndexByRelAndByID(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	rel := filepath.Join("2026", "01", "20260106_8823_999.md")
+	e, ok := idx.ByRel(rel)
+	if !ok {
+		t.Fatalf("ByRel(%q) not found", rel)
+	}
+	if e.ID != "8823" {
+		t.Errorf("ByRel(%q).ID = %q, want 8823", rel, e.ID)
+	}
+
+	if _, ok := idx.ByRel("no/such/path.md"); ok {
+		t.Errorf("ByRel miss should return false")
+	}
+
+	if _, ok := idx.ByID("9999"); ok {
+		t.Errorf("ByID(9999) miss should return false")
+	}
+}
+
+func TestIndexBySlug(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	got := idx.BySlug("meeting")
+	if len(got) != 1 || got[0].ID != "8818" {
+		t.Errorf("BySlug(meeting) = %+v, want [ID=8818]", got)
+	}
+
+	if got := idx.BySlug(""); got != nil {
+		t.Errorf("BySlug(\"\") = %+v, want nil (empty slugs are not indexed)", got)
+	}
+
+	if got := idx.BySlug("nonexistent"); got != nil {
+		t.Errorf("BySlug(nonexistent) = %+v, want nil", got)
+	}
+}
+
+func TestIndexByTagAndTags(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "---\ntags: [Work, Meeting]\n---\n\nbody\n")
+	writeNote(t, root, "2026/01/20260102_2.md", "---\ntags: [work, planning]\n---\n\nbody\n")
+	writeNote(t, root, "2026/01/20260103_3.md", "body with #inline only\n")
+
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	tags := idx.Tags()
+	want := []string{"meeting", "planning", "work"}
+	if len(tags) != len(want) {
+		t.Fatalf("Tags = %v, want %v", tags, want)
+	}
+	for i, w := range want {
+		if tags[i] != w {
+			t.Errorf("Tags[%d] = %q, want %q", i, tags[i], w)
+		}
+	}
+
+	// ByTag is case-insensitive.
+	work := idx.ByTag("WORK")
+	if len(work) != 2 {
+		t.Fatalf("ByTag(WORK) = %d entries, want 2", len(work))
+	}
+	// Sorted newest-first.
+	if work[0].ID != "2" || work[1].ID != "1" {
+		t.Errorf("ByTag(WORK) order = [%s,%s], want [2,1]", work[0].ID, work[1].ID)
+	}
+
+	if got := idx.ByTag("inline"); got != nil {
+		t.Errorf("ByTag(inline) = %+v, want nil (body hashtags not indexed)", got)
+	}
+}
+
+func TestIndexResolve(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		wantID  string
+		wantOK  bool
+		wantErr bool
+	}{
+		{"empty returns most recent", "", "8823", true, false},
+		{"numeric id", "8823", "8823", true, false},
+		{"numeric not found is miss not error", "9999", "", false, false},
+		{"type with special behavior", "todo", "8814", true, false},
+		{"slug substring", "letter_opener", "6973", true, false},
+		{"slug miss", "nonexistent", "", false, false},
+		{"numeric date-ish string is ID miss, not slug match", "202601", "", false, false},
+		{"absolute path hit", filepath.Join(root, "2026", "01", "20260106_8823_999.md"), "8823", true, false},
+		{"path outside root is error", "/tmp", "", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, ok, err := idx.Resolve(tt.query)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Resolve(%q) expected error", tt.query)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q) unexpected error: %v", tt.query, err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("Resolve(%q) ok = %v, want %v", tt.query, ok, tt.wantOK)
+			}
+			if ok && e.ID != tt.wantID {
+				t.Errorf("Resolve(%q).ID = %q, want %q", tt.query, e.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestIndexResolveEmptyStore(t *testing.T) {
+	root := t.TempDir()
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	_, ok, err := idx.Resolve("")
+	if err != nil {
+		t.Fatalf("Resolve empty on empty store error: %v", err)
+	}
+	if ok {
+		t.Errorf("Resolve empty on empty store should miss")
+	}
+}
+
+// TestEntriesDefensiveCopy verifies mutating the returned slice or its
+// frontmatter tag slices does not bleed back into the index.
+func TestEntriesDefensiveCopy(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	e, ok := idx.ByID("8814")
+	if !ok {
+		t.Fatalf("ByID(8814) not found")
+	}
+	if len(e.Frontmatter.Tags) < 2 {
+		t.Fatalf("need at least 2 tags to mutate")
+	}
+	e.Frontmatter.Tags[0] = "tampered"
+
+	again, _ := idx.ByID("8814")
+	if again.Frontmatter.Tags[0] == "tampered" {
+		t.Errorf("mutating returned Entry's Tags changed the index")
+	}
+}
+
+func TestIndexByIDKeepsNewestOnCollision(t *testing.T) {
+	root := t.TempDir()
+	// Two notes with the same ID in different months; the newer RelPath wins.
+	writeNote(t, root, "2026/01/20260101_1.md", "---\ntags: [old]\n---\n\n")
+	writeNote(t, root, "2026/02/20260201_1_newer.md", "---\ntags: [new]\n---\n\n")
+
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	e, ok := idx.ByID("1")
+	if !ok {
+		t.Fatalf("ByID(1) not found")
+	}
+	if e.Slug != "newer" {
+		t.Errorf("ByID(1).Slug = %q, want \"newer\" (newest entry)", e.Slug)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `note.Entry` (embeds `Note` plus `Frontmatter`, `ModTime`, `Size`) and `note.Index`, an in-memory snapshot of a notes store built in a single concurrent pass — replaces the `Scan` → `FilterByTags` → `ExtractTags` re-read chain with one walk.
- Add `note.Load(root, opts...)` with `WithFrontmatter(bool)` (default true), `WithWorkers(int)` (default `runtime.NumCPU()`), and `WithScanOptions(ScanOptions)`. Methods on `*Index`: `Root`, `Entries`, `ByID`, `ByRel`, `BySlug`, `ByTag`, `Tags`, `Resolve`.
- `Resolve` mirrors `ResolveRef`'s priority chain (empty → ID → type with special behavior → path → slug substring) against cached state — no re-walk. Returns `(Entry, bool, error)` so callers distinguish "not found" from path/I-O errors.
- Reads take `RLock`; future `Reload` can swap state atomically under the same mutex. `Tags`/`Aliases` are defensive-copied on return; `Frontmatter.Extra` is shared by reference (documented).
- Existing `Scan` / `ExtractTags` / `ResolveRef` APIs are unchanged — this adds a new primitive, not a replacement.

## References

- closes #142