### PR TITLE
Add note/watch subpackage for filesystem monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.95] - 2026-04-22
+
+### Added
+
+- `note/watch` subpackage: an fsnotify-based `Watcher` that observes `.md` note activity under a store root and emits a single debounced signal on `Events()` after filesystem activity settles. Pairs with `Index.Reload` (step 7) — watcher fires, consumer reloads, index coalescer collapses bursts into at most one rebuild. `watch.WithScanOptions` mirrors `note.ScanOptions`: strict mode (default) ignores events outside `YYYY/MM/*.md`, lenient mode accepts any `.md` anywhere beneath root. Newly created directories are registered automatically. Placed in a subpackage so `fsnotify` stays out of the CLI binary's dependency graph ([#145])
+
 ## [0.1.94] - 2026-04-22
 
 ### Added
@@ -610,3 +616,4 @@
 [#146]: https://github.com/dreikanter/notes-cli/pull/146
 [#149]: https://github.com/dreikanter/notes-cli/pull/149
 [#150]: https://github.com/dreikanter/notes-cli/pull/150
+[#145]: https://github.com/dreikanter/notes-cli/issues/145

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/dreikanter/notes-cli
 go 1.25.7
 
 require (
+	github.com/fsnotify/fsnotify v1.5.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -51,7 +53,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.9 // indirect
 	github.com/go-critic/go-critic v0.12.0 // indirect
@@ -152,7 +153,6 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect

--- a/note/watch/watch.go
+++ b/note/watch/watch.go
@@ -1,0 +1,301 @@
+// Package watch provides a filesystem watcher primitive for notes stores.
+//
+// A Watcher monitors root for .md note activity and emits a single debounced
+// signal after quiescence. It is intended to pair with note.Index.Reload: when
+// the watcher fires, the consumer calls Reload and the index coalescer
+// collapses bursts into at most one rebuild.
+//
+// The package is split out from the note core so the CLI binary does not pull
+// fsnotify into its dependency graph.
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dreikanter/notes-cli/note"
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultDebounce is the quiet period used when WithDebounce is not set.
+const DefaultDebounce = 100 * time.Millisecond
+
+// Option configures a Watcher.
+type Option func(*config)
+
+type config struct {
+	scan     note.ScanOptions
+	debounce time.Duration
+}
+
+// WithScanOptions mirrors note.ScanOptions onto the watcher. In strict mode
+// (the default), events whose path is not a YYYY/MM/*.md file under root are
+// ignored, matching note.Scan's strict discipline. Lenient mode accepts any
+// *.md file anywhere under root.
+func WithScanOptions(o note.ScanOptions) Option {
+	return func(c *config) { c.scan = o }
+}
+
+// WithDebounce sets the quiet period the watcher waits after the last
+// relevant event before emitting a signal. Defaults to DefaultDebounce.
+func WithDebounce(d time.Duration) Option {
+	return func(c *config) { c.debounce = d }
+}
+
+// Watcher observes .md note activity under a store root and delivers a single
+// signal on Events() after filesystem activity settles.
+//
+// The watcher adds directories to the underlying fsnotify recursively: strict
+// mode subscribes only to root, year directories (digits-only names), and
+// two-digit month directories beneath them; lenient mode subscribes to every
+// subdirectory. New directories created while the watcher is running are
+// registered as they appear.
+type Watcher struct {
+	root     string
+	strict   bool
+	debounce time.Duration
+
+	fsw    *fsnotify.Watcher
+	events chan struct{}
+	errs   chan error
+	done   chan struct{}
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// New creates a Watcher rooted at root. The watcher starts observing
+// immediately; call Close to release resources.
+func New(root string, opts ...Option) (*Watcher, error) {
+	cfg := config{
+		scan:     note.ScanOptions{Strict: true},
+		debounce: DefaultDebounce,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("watch: root %q is not a directory", root)
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		root:     root,
+		strict:   cfg.scan.Strict,
+		debounce: cfg.debounce,
+		fsw:      fsw,
+		events:   make(chan struct{}, 1),
+		errs:     make(chan error, 1),
+		done:     make(chan struct{}),
+	}
+
+	if err := w.addTree(root); err != nil {
+		_ = fsw.Close()
+		return nil, err
+	}
+
+	go w.run()
+	return w, nil
+}
+
+// Events returns a channel that receives a single struct{} after each quiet
+// period following relevant activity. The channel is closed when the watcher
+// is closed.
+func (w *Watcher) Events() <-chan struct{} { return w.events }
+
+// Errors returns a channel that receives non-fatal errors from the underlying
+// fsnotify watcher. Errors are dropped when the consumer is not ready; treat
+// this channel as best-effort diagnostics.
+func (w *Watcher) Errors() <-chan error { return w.errs }
+
+// Close stops the watcher and releases resources. Safe to call multiple times;
+// only the first invocation returns the underlying fsnotify close error.
+func (w *Watcher) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.done)
+		w.closeErr = w.fsw.Close()
+	})
+	return w.closeErr
+}
+
+// addTree registers dir and every relevant descendant directory with fsnotify.
+// Errors from individual fsnotify.Add calls for subdirectories are swallowed
+// (likely racy removals or permission glitches); failure to add dir itself is
+// returned.
+func (w *Watcher) addTree(dir string) error {
+	if err := w.fsw.Add(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if path == dir {
+				return err
+			}
+			return nil
+		}
+		if !d.IsDir() || path == dir {
+			return nil
+		}
+		if w.shouldWatchDir(path) {
+			_ = w.fsw.Add(path)
+			return nil
+		}
+		if w.strict && !w.strictDirPrefix(path) {
+			return fs.SkipDir
+		}
+		return nil
+	})
+}
+
+// shouldWatchDir reports whether a directory should be registered with
+// fsnotify. Root is always watched. In lenient mode every subdirectory is
+// watched. In strict mode only year (digits-only) and two-digit month
+// directories beneath year dirs are watched.
+func (w *Watcher) shouldWatchDir(path string) bool {
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil || rel == "." {
+		return true
+	}
+	if !w.strict {
+		return true
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	switch len(parts) {
+	case 1:
+		return note.IsID(parts[0])
+	case 2:
+		return note.IsID(parts[0]) && len(parts[1]) == 2 && note.IsID(parts[1])
+	default:
+		return false
+	}
+}
+
+// strictDirPrefix reports whether a directory could still lead to a watched
+// YYYY/MM directory — i.e. whether WalkDir should keep descending in strict
+// mode. Returns true for root and for year directories; false once a
+// non-conforming component is seen or depth exceeds two.
+func (w *Watcher) strictDirPrefix(path string) bool {
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil || rel == "." {
+		return true
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) > 2 {
+		return false
+	}
+	if !note.IsID(parts[0]) {
+		return false
+	}
+	if len(parts) == 2 && (len(parts[1]) != 2 || !note.IsID(parts[1])) {
+		return false
+	}
+	return true
+}
+
+// strictNotePath reports whether path points at a YYYY/MM/*.md file under root.
+func (w *Watcher) strictNotePath(path string) bool {
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 3 {
+		return false
+	}
+	if !note.IsID(parts[0]) {
+		return false
+	}
+	if len(parts[1]) != 2 || !note.IsID(parts[1]) {
+		return false
+	}
+	return true
+}
+
+// run reads fsnotify events and drives the debounce timer. It exits when
+// done is closed or the fsnotify channels are closed.
+func (w *Watcher) run() {
+	defer close(w.events)
+
+	var (
+		timer  *time.Timer
+		timerC <-chan time.Time
+	)
+	reset := func() {
+		if timer == nil {
+			timer = time.NewTimer(w.debounce)
+		} else {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(w.debounce)
+		}
+		timerC = timer.C
+	}
+
+	for {
+		select {
+		case <-w.done:
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			select {
+			case w.errs <- err:
+			default:
+			}
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			if w.handle(ev) {
+				reset()
+			}
+		case <-timerC:
+			timerC = nil
+			select {
+			case w.events <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// handle updates watch registrations in response to directory creations and
+// reports whether ev is a relevant .md event that should (re)start the
+// debounce timer.
+func (w *Watcher) handle(ev fsnotify.Event) bool {
+	if ev.Op&fsnotify.Create != 0 {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			_ = w.addTree(ev.Name)
+		}
+	}
+	if filepath.Ext(ev.Name) != ".md" {
+		return false
+	}
+	if w.strict && !w.strictNotePath(ev.Name) {
+		return false
+	}
+	return true
+}

--- a/note/watch/watch_test.go
+++ b/note/watch/watch_test.go
@@ -1,0 +1,264 @@
+package watch_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dreikanter/notes-cli/note"
+	"github.com/dreikanter/notes-cli/note/watch"
+)
+
+// debounce is short enough to keep tests fast but long enough to coalesce the
+// multi-step file operations fsnotify reports under typical filesystems.
+const (
+	debounce = 30 * time.Millisecond
+	settle   = 300 * time.Millisecond
+)
+
+// waitEvent returns true if an event arrives within timeout.
+func waitEvent(t *testing.T, w *watch.Watcher, timeout time.Duration) bool {
+	t.Helper()
+	select {
+	case _, ok := <-w.Events():
+		return ok
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// drainQuiet asserts no event arrives within timeout.
+func drainQuiet(t *testing.T, w *watch.Watcher, timeout time.Duration) {
+	t.Helper()
+	select {
+	case _, ok := <-w.Events():
+		if ok {
+			t.Fatalf("expected no event, got one")
+		}
+	case <-time.After(timeout):
+	}
+}
+
+// TestWatcherStrictCreateModifyDelete verifies that create, modify, and delete
+// of a single .md file under YYYY/MM each produce exactly one debounced event.
+func TestWatcherStrictCreateModifyDelete(t *testing.T) {
+	root := t.TempDir()
+	monthDir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	notePath := filepath.Join(monthDir, "20260422_1.md")
+
+	if err := os.WriteFile(notePath, []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event after create")
+	}
+	drainQuiet(t, w, 2*debounce)
+
+	if err := os.WriteFile(notePath, []byte("updated\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event after modify")
+	}
+	drainQuiet(t, w, 2*debounce)
+
+	if err := os.Remove(notePath); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event after delete")
+	}
+	drainQuiet(t, w, 2*debounce)
+}
+
+// TestWatcherDebouncesBurst verifies that a burst of writes to the same file
+// produces a single coalesced event rather than one per write.
+func TestWatcherDebouncesBurst(t *testing.T) {
+	root := t.TempDir()
+	monthDir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	notePath := filepath.Join(monthDir, "20260422_1.md")
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(notePath, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		time.Sleep(debounce / 4)
+	}
+
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event after burst")
+	}
+	drainQuiet(t, w, 2*debounce)
+}
+
+// TestWatcherStrictIgnoresOutsideLayout verifies that in strict mode, a .md
+// file created outside YYYY/MM does not trigger an event.
+func TestWatcherStrictIgnoresOutsideLayout(t *testing.T) {
+	root := t.TempDir()
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	// File directly under root: rejected by strict.
+	outside := filepath.Join(root, "loose.md")
+	if err := os.WriteFile(outside, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	drainQuiet(t, w, settle)
+
+	// File under drafts/ (non-digit parent): rejected by strict.
+	drafts := filepath.Join(root, "drafts")
+	if err := os.MkdirAll(drafts, 0o755); err != nil {
+		t.Fatalf("mkdir drafts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(drafts, "20260422_1.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write drafts: %v", err)
+	}
+	drainQuiet(t, w, settle)
+}
+
+// TestWatcherLenientAcceptsAnywhere verifies that Strict=false picks up .md
+// files anywhere beneath root, including arbitrary nesting.
+func TestWatcherLenientAcceptsAnywhere(t *testing.T) {
+	root := t.TempDir()
+	drafts := filepath.Join(root, "drafts")
+	if err := os.MkdirAll(drafts, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w, err := watch.New(root,
+		watch.WithDebounce(debounce),
+		watch.WithScanOptions(note.ScanOptions{Strict: false}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	// Pre-existing non-digit subdir.
+	if err := os.WriteFile(filepath.Join(drafts, "20260422_1_idea.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event for lenient create in drafts/")
+	}
+	drainQuiet(t, w, 2*debounce)
+
+	// Deeply nested subdir created after watcher start.
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+	// Give fsnotify time to register the new descendants.
+	time.Sleep(2 * debounce)
+	if err := os.WriteFile(filepath.Join(deep, "20260423_2.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write deep: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event for lenient create in deep/")
+	}
+}
+
+// TestWatcherIgnoresNonMd verifies that non-.md activity does not fire events.
+func TestWatcherIgnoresNonMd(t *testing.T) {
+	root := t.TempDir()
+	monthDir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	if err := os.WriteFile(filepath.Join(monthDir, "scratch.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	drainQuiet(t, w, settle)
+}
+
+// TestWatcherPicksUpNewMonthDir verifies that a newly created YYYY/MM
+// directory is observed and its .md contents trigger events.
+func TestWatcherPicksUpNewMonthDir(t *testing.T) {
+	root := t.TempDir()
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	monthDir := filepath.Join(root, "2026", "04")
+	if err := os.MkdirAll(monthDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Let the watcher register the new directories before the file write.
+	time.Sleep(2 * debounce)
+
+	if err := os.WriteFile(filepath.Join(monthDir, "20260422_1.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !waitEvent(t, w, settle) {
+		t.Fatalf("no event after creating note in new month dir")
+	}
+}
+
+// TestWatcherCloseClosesEvents verifies Close releases resources and closes
+// the Events channel.
+func TestWatcherCloseClosesEvents(t *testing.T) {
+	root := t.TempDir()
+
+	w, err := watch.New(root, watch.WithDebounce(debounce))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Second Close is a no-op.
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close (second): %v", err)
+	}
+
+	select {
+	case _, ok := <-w.Events():
+		if ok {
+			t.Fatalf("expected closed channel, received value")
+		}
+	case <-time.After(settle):
+		t.Fatalf("Events channel not closed after Close")
+	}
+}
+
+// TestWatcherRejectsMissingRoot ensures New fails fast when root does not exist.
+func TestWatcherRejectsMissingRoot(t *testing.T) {
+	_, err := watch.New(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatalf("expected error for missing root")
+	}
+}


### PR DESCRIPTION
## Summary

- New `note/watch` subpackage: `Watcher` observes `.md` note activity under a store root via `fsnotify` and emits a single debounced signal on `Events()` after filesystem activity settles. Pairs with `Index.Reload` — watcher fires, consumer reloads, index coalescer collapses bursts into at most one rebuild.
- `watch.WithScanOptions` mirrors `note.ScanOptions`: strict mode (default) ignores events outside `YYYY/MM/*.md`; lenient mode accepts any `.md` beneath root. `watch.WithDebounce` configures the quiet period (default 100ms). Newly created directories are registered at runtime.
- Placed in a subpackage so `fsnotify` stays out of the CLI binary's dep graph (`go list -deps ./cmd/notes` confirms it is absent).
- Integration tests cover strict create/modify/delete, burst coalescing, strict rejection of out-of-layout files, lenient acceptance anywhere, non-`.md` filtering, dynamic month-dir registration, and `Close` semantics.

## References

- closes #145
- relates to #134