### PR TITLE
Add Index.Reload() for atomic index rebuilds with request coalescing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.96] - 2026-04-22
+
+### Added
+
+- `note.Index.Reload() <-chan struct{}` requests a rebuild and returns a channel that closes once a walk completing at or after the call has swapped in. Scheduling: idle → start immediately; in-flight → queue at most one follow-up, and every caller arriving during the in-flight build receives the same queued `done` so they only observe completion after a walk that started after their request. Cleanup runs in a deferred block so a panicking build cannot leave waiters blocked. Pairs with the `note/watch` debouncer (step 7 of #134): watcher fires, consumer calls `Reload`, bursts collapse to at most one rebuild ([#143])
+
 ## [0.1.95] - 2026-04-22
 
 ### Added
@@ -617,3 +623,4 @@
 [#149]: https://github.com/dreikanter/notes-cli/pull/149
 [#150]: https://github.com/dreikanter/notes-cli/pull/150
 [#145]: https://github.com/dreikanter/notes-cli/issues/145
+[#143]: https://github.com/dreikanter/notes-cli/issues/143

--- a/note/index.go
+++ b/note/index.go
@@ -26,10 +26,11 @@ type Entry struct {
 }
 
 // Index is an in-memory, read-only snapshot of a notes store. Build one with
-// Load; future reload semantics will swap state atomically under the RWMutex,
-// so all read methods already take RLock today.
+// Load; Reload swaps state atomically under the RWMutex, so all read methods
+// take RLock today.
 type Index struct {
 	root string
+	cfg  loadConfig
 
 	mu      sync.RWMutex
 	entries []Entry
@@ -38,6 +39,13 @@ type Index struct {
 	bySlug  map[string][]Entry
 	byTag   map[string][]Entry
 	allTags []string
+
+	// buildMu guards curDone and queuedDone — the Reload state machine.
+	// Separate from mu so rebuild bookkeeping does not contend with read
+	// lookups. See Reload for the scheduling semantics.
+	buildMu    sync.Mutex
+	curDone    chan struct{} // in-flight build's completion signal; nil when idle
+	queuedDone chan struct{} // follow-up build queued while curDone runs; nil when none
 }
 
 type loadConfig struct {
@@ -90,18 +98,29 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 		cfg.workers = runtime.NumCPU()
 	}
 
-	notes, err := Scan(root, cfg.scanOpts)
-	if err != nil {
+	idx := &Index{root: root, cfg: cfg}
+	if err := idx.build(); err != nil {
 		return nil, err
+	}
+	return idx, nil
+}
+
+// build walks the notes tree once, reads each entry under the configured
+// worker pool, and atomically swaps the new state in under i.mu. Called by
+// Load for the initial population and by runBuild for subsequent reloads.
+func (i *Index) build() error {
+	notes, err := Scan(i.root, i.cfg.scanOpts)
+	if err != nil {
+		return err
 	}
 
 	entries := make([]Entry, len(notes))
-	for i, n := range notes {
-		entries[i] = Entry{Note: n}
+	for j, n := range notes {
+		entries[j] = Entry{Note: n}
 	}
 
 	if len(entries) > 0 {
-		workers := cfg.workers
+		workers := i.cfg.workers
 		if workers > len(entries) {
 			workers = len(entries)
 		}
@@ -111,11 +130,11 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 
 		g.Go(func() error {
 			defer close(jobs)
-			for i := range entries {
+			for j := range entries {
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
-				case jobs <- i:
+				case jobs <- j:
 				}
 			}
 			return nil
@@ -123,15 +142,15 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 
 		for w := 0; w < workers; w++ {
 			g.Go(func() error {
-				for i := range jobs {
-					path := filepath.Join(root, entries[i].RelPath)
+				for j := range jobs {
+					path := filepath.Join(i.root, entries[j].RelPath)
 					info, err := os.Stat(path)
 					if err != nil {
 						return err
 					}
-					entries[i].ModTime = info.ModTime()
-					entries[i].Size = info.Size()
-					if cfg.frontmatter {
+					entries[j].ModTime = info.ModTime()
+					entries[j].Size = info.Size()
+					if i.cfg.frontmatter {
 						data, err := os.ReadFile(path)
 						if err != nil {
 							return err
@@ -141,7 +160,7 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 							fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
 							continue
 						}
-						entries[i].Frontmatter = fm
+						entries[j].Frontmatter = fm
 					}
 				}
 				return nil
@@ -149,47 +168,107 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 		}
 
 		if err := g.Wait(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	idx := &Index{
-		root:    root,
-		entries: entries,
-		byID:    make(map[string]Entry, len(entries)),
-		byRel:   make(map[string]Entry, len(entries)),
-		bySlug:  make(map[string][]Entry),
-		byTag:   make(map[string][]Entry),
-	}
-
+	byID := make(map[string]Entry, len(entries))
+	byRel := make(map[string]Entry, len(entries))
+	bySlug := make(map[string][]Entry)
+	byTag := make(map[string][]Entry)
 	tagSet := make(map[string]struct{})
 	for _, e := range entries {
 		if e.ID != "" {
-			if _, dup := idx.byID[e.ID]; !dup {
-				idx.byID[e.ID] = e
+			if _, dup := byID[e.ID]; !dup {
+				byID[e.ID] = e
 			}
 		}
-		idx.byRel[e.RelPath] = e
+		byRel[e.RelPath] = e
 		if e.Slug != "" {
-			idx.bySlug[e.Slug] = append(idx.bySlug[e.Slug], e)
+			bySlug[e.Slug] = append(bySlug[e.Slug], e)
 		}
 		for _, t := range e.Frontmatter.Tags {
 			if t == "" {
 				continue
 			}
 			lower := strings.ToLower(t)
-			idx.byTag[lower] = append(idx.byTag[lower], e)
+			byTag[lower] = append(byTag[lower], e)
 			tagSet[lower] = struct{}{}
 		}
 	}
 
-	idx.allTags = make([]string, 0, len(tagSet))
+	allTags := make([]string, 0, len(tagSet))
 	for t := range tagSet {
-		idx.allTags = append(idx.allTags, t)
+		allTags = append(allTags, t)
 	}
-	sort.Strings(idx.allTags)
+	sort.Strings(allTags)
 
-	return idx, nil
+	i.mu.Lock()
+	i.entries = entries
+	i.byID = byID
+	i.byRel = byRel
+	i.bySlug = bySlug
+	i.byTag = byTag
+	i.allTags = allTags
+	i.mu.Unlock()
+
+	return nil
+}
+
+// Reload requests an index rebuild and returns a channel that closes when a
+// build has completed that reflects the tree state at or after this call.
+//
+// Scheduling rules:
+//   - Idle: start a new build immediately.
+//   - Build in-flight: coalesce — queue at most one follow-up. Every caller
+//     that arrives while the in-flight build runs receives the same follow-up's
+//     done channel, so they only observe completion after a full walk that
+//     started after their request.
+//
+// Callers that only need "the current build" can read the returned channel;
+// callers that do not care (e.g. warmup on a navigation) may ignore it.
+func (i *Index) Reload() <-chan struct{} {
+	i.buildMu.Lock()
+	if i.curDone == nil {
+		done := make(chan struct{})
+		i.curDone = done
+		i.buildMu.Unlock()
+		go i.runBuild(done)
+		return done
+	}
+	if i.queuedDone == nil {
+		i.queuedDone = make(chan struct{})
+	}
+	done := i.queuedDone
+	i.buildMu.Unlock()
+	return done
+}
+
+// runBuild executes one build and signals done; if another Reload request
+// arrived during the build, it chains into the follow-up build in the same
+// goroutine lineage.
+//
+// The state-machine cleanup runs in a deferred block so that even if build
+// panics, waiters on done are released and any queued follow-up still gets
+// scheduled — without this, waiting callers would block forever.
+func (i *Index) runBuild(done chan struct{}) {
+	defer func() {
+		i.buildMu.Lock()
+		next := i.queuedDone
+		i.queuedDone = nil
+		i.curDone = next
+		i.buildMu.Unlock()
+
+		close(done)
+
+		if next != nil {
+			go i.runBuild(next)
+		}
+	}()
+
+	if err := i.build(); err != nil {
+		fmt.Fprintf(os.Stderr, "warn: index reload failed: %v\n", err)
+	}
 }
 
 // Root returns the absolute path the index was built from.

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 )
@@ -285,5 +286,82 @@ func TestIndexByIDKeepsNewestOnCollision(t *testing.T) {
 	}
 	if e.Slug != "newer" {
 		t.Errorf("ByID(1).Slug = %q, want \"newer\" (newest entry)", e.Slug)
+	}
+}
+
+// TestReloadDoneReflectsLatestState pins that reading the channel returned
+// from Reload guarantees a build has completed against the tree state at or
+// after the Reload call. Without this guarantee, downstream live-reload hooks
+// could fire before the index catches up and serve stale metadata.
+func TestReloadDoneReflectsLatestState(t *testing.T) {
+	root := t.TempDir()
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+
+	writeNote(t, root, "2026/01/20260101_9999_fresh.md",
+		"---\ntitle: Fresh\n---\n")
+
+	if _, ok := idx.ByRel("2026/01/20260101_9999_fresh.md"); ok {
+		t.Fatal("fresh note should not be indexed before Reload")
+	}
+
+	<-idx.Reload()
+
+	entry, ok := idx.ByRel("2026/01/20260101_9999_fresh.md")
+	if !ok {
+		t.Fatal("fresh note should be indexed after Reload done fires")
+	}
+	if entry.Frontmatter.Title != "Fresh" {
+		t.Errorf("Title = %q, want Fresh", entry.Frontmatter.Title)
+	}
+}
+
+// TestReloadCoalescesRequestsDuringInflight pins the scheduling rule: while a
+// build is in-flight, all new Reload callers share a single queued follow-up.
+// Verified by observing that a request arriving after a write is reflected by
+// the time the returned channel closes.
+func TestReloadCoalescesRequestsDuringInflight(t *testing.T) {
+	root := t.TempDir()
+	// Prime the tree with enough files that build takes measurable time.
+	for i := 0; i < 200; i++ {
+		writeNote(t, root, fmt.Sprintf("2026/01/20260101_%04d.md", i+1),
+			"---\ntitle: T\n---\n")
+	}
+
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+
+	// Kick off a build, then — without waiting — add a new file and request
+	// another reload. The second call must return a channel that reflects
+	// the new file, not the prior in-flight build.
+	first := idx.Reload()
+
+	writeNote(t, root, "2026/02/20260201_9999_late.md",
+		"---\ntitle: Late\n---\n")
+
+	second := idx.Reload()
+
+	// Second must not close before first (queue ordering).
+	select {
+	case <-second:
+		// If this ever fires before first, the queued build was elided.
+		select {
+		case <-first:
+			// Both closed at roughly the same time — acceptable if first
+			// finished between the two reads.
+		default:
+			t.Fatal("second done closed before in-flight build finished")
+		}
+	case <-first:
+	}
+
+	<-second
+
+	if _, ok := idx.ByRel("2026/02/20260201_9999_late.md"); !ok {
+		t.Error("late note must be indexed once second Reload's done fires")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `Index.Reload() <-chan struct{}` that requests an asynchronous rebuild and returns a channel closing once a walk started at or after the call has swapped in new state
- Coalesce concurrent requests: idle starts immediately; while a build is in-flight, all callers share a single queued follow-up so they observe completion only after a walk that began after their request
- Run state-machine cleanup in a deferred block in `runBuild` so a panicking build still releases waiters and schedules any queued follow-up
- Extract `build()` from `Load()` and add `buildMu` separate from `mu` so rebuild bookkeeping does not contend with read lookups

## References

- closes #143
