### PR TITLE
Route FilterByTags, ExtractTags, ResolveRef through note.Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.98] - 2026-04-22
+
+### Changed
+
+- `note.FilterByTags`, `note.ExtractTags`, `note.ResolveRef`, and `note.ResolveRefDate` now route through `note.Load` + `Index` instead of re-walking and re-reading the store on every call. Behavior is unchanged: tag sources still merge frontmatter `tags:` with body hashtags, the resolve priority chain (ID → type → path → slug substring) is identical, and a per-note frontmatter parse error still logs to stderr and falls back to body hashtags only. Callers that already hold an `Index` can skip the wrappers and call `Index.Resolve` / `Entry.MergedTags` directly to avoid a second file-read pass. `Entry.MergedTags()` returns the sorted, lowercased, deduplicated union of frontmatter tags and body hashtags for a single entry ([#144])
+
 ## [0.1.96] - 2026-04-22
 
 ### Added
@@ -624,3 +630,4 @@
 [#150]: https://github.com/dreikanter/notes-cli/pull/150
 [#145]: https://github.com/dreikanter/notes-cli/issues/145
 [#143]: https://github.com/dreikanter/notes-cli/issues/143
+[#144]: https://github.com/dreikanter/notes-cli/issues/144

--- a/note/index.go
+++ b/note/index.go
@@ -23,6 +23,38 @@ type Entry struct {
 	Frontmatter Frontmatter
 	ModTime     time.Time
 	Size        int64
+
+	// bodyHashtags holds the lowercased, deduplicated body hashtags extracted
+	// during Load. Read via MergedTags; the field is unexported because it
+	// only feeds migration shims (FilterByTags, ExtractTags). Nil when Load
+	// ran with WithFrontmatter(false).
+	bodyHashtags []string
+}
+
+// MergedTags returns the lowercased, deduplicated union of the entry's
+// frontmatter tags and body hashtags. This matches the tag source used by
+// FilterByTags and ExtractTags: both frontmatter `tags:` values and in-body
+// `#hashtag` tokens. Result is sorted.
+func (e Entry) MergedTags() []string {
+	set := make(map[string]struct{}, len(e.Frontmatter.Tags)+len(e.bodyHashtags))
+	for _, t := range e.Frontmatter.Tags {
+		if t == "" {
+			continue
+		}
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	for _, t := range e.bodyHashtags {
+		set[t] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Index is an in-memory, read-only snapshot of a notes store. Build one with
@@ -155,12 +187,14 @@ func (i *Index) build() error {
 						if err != nil {
 							return err
 						}
-						fm, _, parseErr := ParseNote(data)
+						fm, body, parseErr := ParseNote(data)
 						if parseErr != nil {
 							fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
-							continue
+							body = data
+						} else {
+							entries[j].Frontmatter = fm
 						}
-						entries[j].Frontmatter = fm
+						entries[j].bodyHashtags = normalizeHashtags(ExtractHashtags(body))
 					}
 				}
 				return nil
@@ -440,6 +474,7 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 func cloneEntry(e Entry) Entry {
 	e.Frontmatter.Tags = cloneStrings(e.Frontmatter.Tags)
 	e.Frontmatter.Aliases = cloneStrings(e.Frontmatter.Aliases)
+	e.bodyHashtags = cloneStrings(e.bodyHashtags)
 	return e
 }
 
@@ -449,5 +484,30 @@ func cloneStrings(s []string) []string {
 	}
 	out := make([]string, len(s))
 	copy(out, s)
+	return out
+}
+
+// normalizeHashtags lowercases and deduplicates a hashtag list from
+// ExtractHashtags into the canonical form used by Entry.bodyHashtags.
+// Returns nil when the input is empty so equality checks against nil hold.
+func normalizeHashtags(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(raw))
+	for _, t := range raw {
+		if t == "" {
+			continue
+		}
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
 	return out
 }

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -186,6 +186,63 @@ func TestIndexByTagAndTags(t *testing.T) {
 	}
 }
 
+// TestEntryMergedTags verifies that body hashtags are extracted during Load
+// and surface via Entry.MergedTags alongside frontmatter tags, case-folded
+// and deduped. This is the path FilterByTags and ExtractTags route through.
+func TestEntryMergedTags(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [Work, Planning]\n---\n\nbody mentions #inline and #Work again.\n")
+	writeNote(t, root, "2026/01/20260102_2.md",
+		"no frontmatter, just #solo\n")
+
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	e1, ok := idx.ByID("1")
+	if !ok {
+		t.Fatalf("ByID(1) missing")
+	}
+	got := e1.MergedTags()
+	want := []string{"inline", "planning", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("MergedTags(1) = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("MergedTags(1)[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+
+	e2, _ := idx.ByID("2")
+	if got := e2.MergedTags(); len(got) != 1 || got[0] != "solo" {
+		t.Errorf("MergedTags(2) = %v, want [solo]", got)
+	}
+}
+
+// TestLoadWithoutFrontmatterSkipsBodyHashtags documents that WithFrontmatter(false)
+// turns off both frontmatter parsing and body hashtag extraction — Entry.MergedTags
+// returns empty because neither source is populated.
+func TestLoadWithoutFrontmatterSkipsBodyHashtags(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [fm]\n---\n\nbody with #inline tag\n")
+
+	idx, err := Load(root, WithFrontmatter(false))
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	e, ok := idx.ByID("1")
+	if !ok {
+		t.Fatalf("ByID(1) missing")
+	}
+	if got := e.MergedTags(); got != nil {
+		t.Errorf("MergedTags on WithFrontmatter(false) = %v, want nil", got)
+	}
+}
+
 func TestIndexResolve(t *testing.T) {
 	root := testdataPath(t)
 	idx, err := Load(root)

--- a/note/store.go
+++ b/note/store.go
@@ -151,6 +151,10 @@ func scanLenient(root string) ([]Note, error) {
 //  2. Type with special behavior (todo, backlog, weekly) — most recent match
 //  3. Path — absolute or relative path with separator, exact match under root
 //  4. Slug substring — most recent note whose slug contains the query
+//
+// Implementation routes through Index.Resolve on a WithFrontmatter(false)
+// load, so CLI commands that already hold an Index can call Index.Resolve
+// directly and skip this wrapper.
 func ResolveRef(root, query string) (Note, error) {
 	return ResolveRefDate(root, query, "")
 }
@@ -158,58 +162,96 @@ func ResolveRef(root, query string) (Note, error) {
 // ResolveRefDate works like ResolveRef but optionally restricts candidates to
 // notes matching the given YYYYMMDD date string. Pass "" to skip date filtering.
 func ResolveRefDate(root, query, date string) (Note, error) {
-	query = strings.TrimSpace(query)
-
-	notes, err := Scan(root)
+	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
 		return Note{}, err
 	}
 
-	if date != "" {
-		notes = FilterByDate(notes, date)
-	}
-
-	// Step 1: numeric ID — strict, no fallthrough
-	if IsID(query) {
-		for i := range notes {
-			if notes[i].ID == query {
-				return notes[i], nil
-			}
-		}
-		return Note{}, fmt.Errorf("note not found: %s", query)
-	}
-
-	// Step 2: type — most recent match
-	if HasSpecialBehavior(query) {
-		for i := range notes {
-			if notes[i].Type == query {
-				return notes[i], nil
-			}
-		}
-	}
-
-	// Step 3: path (absolute, or relative containing a separator) — exact match
-	if filepath.IsAbs(query) || strings.ContainsAny(query, "/\\") {
-		rel, err := resolveRelPath(root, query)
+	if date == "" {
+		e, ok, err := idx.Resolve(query)
 		if err != nil {
 			return Note{}, err
 		}
-		for i := range notes {
-			if notes[i].RelPath == rel {
-				return notes[i], nil
+		if !ok {
+			return Note{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
+		}
+		return e.Note, nil
+	}
+
+	entries := idx.Entries()
+	filtered := filterEntriesByDate(entries, date)
+	e, ok, err := resolveInEntries(root, filtered, query)
+	if err != nil {
+		return Note{}, err
+	}
+	if !ok {
+		return Note{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
+	}
+	return e.Note, nil
+}
+
+// filterEntriesByDate returns entries whose Date field matches the given
+// YYYYMMDD string, preserving input order.
+func filterEntriesByDate(entries []Entry, date string) []Entry {
+	var out []Entry
+	for _, e := range entries {
+		if e.Date == date {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// resolveInEntries applies the ResolveRef priority chain to an arbitrary
+// (pre-filtered) entry slice. It mirrors Index.Resolve but linear-scans,
+// because date-restricted subsets don't share the index's maps.
+func resolveInEntries(root string, entries []Entry, query string) (Entry, bool, error) {
+	query = strings.TrimSpace(query)
+
+	if query == "" {
+		if len(entries) == 0 {
+			return Entry{}, false, nil
+		}
+		return entries[0], true, nil
+	}
+
+	if IsID(query) {
+		for _, e := range entries {
+			if e.ID == query {
+				return e, true, nil
 			}
 		}
-		return Note{}, fmt.Errorf("note not found: %s", query)
+		return Entry{}, false, nil
 	}
 
-	// Step 4: slug substring — most recent match
-	for i := range notes {
-		if strings.Contains(notes[i].Slug, query) {
-			return notes[i], nil
+	if HasSpecialBehavior(query) {
+		for _, e := range entries {
+			if e.Type == query {
+				return e, true, nil
+			}
 		}
 	}
 
-	return Note{}, fmt.Errorf("note not found: %s", query)
+	if filepath.IsAbs(query) || strings.ContainsAny(query, `/\`) {
+		rel, err := resolveRelPath(root, query)
+		if err != nil {
+			return Entry{}, false, err
+		}
+		for _, e := range entries {
+			if e.RelPath == rel {
+				return e, true, nil
+			}
+		}
+		return Entry{}, false, nil
+	}
+
+	for _, e := range entries {
+		if e.Slug != "" && strings.Contains(e.Slug, query) {
+			return e, true, nil
+		}
+	}
+
+	return Entry{}, false, nil
 }
 
 // resolveRelPath converts a path-like query to a note RelPath under root.
@@ -253,31 +295,36 @@ func Filter(notes []Note, fragment string) []Note {
 // FilterByTags returns notes that contain all of the given tags. Tag sources
 // mirror ExtractTags: frontmatter `tags:` fields and body hashtags (#word).
 // Comparison is case-insensitive.
-// A per-note frontmatter parse error is written to stderr and the note's
-// frontmatter tags are skipped (body hashtags are still considered).
+//
+// Implementation routes through Load so the tag index is built from a single
+// concurrent file-read pass; the []Note signature is preserved as a shim for
+// callers that don't yet hold an Index. A per-note frontmatter parse error is
+// logged to stderr during Load and leaves the note's frontmatter tags empty;
+// body hashtags are still considered.
 func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
+	if len(notes) == 0 {
+		return nil, nil
+	}
+	idx, err := Load(root)
+	if err != nil {
+		return nil, err
+	}
 	var results []Note
 	for _, n := range notes {
-		path := filepath.Join(root, n.RelPath)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, err
+		e, ok := idx.ByRel(n.RelPath)
+		if !ok {
+			continue
 		}
-		fm, body, parseErr := ParseNote(data)
-		if parseErr != nil {
-			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
-		}
-		hashtags := ExtractHashtags(body)
-		noteTags := make([]string, 0, len(fm.Tags)+len(hashtags))
-		noteTags = append(noteTags, fm.Tags...)
-		noteTags = append(noteTags, hashtags...)
-		if hasAllTags(noteTags, tags) {
+		if hasAllTags(e.MergedTags(), tags) {
 			results = append(results, n)
 		}
 	}
 	return results, nil
 }
 
+// hasAllTags reports whether every entry in required appears in noteTags,
+// case-insensitively. noteTags may be pre-lowercased (as from Entry.MergedTags)
+// or mixed-case — both sides are folded for comparison.
 func hasAllTags(noteTags []string, required []string) bool {
 	set := make(map[string]struct{}, len(noteTags))
 	for _, t := range noteTags {

--- a/note/tags.go
+++ b/note/tags.go
@@ -2,97 +2,53 @@ package note
 
 import (
 	"bytes"
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
 	"sort"
-	"strings"
-	"sync"
-
-	"golang.org/x/sync/errgroup"
 )
 
 // ExtractTags scans the note store under root and returns a sorted,
 // deduplicated, lowercased list of tags. Sources: frontmatter `tags:` fields
-// and body hashtags (#word) in the prose. File reads run concurrently across
-// runtime.NumCPU() workers. Returns a nil slice for an empty store.
-// A per-note frontmatter parse error is written to stderr and the
+// and body hashtags (#word) in the prose. Returns a nil slice for an empty
+// store. A per-note frontmatter parse error is written to stderr and the
 // note's frontmatter tags are skipped (body hashtags are still collected).
 // Any file-read error aborts the scan.
+//
+// Implementation routes through Load so concurrent callers reuse a single
+// file-read pass; the worker pool and error-group coordination live in Load.
 func ExtractTags(root string) ([]string, error) {
-	notes, err := Scan(root)
+	idx, err := Load(root)
 	if err != nil {
 		return nil, err
 	}
-	if len(notes) == 0 {
-		return nil, nil
-	}
+	return idx.mergedTagsSorted(), nil
+}
 
-	workers := runtime.NumCPU()
-	if workers > len(notes) {
-		workers = len(notes)
-	}
-
-	g, ctx := errgroup.WithContext(context.Background())
-	jobs := make(chan Note)
-	var mu sync.Mutex
-	merged := make(map[string]struct{})
-
-	g.Go(func() error {
-		defer close(jobs)
-		for _, n := range notes {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case jobs <- n:
-			}
-		}
+// mergedTagsSorted returns the sorted, deduplicated, lowercased union of all
+// entries' frontmatter tags and body hashtags. Returns nil on an empty index
+// to match ExtractTags's pre-migration behavior.
+func (i *Index) mergedTagsSorted() []string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if len(i.entries) == 0 {
 		return nil
-	})
-
-	for i := 0; i < workers; i++ {
-		g.Go(func() error {
-			local := make(map[string]struct{})
-			for n := range jobs {
-				path := filepath.Join(root, n.RelPath)
-				data, err := os.ReadFile(path)
-				if err != nil {
-					return err
-				}
-				fm, body, parseErr := ParseNote(data)
-				if parseErr != nil {
-					fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
-				}
-				for _, t := range fm.Tags {
-					if t != "" {
-						local[strings.ToLower(t)] = struct{}{}
-					}
-				}
-				for _, t := range ExtractHashtags(body) {
-					local[strings.ToLower(t)] = struct{}{}
-				}
-			}
-			mu.Lock()
-			for t := range local {
-				merged[t] = struct{}{}
-			}
-			mu.Unlock()
-			return nil
-		})
 	}
-
-	if err := g.Wait(); err != nil {
-		return nil, err
+	set := make(map[string]struct{})
+	for _, t := range i.allTags {
+		set[t] = struct{}{}
 	}
-
-	out := make([]string, 0, len(merged))
-	for t := range merged {
+	for _, e := range i.entries {
+		for _, t := range e.bodyHashtags {
+			set[t] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
 		out = append(out, t)
 	}
 	sort.Strings(out)
-	return out, nil
+	return out
 }
 
 // ExtractHashtags scans body text and returns hashtag tokens (without the


### PR DESCRIPTION
## Summary

- Route `FilterByTags`, `ExtractTags`, `ResolveRef`, and `ResolveRefDate` through `note.Load` + `Index` instead of re-walking and re-reading the store on every call. No behavior change beyond speed — existing tests pass unchanged.
- Extend `Entry` with an unexported `bodyHashtags` field populated during `Load`'s single concurrent pass; surfaced via a new `Entry.MergedTags()` method returning the sorted, lowercased, deduplicated union of frontmatter `tags:` and body `#hashtag` tokens.
- Callers that already hold an `Index` (follow-up CLI wiring) can skip the wrappers and call `Index.Resolve` / `Entry.MergedTags` directly to avoid a second file-read pass.

## References

- closes #144