### PR TITLE
Switch ResolveEntryDate signature to take Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.99] - 2026-04-22
+
+### Changed
+
+- `note.ResolveEntryDate` now takes the `Entry` directly (`func ResolveEntryDate(e Entry, fi fs.FileInfo) (time.Time, string)`) instead of the explicit `Note` + `Frontmatter` pair it accepted when it landed in #149 before `Entry` existed. Priority, source labels, and `fi == nil` handling are unchanged. Callers holding an `Entry` from `note.Index` no longer need to unpack it ([#140])
+
 ## [0.1.98] - 2026-04-22
 
 ### Changed
@@ -631,3 +637,4 @@
 [#145]: https://github.com/dreikanter/notes-cli/issues/145
 [#143]: https://github.com/dreikanter/notes-cli/issues/143
 [#144]: https://github.com/dreikanter/notes-cli/issues/144
+[#140]: https://github.com/dreikanter/notes-cli/issues/140

--- a/note/date.go
+++ b/note/date.go
@@ -17,25 +17,22 @@ func (n Note) Time() (time.Time, bool) {
 	return t, true
 }
 
-// ResolveEntryDate picks a single canonical date for a note, returning a
+// ResolveEntryDate picks a single canonical date for an entry, returning a
 // source label so callers can surface or override the choice.
 //
 // Priority (first match wins):
-//  1. UID-derived date — Note.Date parses cleanly as YYYYMMDD ("uid").
-//  2. Frontmatter date — fm.Date is non-zero ("frontmatter").
+//  1. UID-derived date — e.Date parses cleanly as YYYYMMDD ("uid").
+//  2. Frontmatter date — e.Frontmatter.Date is non-zero ("frontmatter").
 //  3. File mtime — fi is non-nil ("mtime").
 //
 // fi may be nil to skip the mtime fallback. When no source resolves, the
 // zero time.Time and an empty source label are returned.
-//
-// The signature takes Note and Frontmatter explicitly until the Entry type
-// from #142 lands; callers will then pass entry.Note and entry.Frontmatter.
-func ResolveEntryDate(n Note, fm Frontmatter, fi fs.FileInfo) (time.Time, string) {
-	if t, ok := n.Time(); ok {
+func ResolveEntryDate(e Entry, fi fs.FileInfo) (time.Time, string) {
+	if t, ok := e.Time(); ok {
 		return t, "uid"
 	}
-	if !fm.Date.IsZero() {
-		return fm.Date, "frontmatter"
+	if !e.Frontmatter.Date.IsZero() {
+		return e.Frontmatter.Date, "frontmatter"
 	}
 	if fi != nil {
 		return fi.ModTime(), "mtime"

--- a/note/date_test.go
+++ b/note/date_test.go
@@ -71,64 +71,56 @@ func TestResolveEntryDate(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		note       Note
-		fm         Frontmatter
+		entry      Entry
 		fi         fs.FileInfo
 		wantTime   time.Time
 		wantSource string
 	}{
 		{
 			name:       "uid wins over frontmatter and mtime",
-			note:       Note{Date: "20260106"},
-			fm:         Frontmatter{Date: fmTime},
+			entry:      Entry{Note: Note{Date: "20260106"}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   uidTime,
 			wantSource: "uid",
 		},
 		{
 			name:       "frontmatter when uid malformed",
-			note:       Note{Date: "bogus"},
-			fm:         Frontmatter{Date: fmTime},
+			entry:      Entry{Note: Note{Date: "bogus"}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   fmTime,
 			wantSource: "frontmatter",
 		},
 		{
 			name:       "mtime when uid malformed and frontmatter zero",
-			note:       Note{Date: ""},
-			fm:         Frontmatter{},
+			entry:      Entry{Note: Note{Date: ""}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   mtime,
 			wantSource: "mtime",
 		},
 		{
 			name:       "nil fi skips mtime fallback",
-			note:       Note{Date: "bad"},
-			fm:         Frontmatter{},
+			entry:      Entry{Note: Note{Date: "bad"}},
 			fi:         nil,
 			wantTime:   time.Time{},
 			wantSource: "",
 		},
 		{
 			name:       "nil fi still uses uid when valid",
-			note:       Note{Date: "20260106"},
-			fm:         Frontmatter{},
+			entry:      Entry{Note: Note{Date: "20260106"}},
 			fi:         nil,
 			wantTime:   uidTime,
 			wantSource: "uid",
 		},
 		{
 			name:       "nil fi still uses frontmatter when uid malformed",
-			note:       Note{Date: ""},
-			fm:         Frontmatter{Date: fmTime},
+			entry:      Entry{Note: Note{Date: ""}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         nil,
 			wantTime:   fmTime,
 			wantSource: "frontmatter",
 		},
 		{
 			name:       "uid wins even when frontmatter is zero",
-			note:       Note{Date: "20260106"},
-			fm:         Frontmatter{},
+			entry:      Entry{Note: Note{Date: "20260106"}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   uidTime,
 			wantSource: "uid",
@@ -137,7 +129,7 @@ func TestResolveEntryDate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, src := ResolveEntryDate(tc.note, tc.fm, tc.fi)
+			got, src := ResolveEntryDate(tc.entry, tc.fi)
 			if src != tc.wantSource {
 				t.Errorf("source = %q, want %q", src, tc.wantSource)
 			}


### PR DESCRIPTION
## Summary

- `note.ResolveEntryDate` now takes `(Entry, fs.FileInfo)` instead of `(Note, Frontmatter, fs.FileInfo)`, matching the signature specified in #140 now that `note.Entry` has landed (#150).
- Priority chain (UID → frontmatter `date:` → mtime), source labels (`"uid"` / `"frontmatter"` / `"mtime"`), and `fi == nil` handling are unchanged.
- Tests updated to pass `Entry{Note: ..., Frontmatter: ...}` literals; all priority branches still covered.
- CHANGELOG entry added under `0.1.99`.

## References

- closes #140