### PR TITLE
Make FormatNote return error instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.101] - 2026-04-23
+
+### Changed
+
+- `note.FormatNote` now returns `([]byte, error)` instead of panicking when `yaml.Marshal` fails. `Frontmatter.Extra` holds arbitrary `yaml.Node` values sourced from user input, which can in principle fail to re-encode (cycles, aliases), so the prior "impossible" panic was unsafe. All four production callers (`create`, `new_todo`, `annotate`, `update`) and the `frontmatter_test.go` suite (via a new `mustFormatNote` helper) handle the error ([#158])
+- `note.DateFormat` exported as the canonical `"20060102"` layout constant. The literal was duplicated across 11 call sites in `note/` and `internal/cli/` (production and tests); every site now references the constant, giving a single source of truth for UID-derived and CLI-facing dates ([#158])
+
 ## [0.1.100] - 2026-04-23
 
 ### Changed
@@ -668,3 +675,4 @@
 [#140]: https://github.com/dreikanter/notes-cli/issues/140
 [#134]: https://github.com/dreikanter/notes-cli/issues/134
 [#156]: https://github.com/dreikanter/notes-cli/pull/156
+[#158]: https://github.com/dreikanter/notes-cli/pull/158

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -114,7 +114,10 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	merged := mergeAnnotation(existing, gen)
-	newContent := note.FormatNote(merged, body)
+	newContent, err := note.FormatNote(merged, body)
+	if err != nil {
+		return err
+	}
 
 	if err := writeAtomic(fullPath, newContent); err != nil {
 		return err

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -50,7 +50,7 @@ func writeAtomic(path string, data []byte) error {
 // createNote creates a new note file with optional frontmatter and body content.
 // Returns the absolute path to the created file.
 func createNote(p createNoteParams) (string, error) {
-	today := time.Now().Format("20060102")
+	today := time.Now().Format(note.DateFormat)
 
 	id, err := note.NextID(p.Root)
 	if err != nil {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -74,7 +74,10 @@ func createNote(p createNoteParams) (string, error) {
 		Description: p.Description,
 		Public:      p.Public,
 	}
-	content := note.FormatNote(fm, []byte(p.Body))
+	content, err := note.FormatNote(fm, []byte(p.Body))
+	if err != nil {
+		return "", err
+	}
 
 	if err := writeAtomic(fullPath, content); err != nil {
 		return "", err

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -56,7 +56,7 @@ func (f filterOpts) describe() string {
 // applyFilters applies the common filter pipeline to a list of notes.
 func applyFilters(notes []note.Note, root string, f filterOpts) ([]note.Note, error) {
 	if f.Today {
-		notes = note.FilterByDate(notes, time.Now().Format("20060102"))
+		notes = note.FilterByDate(notes, time.Now().Format(note.DateFormat))
 	}
 	if len(f.Types) > 0 {
 		notes = note.FilterByTypes(notes, f.Types)

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -39,7 +39,7 @@ var newCmd = &cobra.Command{
 
 		// --upsert: check if today already has a matching note
 		if upsert {
-			today := time.Now().Format("20060102")
+			today := time.Now().Format(note.DateFormat)
 			notes, err := note.Scan(root)
 			if err != nil {
 				return err

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -20,7 +20,7 @@ var newTodoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		today := time.Now().Format("20060102")
+		today := time.Now().Format(note.DateFormat)
 
 		notes, err := note.Scan(root)
 		if err != nil {

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -65,7 +65,10 @@ var newTodoCmd = &cobra.Command{
 
 		fullPath := filepath.Join(dir, filename)
 		body := []byte(note.FormatTodoContent(carriedTasks))
-		content := note.FormatNote(note.Frontmatter{Type: "todo"}, body)
+		content, err := note.FormatNote(note.Frontmatter{Type: "todo"}, body)
+		if err != nil {
+			return err
+		}
 
 		if err := writeAtomic(fullPath, content); err != nil {
 			return err

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dreikanter/notes-cli/note"
 )
 
 func runNewTodo(t *testing.T, root string, args ...string) (string, error) {
@@ -40,7 +42,7 @@ func TestNewTodoCreatesFromPrevious(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	today := time.Now().Format("20060102")
+	today := time.Now().Format(note.DateFormat)
 	if !strings.Contains(filepath.Base(out), today) {
 		t.Errorf("expected today's date %s in filename, got %q", today, filepath.Base(out))
 	}

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dreikanter/notes-cli/note"
 )
 
 func runRead(t *testing.T, args ...string) (string, error) {
@@ -68,7 +70,7 @@ func TestReadBySlugFilter(t *testing.T) {
 
 func TestReadByTodayFilter(t *testing.T) {
 	// No notes in testdata match today's date, so this should error.
-	today := time.Now().Format("20060102")
+	today := time.Now().Format(note.DateFormat)
 	_, err := runRead(t, "--today")
 	if err == nil {
 		t.Fatalf("expected error for --today with no matching notes (today=%s), got nil", today)

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -42,7 +42,7 @@ positional resolution to notes dated today.`,
 
 			var date string
 			if f.Today {
-				date = time.Now().Format("20060102")
+				date = time.Now().Format(note.DateFormat)
 			}
 
 			n, err := note.ResolveRefDate(root, args[0], date)

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dreikanter/notes-cli/note"
 )
 
 func testdataPath(t *testing.T) string {
@@ -148,7 +150,7 @@ func TestResolveTodayFilterExcludesOldNotes(t *testing.T) {
 
 func TestResolveTodayFilterMatchesToday(t *testing.T) {
 	root := t.TempDir()
-	today := time.Now().Format("20060102")
+	today := time.Now().Format(note.DateFormat)
 	month := today[:6]
 	dir := filepath.Join(root, today[:4], month[4:6])
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -24,7 +24,7 @@ var rmCmd = &cobra.Command{
 
 		var date string
 		if today {
-			date = time.Now().Format("20060102")
+			date = time.Now().Format(note.DateFormat)
 		}
 
 		n, err := note.ResolveRefDate(root, args[0], date)

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dreikanter/notes-cli/note"
 )
 
 func runRm(t *testing.T, root string, args ...string) (string, error) {
@@ -70,7 +72,7 @@ func TestRmNonExistentErrors(t *testing.T) {
 
 func TestRmTodayFlag(t *testing.T) {
 	root := t.TempDir()
-	today := time.Now().Format("20060102")
+	today := time.Now().Format(note.DateFormat)
 	dir := filepath.Join(root, today[:4], today[4:6])
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -103,7 +103,10 @@ var updateCmd = &cobra.Command{
 		}
 
 		if contentChanged {
-			newContent := note.FormatNote(updated, body)
+			newContent, err := note.FormatNote(updated, body)
+			if err != nil {
+				return err
+			}
 			if err := writeAtomic(oldPath, newContent); err != nil {
 				return err
 			}

--- a/note/date.go
+++ b/note/date.go
@@ -5,12 +5,16 @@ import (
 	"time"
 )
 
+// DateFormat is the canonical YYYYMMDD layout for UID-derived and CLI-facing
+// dates. Use with time.Parse / time.Format (and ParseInLocation for UTC).
+const DateFormat = "20060102"
+
 // Time parses Note.Date (the UID-derived YYYYMMDD prefix) to a time.Time at
 // midnight UTC. It returns false when Date is not a valid YYYYMMDD value;
 // values outside the canonical 8-character form (e.g. short or long years)
 // are reported as malformed even though ParseFilename accepts them.
 func (n Note) Time() (time.Time, bool) {
-	t, err := time.ParseInLocation("20060102", n.Date, time.UTC)
+	t, err := time.ParseInLocation(DateFormat, n.Date, time.UTC)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -214,15 +214,16 @@ func ParseNote(data []byte) (Frontmatter, []byte, error) {
 }
 
 // FormatNote serialises frontmatter followed by body. Omits the frontmatter
-// block entirely when f.IsZero(). yaml.Marshal cannot fail for this struct,
-// so marshal errors are treated as impossible and cause a panic.
-func FormatNote(f Frontmatter, body []byte) []byte {
+// block entirely when f.IsZero(). Marshal errors surface to the caller;
+// f.Extra values sourced from arbitrary YAML input can in principle fail to
+// re-encode, so callers should handle the error rather than assume success.
+func FormatNote(f Frontmatter, body []byte) ([]byte, error) {
 	if f.IsZero() {
-		return body
+		return body, nil
 	}
 	out, err := yaml.Marshal(f)
 	if err != nil {
-		panic(fmt.Sprintf("yaml.Marshal Frontmatter: %v", err))
+		return nil, fmt.Errorf("marshal frontmatter: %w", err)
 	}
 	const prefix = "---\n"
 	const suffix = "---\n\n"
@@ -231,7 +232,7 @@ func FormatNote(f Frontmatter, body []byte) []byte {
 	buf = append(buf, out...)
 	buf = append(buf, suffix...)
 	buf = append(buf, body...)
-	return buf
+	return buf, nil
 }
 
 // StripFrontmatter returns data with any leading frontmatter block removed.

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -9,6 +9,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func mustFormatNote(t *testing.T, f Frontmatter, body []byte) []byte {
+	t.Helper()
+	out, err := FormatNote(f, body)
+	if err != nil {
+		t.Fatalf("FormatNote: %v", err)
+	}
+	return out
+}
+
 func TestFrontmatterIsZero(t *testing.T) {
 	tests := []struct {
 		name string
@@ -148,14 +157,14 @@ func TestFormatNoteSnapshotAllFields(t *testing.T) {
 		Public:      true,
 	}
 	want := "---\ntitle: T\nslug: s\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
-	got := string(FormatNote(f, []byte("body\n")))
+	got := string(mustFormatNote(t, f, []byte("body\n")))
 	if got != want {
 		t.Errorf("got:\n%q\nwant:\n%q", got, want)
 	}
 }
 
 func TestFormatNoteEmptyFrontmatter(t *testing.T) {
-	if got := string(FormatNote(Frontmatter{}, []byte("body\n"))); got != "body\n" {
+	if got := string(mustFormatNote(t, Frontmatter{}, []byte("body\n"))); got != "body\n" {
 		t.Errorf("got %q, want %q", got, "body\n")
 	}
 }
@@ -173,7 +182,7 @@ func TestRoundtrip(t *testing.T) {
 	}
 	for i, fm := range cases {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			out := FormatNote(fm, []byte("body\n"))
+			out := mustFormatNote(t, fm, []byte("body\n"))
 			gotF, gotBody, err := ParseNote(out)
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)
@@ -209,7 +218,7 @@ func TestStripFrontmatter(t *testing.T) {
 		{"multiple closing delimiters", "---\na\n---\nb\n---\n\nBody\n", "b\n---\n\nBody\n"},
 		{
 			name:  "roundtrip with FormatNote",
-			input: string(FormatNote(Frontmatter{Tags: []string{"journal"}, Description: "A note"}, []byte("# Content\n"))),
+			input: string(mustFormatNote(t, Frontmatter{Tags: []string{"journal"}, Description: "A note"}, []byte("# Content\n"))),
 			want:  "# Content\n",
 		},
 	}
@@ -244,7 +253,7 @@ func TestParseNoteCRLFInteriorPreserved(t *testing.T) {
 }
 
 func TestFormatNoteWritesLFOnly(t *testing.T) {
-	out := FormatNote(Frontmatter{Title: "T"}, []byte("hello\r\nworld\r\n"))
+	out := mustFormatNote(t, Frontmatter{Title: "T"}, []byte("hello\r\nworld\r\n"))
 	wantPrefix := "---\ntitle: T\n---\n\n"
 	if string(out[:len(wantPrefix)]) != wantPrefix {
 		t.Errorf("delimiter lines not LF-only: %q", string(out[:len(wantPrefix)]))
@@ -288,7 +297,7 @@ func TestFormatNoteExtraPreservedInAlphaOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseNote: %v", err)
 	}
-	out := string(FormatNote(fm, body))
+	out := string(mustFormatNote(t, fm, body))
 	// Reserved "title" first; Extra keys alpha-sorted: alpha, featured, zebra.
 	want := "---\ntitle: T\nalpha: 1\nfeatured: true\nzebra: striped\n---\n\nbody\n"
 	if out != want {
@@ -301,7 +310,7 @@ func TestFormatNoteEmptyFrontmatterWithExtraOnly(t *testing.T) {
 		"featured": {Kind: yaml.ScalarNode, Value: "true", Tag: "!!bool"},
 	}}
 	want := "---\nfeatured: true\n---\n\nbody\n"
-	got := string(FormatNote(fm, []byte("body\n")))
+	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -328,7 +337,7 @@ func TestTypeRoundTrips(t *testing.T) {
 	if fm.Type != "meeting" {
 		t.Errorf("Type = %q, want meeting", fm.Type)
 	}
-	out := string(FormatNote(fm, body))
+	out := string(mustFormatNote(t, fm, body))
 	want := "---\ntitle: T\ntype: meeting\n---\n\nbody\n"
 	if out != want {
 		t.Errorf("out = %q, want %q", out, want)
@@ -340,7 +349,7 @@ func TestTypeFieldOrder(t *testing.T) {
 		Title: "T", Slug: "s", Type: "meeting",
 		Tags: []string{"a"}, Description: "D", Public: true,
 	}
-	got := string(FormatNote(fm, []byte("body\n")))
+	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
 	if got != want {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
@@ -360,7 +369,7 @@ func TestDateRoundTripDateOnly(t *testing.T) {
 	if _, ok := fm.Extra["date"]; ok {
 		t.Error("Date should be on the typed field, not in Extra")
 	}
-	out := string(FormatNote(fm, body))
+	out := string(mustFormatNote(t, fm, body))
 	wantOut := "---\ntitle: T\ndate: 2026-04-22\n---\n\nbody\n"
 	if out != wantOut {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
@@ -377,7 +386,7 @@ func TestDateRoundTripRFC3339(t *testing.T) {
 	if !fm.Date.Equal(want) {
 		t.Errorf("Date = %v, want %v", fm.Date, want)
 	}
-	out := string(FormatNote(fm, body))
+	out := string(mustFormatNote(t, fm, body))
 	wantOut := "---\ntitle: T\ndate: 2026-04-22T15:30:00Z\n---\n\nbody\n"
 	if out != wantOut {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
@@ -390,7 +399,7 @@ func TestDateFieldOrder(t *testing.T) {
 		Date: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
 		Tags: []string{"a"}, Description: "D", Public: true,
 	}
-	got := string(FormatNote(fm, []byte("body\n")))
+	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
 	if got != want {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
@@ -437,7 +446,7 @@ func TestAliasesRoundTrip(t *testing.T) {
 	if _, ok := fm.Extra["aliases"]; ok {
 		t.Error("Aliases should be on the typed field, not in Extra")
 	}
-	out := string(FormatNote(fm, body))
+	out := string(mustFormatNote(t, fm, body))
 	want := "---\ntitle: T\naliases:\n    - old-slug\n    - even-older\n---\n\nbody\n"
 	if out != want {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, want)
@@ -452,7 +461,7 @@ func TestAliasesFieldOrder(t *testing.T) {
 		Aliases:     []string{"old"},
 		Description: "D", Public: true,
 	}
-	got := string(FormatNote(fm, []byte("body\n")))
+	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\naliases:\n    - old\ndescription: D\npublic: true\n---\n\nbody\n"
 	if got != want {
 		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
@@ -497,7 +506,7 @@ func TestRoundtripWithAliases(t *testing.T) {
 	}
 	for i, fm := range cases {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			out := FormatNote(fm, []byte("body\n"))
+			out := mustFormatNote(t, fm, []byte("body\n"))
 			gotF, gotBody, err := ParseNote(out)
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)
@@ -520,7 +529,7 @@ func TestRoundtripWithDate(t *testing.T) {
 	}
 	for i, fm := range cases {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			out := FormatNote(fm, []byte("body\n"))
+			out := mustFormatNote(t, fm, []byte("body\n"))
 			gotF, gotBody, err := ParseNote(out)
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)

--- a/note/index.go
+++ b/note/index.go
@@ -82,6 +82,7 @@ type Index struct {
 
 type loadConfig struct {
 	frontmatter bool
+	workers     int
 	scanOpts    ScanOptions
 }
 
@@ -94,6 +95,13 @@ type LoadOption func(*loadConfig)
 // are empty.
 func WithFrontmatter(b bool) LoadOption {
 	return func(c *loadConfig) { c.frontmatter = b }
+}
+
+// WithWorkers sets the number of concurrent file-parsing workers. Default
+// runtime.NumCPU(). Values <=0 fall back to the default; the effective worker
+// count is capped at the number of notes.
+func WithWorkers(n int) LoadOption {
+	return func(c *loadConfig) { c.workers = n }
 }
 
 // WithScanOptions forwards directory-traversal options to the underlying
@@ -112,10 +120,14 @@ func WithScanOptions(o ScanOptions) LoadOption {
 func Load(root string, opts ...LoadOption) (*Index, error) {
 	cfg := loadConfig{
 		frontmatter: true,
+		workers:     runtime.NumCPU(),
 		scanOpts:    ScanOptions{Strict: true},
 	}
 	for _, o := range opts {
 		o(&cfg)
+	}
+	if cfg.workers <= 0 {
+		cfg.workers = runtime.NumCPU()
 	}
 
 	idx := &Index{root: root, cfg: cfg}
@@ -140,7 +152,7 @@ func (i *Index) build() error {
 	}
 
 	if len(entries) > 0 {
-		workers := runtime.NumCPU()
+		workers := i.cfg.workers
 		if workers > len(entries) {
 			workers = len(entries)
 		}

--- a/note/index.go
+++ b/note/index.go
@@ -82,7 +82,6 @@ type Index struct {
 
 type loadConfig struct {
 	frontmatter bool
-	workers     int
 	scanOpts    ScanOptions
 }
 
@@ -95,13 +94,6 @@ type LoadOption func(*loadConfig)
 // are empty.
 func WithFrontmatter(b bool) LoadOption {
 	return func(c *loadConfig) { c.frontmatter = b }
-}
-
-// WithWorkers sets the number of concurrent file-parsing workers. Default
-// runtime.NumCPU(). Values <=0 fall back to the default; the effective worker
-// count is capped at the number of notes.
-func WithWorkers(n int) LoadOption {
-	return func(c *loadConfig) { c.workers = n }
 }
 
 // WithScanOptions forwards directory-traversal options to the underlying
@@ -120,14 +112,10 @@ func WithScanOptions(o ScanOptions) LoadOption {
 func Load(root string, opts ...LoadOption) (*Index, error) {
 	cfg := loadConfig{
 		frontmatter: true,
-		workers:     runtime.NumCPU(),
 		scanOpts:    ScanOptions{Strict: true},
 	}
 	for _, o := range opts {
 		o(&cfg)
-	}
-	if cfg.workers <= 0 {
-		cfg.workers = runtime.NumCPU()
 	}
 
 	idx := &Index{root: root, cfg: cfg}
@@ -152,7 +140,7 @@ func (i *Index) build() error {
 	}
 
 	if len(entries) > 0 {
-		workers := i.cfg.workers
+		workers := runtime.NumCPU()
 		if workers > len(entries) {
 			workers = len(entries)
 		}


### PR DESCRIPTION
## Summary

Two code-quality fixes surfaced by a review of the Go production code.

- `note.FormatNote` now returns `([]byte, error)` instead of panicking on `yaml.Marshal` failure. The prior "impossible" panic was unsafe: `Frontmatter.Extra` holds arbitrary `yaml.Node` values sourced from user input, which can in principle fail to re-encode (cycles, aliases). All four production callers (`create`, `new_todo`, `annotate`, `update`) and the `frontmatter_test.go` suite (via a new `mustFormatNote` helper) are updated.
- Extracted the duplicated `"20060102"` date layout into `note.DateFormat` and replaced all 11 call sites across `note/` and `internal/cli/` (production and tests).

A third commit removed the unused `WithWorkers` `LoadOption`, but it was reverted on the branch: `WithWorkers` is part of the `note` package's public API consumed by downstream tools (`notes-view`, `notes-pub`) outside this repo, and I could not verify zero external callers from this scope. Net diff keeps `WithWorkers` unchanged.

## References

- Relates to #134