### PR TITLE
Improve error handling and rename note utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.103] - 2026-04-23
+
+### Changed
+
+- `note.NoteFilename` and `note.NoteDirPath` renamed to `note.Filename` and `note.DirPath` to drop the package-name stutter (`note.Note*`) that repeated at every call site. Tests and the one surviving doc-comment reference were updated in the same pass ([#159])
+- `notes update` now reads the parsed bool value for both `--public` and `--private` instead of hardcoding `true`/`false` on `Changed()`. Previously `--public=false` would flip `Public` to `true` (the inverse of intent) and `--private=false` was a no-op. `MarkFlagsMutuallyExclusive("public","private")` still prevents both being set at once ([#159])
+- `buildAnnotateSchema` in `internal/cli/annotate.go` now returns `(string, error)` and propagates the `json.Marshal` failure instead of silently discarding it with `_`. The input is controlled so today's callers can't trigger the error, but the pattern violated the "no silent error swallowing" rule ([#159])
+- `CLAUDE.md` documents the CHANGELOG workflow explicitly: open the PR first, note the assigned number, then add the CHANGELOG entry referencing that number in a follow-up atomic commit. Avoids the chicken-and-egg of trying to predict the PR number before creation ([#159])
+
 ## [0.1.101] - 2026-04-23
 
 ### Changed
@@ -676,3 +685,4 @@
 [#134]: https://github.com/dreikanter/notes-cli/issues/134
 [#156]: https://github.com/dreikanter/notes-cli/pull/156
 [#158]: https://github.com/dreikanter/notes-cli/pull/158
+[#159]: https://github.com/dreikanter/notes-cli/pull/159

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,13 @@ Rules:
 - Use the exact next patch version as the heading
 - Reference the PR number (`[#N]`) in the entry and add its link at the bottom
 
+Workflow: the PR number is assigned on creation, so add the CHANGELOG entry as
+a follow-up commit on the same branch:
+1. Open the PR without the CHANGELOG entry.
+2. Note the assigned PR number.
+3. Add the CHANGELOG entry referencing that number in its own atomic commit.
+4. Push; the PR updates in place.
+
 ## Pull Requests
 
 Use `.github/pull_request_template.md` for all PR bodies. When running `gh pr create`, pass its content via `--body`.

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -96,7 +96,10 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	schema := buildAnnotateSchema(empty)
+	schema, err := buildAnnotateSchema(empty)
+	if err != nil {
+		return err
+	}
 	ctx := cmd.Context()
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -187,7 +190,7 @@ func annotateEmptyFields(f note.Frontmatter) []string {
 
 // buildAnnotateSchema returns a JSON Schema string requiring only the given fields.
 // Fields must be a subset of {"title", "description", "tags"}.
-func buildAnnotateSchema(fields []string) string {
+func buildAnnotateSchema(fields []string) (string, error) {
 	props := map[string]any{}
 	for _, f := range fields {
 		switch f {
@@ -207,8 +210,11 @@ func buildAnnotateSchema(fields []string) string {
 		"required":             fields,
 		"additionalProperties": false,
 	}
-	b, _ := json.Marshal(schema)
-	return string(b)
+	b, err := json.Marshal(schema)
+	if err != nil {
+		return "", fmt.Errorf("cannot marshal annotate schema: %w", err)
+	}
+	return string(b), nil
 }
 
 // annotateEnvelope mirrors the outer JSON written by `claude -p --output-format json`.

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -53,7 +53,10 @@ func TestAnnotateEmptyFieldsAllFilled(t *testing.T) {
 }
 
 func TestBuildAnnotateSchemaAllFields(t *testing.T) {
-	s := buildAnnotateSchema([]string{"title", "description", "tags"})
+	s, err := buildAnnotateSchema([]string{"title", "description", "tags"})
+	if err != nil {
+		t.Fatalf("buildAnnotateSchema: %v", err)
+	}
 
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
@@ -87,7 +90,10 @@ func TestBuildAnnotateSchemaAllFields(t *testing.T) {
 }
 
 func TestBuildAnnotateSchemaTagsOnly(t *testing.T) {
-	s := buildAnnotateSchema([]string{"tags"})
+	s, err := buildAnnotateSchema([]string{"tags"})
+	if err != nil {
+		t.Fatalf("buildAnnotateSchema: %v", err)
+	}
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
 		t.Fatalf("invalid JSON: %v", err)

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -57,8 +57,8 @@ func createNote(p createNoteParams) (string, error) {
 		return "", err
 	}
 
-	filename := note.NoteFilename(today, id, p.Slug, p.Type)
-	dir := note.NoteDirPath(p.Root, today)
+	filename := note.Filename(today, id, p.Slug, p.Type)
+	dir := note.DirPath(p.Root, today)
 
 	if err := os.MkdirAll(dir, rootDirMode(p.Root)); err != nil {
 		return "", fmt.Errorf("cannot create directory %s: %w", dir, err)

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -57,8 +57,8 @@ var newTodoCmd = &cobra.Command{
 			return err
 		}
 
-		filename := note.NoteFilename(today, id, "", "todo")
-		dir := note.NoteDirPath(root, today)
+		filename := note.Filename(today, id, "", "todo")
+		dir := note.DirPath(root, today)
 		if err := os.MkdirAll(dir, rootDirMode(root)); err != nil {
 			return fmt.Errorf("cannot create directory %s: %w", dir, err)
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -130,7 +130,7 @@ var updateCmd = &cobra.Command{
 			if syncType == "" && !cmd.Flags().Changed("type") && !updateNoType {
 				syncType = n.Type
 			}
-			newFilename := note.NoteFilename(n.Date, id, syncSlug, syncType)
+			newFilename := note.Filename(n.Date, id, syncSlug, syncType)
 			dir := filepath.Dir(oldPath)
 			newPath = filepath.Join(dir, newFilename)
 			if newPath != oldPath {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -25,7 +25,6 @@ var updateCmd = &cobra.Command{
 		updateNoSlug, _ := cmd.Flags().GetBool("no-slug")
 		updateType, _ := cmd.Flags().GetString("type")
 		updateNoType, _ := cmd.Flags().GetBool("no-type")
-		updatePrivate, _ := cmd.Flags().GetBool("private")
 		syncFilename, _ := cmd.Flags().GetBool("sync-filename")
 
 		hasFlag := false
@@ -87,11 +86,13 @@ var updateCmd = &cobra.Command{
 			updated.Slug = updateSlug
 			contentChanged = true
 		}
-		if updatePrivate {
-			updated.Public = false
+		if cmd.Flags().Changed("private") {
+			v, _ := cmd.Flags().GetBool("private")
+			updated.Public = !v
 			contentChanged = true
 		} else if cmd.Flags().Changed("public") {
-			updated.Public = true
+			v, _ := cmd.Flags().GetBool("public")
+			updated.Public = v
 			contentChanged = true
 		}
 		if updateNoType {

--- a/note/note.go
+++ b/note/note.go
@@ -47,7 +47,7 @@ func ParseFilename(baseName string) (Note, error) {
 	remaining := baseName
 
 	// Only treat the dot-suffix as a type if the remaining base is itself
-	// dot-free — i.e. the suffix round-trips through NoteFilename. Otherwise
+	// dot-free — i.e. the suffix round-trips through Filename. Otherwise
 	// leave Type empty and let the caller rely on frontmatter.
 	if idx := strings.LastIndex(baseName, "."); idx >= 0 {
 		suffix := baseName[idx+1:]
@@ -86,11 +86,11 @@ func ParseFilename(baseName string) (Note, error) {
 	}, nil
 }
 
-// NoteFilename generates a note filename from date, id, optional slug, and optional type.
+// Filename generates a note filename from date, id, optional slug, and optional type.
 // Type is encoded as a secondary file extension (e.g. ".todo.md") only when it's
 // safe to round-trip through ParseFilename; values with '.' or path separators
 // are omitted from the filename, with frontmatter remaining canonical.
-func NoteFilename(date string, id int, slug, noteType string) string {
+func Filename(date string, id int, slug, noteType string) string {
 	base := fmt.Sprintf("%s_%d", date, id)
 	if slug != "" {
 		base = fmt.Sprintf("%s_%s", base, slug)
@@ -101,9 +101,9 @@ func NoteFilename(date string, id int, slug, noteType string) string {
 	return base + ".md"
 }
 
-// NoteDirPath returns the year/month directory path for a given date string (Y...YMMDD),
+// DirPath returns the year/month directory path for a given date string (Y...YMMDD),
 // where MM and DD are zero-padded.
-func NoteDirPath(root, date string) string {
+func DirPath(root, date string) string {
 	year := date[:len(date)-4]
 	month := date[len(date)-4 : len(date)-2]
 	return filepath.Join(root, year, month)

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -71,7 +71,7 @@ func TestParseFilename(t *testing.T) {
 			wantType: "bar",
 		},
 		{
-			// Multi-dot basenames can't come from NoteFilename (unsafe types
+			// Multi-dot basenames can't come from Filename (unsafe types
 			// are omitted), so a stray '.' in the prefix means the suffix is
 			// not a cached type — leave Type empty.
 			name:    "multi-dot basename rejects suffix as type",

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -256,7 +256,7 @@ func TestFormatTodoContentEmpty(t *testing.T) {
 	}
 }
 
-func TestNoteFilename(t *testing.T) {
+func TestFilename(t *testing.T) {
 	tests := []struct {
 		date     string
 		id       int
@@ -276,15 +276,15 @@ func TestNoteFilename(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := NoteFilename(tt.date, tt.id, tt.slug, tt.noteType)
+		got := Filename(tt.date, tt.id, tt.slug, tt.noteType)
 		if got != tt.want {
-			t.Errorf("NoteFilename(%q, %d, %q, %q) = %q, want %q", tt.date, tt.id, tt.slug, tt.noteType, got, tt.want)
+			t.Errorf("Filename(%q, %d, %q, %q) = %q, want %q", tt.date, tt.id, tt.slug, tt.noteType, got, tt.want)
 		}
 	}
 }
 
-func TestNoteDirPath(t *testing.T) {
-	got := NoteDirPath("/archive", "20260312")
+func TestDirPath(t *testing.T) {
+	got := DirPath("/archive", "20260312")
 	want := "/archive/2026/03"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)


### PR DESCRIPTION
## Summary

This PR improves error handling in the annotate command and renames several note utility functions for clarity:

**Error Handling:**
- `buildAnnotateSchema()` now returns an error in addition to the schema string, allowing proper error propagation when JSON marshaling fails
- Updated `annotateRunE()` to handle the error returned by `buildAnnotateSchema()`
- Updated all call sites and tests to handle the new error return value

**Function Renames:**
- `NoteFilename()` → `Filename()` - shorter, clearer name for the note package
- `NoteDirPath()` → `DirPath()` - consistent naming convention
- Updated all call sites in `create.go`, `new_todo.go`, and `update.go`
- Updated all tests and comments to reflect the new names

**Bug Fix:**
- Fixed `update.go` to properly handle the `--private` and `--public` flags by checking if they were explicitly set, rather than just reading their values. This ensures the flags work correctly when combined with other options.

## References

- Relates to #134
- https://claude.ai/code/session_01SvNjaVjPuZnr4qcNVKhN7Y