### PR TITLE
Collapse ResolveRef/ResolveRefDate and thread date through Index.Resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.106] - 2026-04-23
+
+### Changed
+
+- `note.ResolveRef` and `note.ResolveRefDate` collapsed into a single `ResolveRef(root, query, opts...)` with a `WithDate` functional option, matching the `Load` options pattern. The `Date` suffix described a parameter rather than the operation, and `ResolveRef` was a zero-value wrapper over `ResolveRefDate(root, query, "")`. Date-aware call sites (`resolve`, `rm`) now pass `note.WithDate(date)`; plain callers keep their existing two-arg form. Adding future constraints (e.g. `WithType`) becomes a one-liner ([#161])
+
 ## [0.1.105] - 2026-04-23
 
 ### Changed
@@ -693,3 +699,4 @@
 [#158]: https://github.com/dreikanter/notes-cli/pull/158
 [#159]: https://github.com/dreikanter/notes-cli/pull/159
 [#162]: https://github.com/dreikanter/notes-cli/pull/162
+[#161]: https://github.com/dreikanter/notes-cli/pull/161

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `note.ResolveRef` and `note.ResolveRefDate` collapsed into a single `ResolveRef(root, query, opts...)` with a `WithDate` functional option, matching the `Load` options pattern. The `Date` suffix described a parameter rather than the operation, and `ResolveRef` was a zero-value wrapper over `ResolveRefDate(root, query, "")`. Date-aware call sites (`resolve`, `rm`) now pass `note.WithDate(date)`; plain callers keep their existing two-arg form. Adding future constraints (e.g. `WithType`) becomes a one-liner ([#161])
+- `Index.Resolve` now accepts the same variadic `ResolveOption` set, so `WithDate` threads through the cached index and the by-ID / by-path map lookups stay O(1) even when date-filtered (the match is discarded after the fact if its `Date` does not match). The duplicated priority chain in `resolveInEntries` (which linear-scanned a pre-filtered entry slice because it had lost the index maps) is gone; `ResolveRef` is now a thin `Load` + `Index.Resolve` wrapper ([#161])
 
 ## [0.1.105] - 2026-04-23
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -45,7 +45,7 @@ positional resolution to notes dated today.`,
 				date = time.Now().Format(note.DateFormat)
 			}
 
-			n, err := note.ResolveRefDate(root, args[0], date)
+			n, err := note.ResolveRef(root, args[0], note.WithDate(date))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -27,7 +27,7 @@ var rmCmd = &cobra.Command{
 			date = time.Now().Format(note.DateFormat)
 		}
 
-		n, err := note.ResolveRefDate(root, args[0], date)
+		n, err := note.ResolveRef(root, args[0], note.WithDate(date))
 		if err != nil {
 			return err
 		}

--- a/note/index.go
+++ b/note/index.go
@@ -403,6 +403,10 @@ func (i *Index) Tags() []string {
 //     filesystem resolution; errors on paths outside root or missing files
 //  5. slug substring → most recent entry whose Slug contains the query
 //
+// Options narrow the candidate set before the chain runs; see WithDate.
+// With a date filter the by-ID and by-path map lookups stay O(1); the match
+// is discarded after the fact if its Date does not match.
+//
 // Returns (entry, true, nil) on match, (zero, false, nil) on no match, and
 // (zero, false, err) only for genuine failures (path outside root, symlink
 // resolution error). The bool-vs-error split lets callers distinguish
@@ -413,7 +417,12 @@ func (i *Index) Tags() []string {
 // writer is not blocked on filesystem round-trips. This relies on the
 // swap-only Reload discipline — the aliased slice and maps must remain
 // immutable for the lifetime of the snapshot.
-func (i *Index) Resolve(query string) (Entry, bool, error) {
+func (i *Index) Resolve(query string, opts ...ResolveOption) (Entry, bool, error) {
+	cfg := resolveConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	query = strings.TrimSpace(query)
 
 	i.mu.RLock()
@@ -422,6 +431,16 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 	byID := i.byID
 	byRel := i.byRel
 	i.mu.RUnlock()
+
+	if cfg.date != "" {
+		filtered := make([]Entry, 0, len(entries))
+		for _, e := range entries {
+			if e.Date == cfg.date {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
 
 	if query == "" {
 		if len(entries) == 0 {
@@ -433,6 +452,9 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 	if IsID(query) {
 		e, ok := byID[query]
 		if !ok {
+			return Entry{}, false, nil
+		}
+		if cfg.date != "" && e.Date != cfg.date {
 			return Entry{}, false, nil
 		}
 		return cloneEntry(e), true, nil
@@ -453,6 +475,9 @@ func (i *Index) Resolve(query string) (Entry, bool, error) {
 		}
 		e, ok := byRel[rel]
 		if !ok {
+			return Entry{}, false, nil
+		}
+		if cfg.date != "" && e.Date != cfg.date {
 			return Entry{}, false, nil
 		}
 		return cloneEntry(e), true, nil

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -289,6 +289,54 @@ func TestIndexResolve(t *testing.T) {
 	}
 }
 
+func TestIndexResolveWithDate(t *testing.T) {
+	root := testdataPath(t)
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		date    string
+		wantID  string
+		wantOK  bool
+		wantErr bool
+	}{
+		{"empty + date picks newest on date", "", "20260104", "8818", true, false},
+		{"empty + date with no matches misses", "", "19000101", "", false, false},
+		{"id match + matching date hits", "8818", "20260104", "8818", true, false},
+		{"id match + wrong date misses (no fallthrough)", "8818", "20260106", "", false, false},
+		{"slug + matching date hits", "meeting", "20260104", "8818", true, false},
+		{"slug + non-matching date misses", "meeting", "20260106", "", false, false},
+		{"type todo + matching date hits", "todo", "20260102", "8814", true, false},
+		{"type todo + non-matching date misses", "todo", "20260106", "", false, false},
+		{"path + matching date hits", filepath.Join(root, "2026", "01", "20260106_8823_999.md"), "20260106", "8823", true, false},
+		{"path + non-matching date misses", filepath.Join(root, "2026", "01", "20260106_8823_999.md"), "20260104", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e, ok, err := idx.Resolve(tt.query, WithDate(tt.date))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Resolve(%q, WithDate(%q)) expected error", tt.query, tt.date)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q, WithDate(%q)) unexpected error: %v", tt.query, tt.date, err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("Resolve(%q, WithDate(%q)) ok = %v, want %v", tt.query, tt.date, ok, tt.wantOK)
+			}
+			if ok && e.ID != tt.wantID {
+				t.Errorf("Resolve(%q, WithDate(%q)).ID = %q, want %q", tt.query, tt.date, e.ID, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestIndexResolveEmptyStore(t *testing.T) {
 	root := t.TempDir()
 	idx, err := Load(root)

--- a/note/store.go
+++ b/note/store.go
@@ -146,28 +146,44 @@ func scanLenient(root string) ([]Note, error) {
 	return notes, nil
 }
 
+// ResolveOption configures ResolveRef. All options are optional; pass zero or
+// more.
+type ResolveOption func(*resolveConfig)
+
+type resolveConfig struct {
+	date string
+}
+
+// WithDate restricts ResolveRef candidates to notes matching the given
+// YYYYMMDD date string. An empty string disables the filter (the default).
+func WithDate(date string) ResolveOption {
+	return func(c *resolveConfig) { c.date = date }
+}
+
 // ResolveRef resolves a note reference to a Note using the following priority:
 //  1. Numeric ID — exact match; all-digit queries never fall through
 //  2. Type with special behavior (todo, backlog, weekly) — most recent match
 //  3. Path — absolute or relative path with separator, exact match under root
 //  4. Slug substring — most recent note whose slug contains the query
 //
+// Options narrow the candidate set before the priority chain runs; see
+// WithDate.
+//
 // Implementation routes through Index.Resolve on a WithFrontmatter(false)
 // load, so CLI commands that already hold an Index can call Index.Resolve
 // directly and skip this wrapper.
-func ResolveRef(root, query string) (Note, error) {
-	return ResolveRefDate(root, query, "")
-}
+func ResolveRef(root, query string, opts ...ResolveOption) (Note, error) {
+	cfg := resolveConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
 
-// ResolveRefDate works like ResolveRef but optionally restricts candidates to
-// notes matching the given YYYYMMDD date string. Pass "" to skip date filtering.
-func ResolveRefDate(root, query, date string) (Note, error) {
 	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
 		return Note{}, err
 	}
 
-	if date == "" {
+	if cfg.date == "" {
 		e, ok, err := idx.Resolve(query)
 		if err != nil {
 			return Note{}, err
@@ -179,7 +195,7 @@ func ResolveRefDate(root, query, date string) (Note, error) {
 	}
 
 	entries := idx.Entries()
-	filtered := filterEntriesByDate(entries, date)
+	filtered := filterEntriesByDate(entries, cfg.date)
 	e, ok, err := resolveInEntries(root, filtered, query)
 	if err != nil {
 		return Note{}, err

--- a/note/store.go
+++ b/note/store.go
@@ -173,30 +173,12 @@ func WithDate(date string) ResolveOption {
 // load, so CLI commands that already hold an Index can call Index.Resolve
 // directly and skip this wrapper.
 func ResolveRef(root, query string, opts ...ResolveOption) (Note, error) {
-	cfg := resolveConfig{}
-	for _, o := range opts {
-		o(&cfg)
-	}
-
 	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
 		return Note{}, err
 	}
 
-	if cfg.date == "" {
-		e, ok, err := idx.Resolve(query)
-		if err != nil {
-			return Note{}, err
-		}
-		if !ok {
-			return Note{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
-		}
-		return e.Note, nil
-	}
-
-	entries := idx.Entries()
-	filtered := filterEntriesByDate(entries, cfg.date)
-	e, ok, err := resolveInEntries(root, filtered, query)
+	e, ok, err := idx.Resolve(query, opts...)
 	if err != nil {
 		return Note{}, err
 	}
@@ -204,70 +186,6 @@ func ResolveRef(root, query string, opts ...ResolveOption) (Note, error) {
 		return Note{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
 	}
 	return e.Note, nil
-}
-
-// filterEntriesByDate returns entries whose Date field matches the given
-// YYYYMMDD string, preserving input order.
-func filterEntriesByDate(entries []Entry, date string) []Entry {
-	var out []Entry
-	for _, e := range entries {
-		if e.Date == date {
-			out = append(out, e)
-		}
-	}
-	return out
-}
-
-// resolveInEntries applies the ResolveRef priority chain to an arbitrary
-// (pre-filtered) entry slice. It mirrors Index.Resolve but linear-scans,
-// because date-restricted subsets don't share the index's maps.
-func resolveInEntries(root string, entries []Entry, query string) (Entry, bool, error) {
-	query = strings.TrimSpace(query)
-
-	if query == "" {
-		if len(entries) == 0 {
-			return Entry{}, false, nil
-		}
-		return entries[0], true, nil
-	}
-
-	if IsID(query) {
-		for _, e := range entries {
-			if e.ID == query {
-				return e, true, nil
-			}
-		}
-		return Entry{}, false, nil
-	}
-
-	if HasSpecialBehavior(query) {
-		for _, e := range entries {
-			if e.Type == query {
-				return e, true, nil
-			}
-		}
-	}
-
-	if filepath.IsAbs(query) || strings.ContainsAny(query, `/\`) {
-		rel, err := resolveRelPath(root, query)
-		if err != nil {
-			return Entry{}, false, err
-		}
-		for _, e := range entries {
-			if e.RelPath == rel {
-				return e, true, nil
-			}
-		}
-		return Entry{}, false, nil
-	}
-
-	for _, e := range entries {
-		if e.Slug != "" && strings.Contains(e.Slug, query) {
-			return e, true, nil
-		}
-	}
-
-	return Entry{}, false, nil
 }
 
 // resolveRelPath converts a path-like query to a note RelPath under root.

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -247,14 +247,14 @@ func TestResolveRef(t *testing.T) {
 	}
 }
 
-func TestResolveRefDateEmptyQueryFiltersByDate(t *testing.T) {
+func TestResolveRefWithDateEmptyQueryFiltersByDate(t *testing.T) {
 	root := testdataPath(t)
-	got, err := ResolveRefDate(root, "", "20260104")
+	got, err := ResolveRef(root, "", WithDate("20260104"))
 	if err != nil {
-		t.Fatalf("ResolveRefDate empty query error: %v", err)
+		t.Fatalf("ResolveRef WithDate empty query error: %v", err)
 	}
 	if got.ID != "8818" {
-		t.Errorf("ResolveRefDate empty + date 20260104 = %q, want 8818", got.ID)
+		t.Errorf("ResolveRef empty + WithDate(20260104) = %q, want 8818", got.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Collapse `note.ResolveRef` and `note.ResolveRefDate` into one `ResolveRef(root, query, opts...)` with a `WithDate` functional option, matching the pattern `Load` already uses. Adding future constraints (e.g. `WithType`) becomes a one-liner.
- Thread the same `ResolveOption` set through `Index.Resolve`. A date filter narrows the candidate slice up front; `byID`/`byRel` stay O(1) (the map hit is dropped after the fact when its `Date` does not match).
- Drop the duplicate priority chain (`resolveInEntries` + `filterEntriesByDate`). `ResolveRef` is now a thin `Load` + `Index.Resolve` wrapper.
- Date-aware CLI callers (`resolve`, `rm`) pass `note.WithDate(date)`; the six plain callers are unaffected because `opts` is variadic.
- New `TestIndexResolveWithDate` covers id/slug/type/path × matching/non-matching date (including the "id found but wrong date → miss, no fallthrough" invariant).

## References

- Closes Q4 of #160
- Closes Q5 of #160
