### PR TITLE
Build Index once per CLI command and route filters through []Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.107] - 2026-04-23
+
+### Changed
+
+- `note.FilterByTags` no longer re-scans the store. Its signature is now `FilterByTags(entries []Entry, tags []string) []Entry` — the `root` argument and internal `Load` are gone; merged tags are read directly from `Entry.MergedTags()`. For `ls --tag foo` the prior two `WalkDir` passes (plus a second frontmatter read the first pass did not need) collapse to one walk with frontmatter ([#163])
+- `note.Filter`, `FilterByDate`, `FilterBySlug`, `FilterByTypes`, `FindTodayTodo`, and `FindLatestTodo` now take `[]Entry` so the CLI pipeline is uniformly `Load → []Entry → …`. `Entry` embeds `Note`, so field access inside these helpers is unchanged ([#163])
+- `internal/cli`: `applyFilters` takes and returns `[]note.Entry` (and no longer needs `root`). A new `loadOptsFor(f)` picks `note.WithFrontmatter(true)` only when a `--tag` filter is active, so commands that do not touch tags do not pay the frontmatter-read cost. Every CLI entry point (`ls`, `resolve`, `read`, `append`, `new --upsert`, `new-todo`) now does a single `note.Load` at the top and feeds `idx.Entries()` through the pipeline ([#163])
+
 ## [0.1.106] - 2026-04-23
 
 ### Changed
@@ -701,3 +709,4 @@
 [#159]: https://github.com/dreikanter/notes-cli/pull/159
 [#162]: https://github.com/dreikanter/notes-cli/pull/162
 [#161]: https://github.com/dreikanter/notes-cli/pull/161
+[#163]: https://github.com/dreikanter/notes-cli/pull/163

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -51,20 +51,17 @@ var appendCmd = &cobra.Command{
 			}
 			targetPath = filepath.Join(root, n.RelPath)
 		} else if f.active() {
-			notes, scanErr := note.Scan(root)
-			if scanErr != nil {
-				return scanErr
+			idx, loadErr := note.Load(root, loadOptsFor(f))
+			if loadErr != nil {
+				return loadErr
 			}
 
-			notes, err = applyFilters(notes, root, f)
-			if err != nil {
-				return err
-			}
+			entries := applyFilters(idx.Entries(), f)
 
-			if len(notes) == 0 {
+			if len(entries) == 0 {
 				return fmt.Errorf("no notes found matching filters: %s", f.describe())
 			}
-			targetPath = filepath.Join(root, notes[0].RelPath)
+			targetPath = filepath.Join(root, entries[0].RelPath)
 		} else {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -53,25 +53,30 @@ func (f filterOpts) describe() string {
 	return strings.Join(parts, " ")
 }
 
-// applyFilters applies the common filter pipeline to a list of notes.
-func applyFilters(notes []note.Note, root string, f filterOpts) ([]note.Note, error) {
+// loadOptsFor picks Load options matching the fields this filter set touches.
+// Tag filters need merged frontmatter+body tags; every other filter only
+// touches filename-derived fields, so the frontmatter read is skipped.
+func loadOptsFor(f filterOpts) note.LoadOption {
+	return note.WithFrontmatter(len(f.Tags) > 0)
+}
+
+// applyFilters applies the common filter pipeline to a list of entries.
+// All stages operate on []Entry, so the tag filter reads tags directly from
+// the entries (populated once during Load) rather than re-scanning the store.
+func applyFilters(entries []note.Entry, f filterOpts) []note.Entry {
 	if f.Today {
-		notes = note.FilterByDate(notes, time.Now().Format(note.DateFormat))
+		entries = note.FilterByDate(entries, time.Now().Format(note.DateFormat))
 	}
 	if len(f.Types) > 0 {
-		notes = note.FilterByTypes(notes, f.Types)
+		entries = note.FilterByTypes(entries, f.Types)
 	}
 	if f.Slug != "" {
-		notes = note.FilterBySlug(notes, f.Slug)
+		entries = note.FilterBySlug(entries, f.Slug)
 	}
 	if len(f.Tags) > 0 {
-		var err error
-		notes, err = note.FilterByTags(notes, root, f.Tags)
-		if err != nil {
-			return nil, err
-		}
+		entries = note.FilterByTags(entries, f.Tags)
 	}
-	return notes, nil
+	return entries
 }
 
 // addFilterFlags registers the common filter flags on a command.

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -21,26 +21,24 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		notes, err := note.Scan(root)
+		idx, err := note.Load(root, loadOptsFor(f))
 		if err != nil {
 			return err
 		}
+		entries := idx.Entries()
 
 		if lsName != "" {
-			notes = note.Filter(notes, lsName)
+			entries = note.Filter(entries, lsName)
 		}
 
-		notes, err = applyFilters(notes, root, f)
-		if err != nil {
-			return err
+		entries = applyFilters(entries, f)
+
+		if lsLimit > 0 && len(entries) > lsLimit {
+			entries = entries[:lsLimit]
 		}
 
-		if lsLimit > 0 && len(notes) > lsLimit {
-			notes = notes[:lsLimit]
-		}
-
-		for _, n := range notes {
-			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
+		for _, e := range entries {
+			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, e.RelPath))
 		}
 		return nil
 	},

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -40,19 +40,19 @@ var newCmd = &cobra.Command{
 		// --upsert: check if today already has a matching note
 		if upsert {
 			today := time.Now().Format(note.DateFormat)
-			notes, err := note.Scan(root)
+			idx, err := note.Load(root, note.WithFrontmatter(false))
 			if err != nil {
 				return err
 			}
-			notes = note.FilterByDate(notes, today)
+			entries := note.FilterByDate(idx.Entries(), today)
 			if noteType != "" {
-				notes = note.FilterByTypes(notes, []string{noteType})
+				entries = note.FilterByTypes(entries, []string{noteType})
 			}
 			if slug != "" {
-				notes = note.FilterBySlug(notes, slug)
+				entries = note.FilterBySlug(entries, slug)
 			}
-			if len(notes) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, notes[0].RelPath))
+			if len(entries) > 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, entries[0].RelPath))
 				return nil
 			}
 		}

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -22,19 +22,20 @@ var newTodoCmd = &cobra.Command{
 		}
 		today := time.Now().Format(note.DateFormat)
 
-		notes, err := note.Scan(root)
+		idx, err := note.Load(root, note.WithFrontmatter(false))
 		if err != nil {
 			return err
 		}
+		entries := idx.Entries()
 
-		if existing := note.FindTodayTodo(notes, today); existing != nil {
+		if existing := note.FindTodayTodo(entries, today); existing != nil {
 			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, existing.RelPath))
 			return nil
 		}
 
 		// Find the most recent previous todo and roll over tasks
 		var carriedTasks []note.Task
-		prev := note.FindLatestTodo(notes, today)
+		prev := note.FindLatestTodo(entries, today)
 		if prev != nil {
 			prevPath := filepath.Join(root, prev.RelPath)
 			prevData, err := os.ReadFile(prevPath)

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -33,20 +33,17 @@ var readCmd = &cobra.Command{
 			}
 			relPath = n.RelPath
 		} else if f.active() {
-			notes, err := note.Scan(root)
+			idx, err := note.Load(root, loadOptsFor(f))
 			if err != nil {
 				return err
 			}
 
-			notes, err = applyFilters(notes, root, f)
-			if err != nil {
-				return err
-			}
+			entries := applyFilters(idx.Entries(), f)
 
-			if len(notes) == 0 {
+			if len(entries) == 0 {
 				return fmt.Errorf("no notes found matching filters: %s", f.describe())
 			}
-			relPath = notes[0].RelPath
+			relPath = entries[0].RelPath
 		} else {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -54,24 +54,21 @@ positional resolution to notes dated today.`,
 			return nil
 		}
 
-		notes, err := note.Scan(root)
+		idx, err := note.Load(root, loadOptsFor(f))
 		if err != nil {
 			return err
 		}
 
-		notes, err = applyFilters(notes, root, f)
-		if err != nil {
-			return err
-		}
+		entries := applyFilters(idx.Entries(), f)
 
-		if len(notes) == 0 {
+		if len(entries) == 0 {
 			if f.active() {
 				return fmt.Errorf("no notes found matching filters: %s", f.describe())
 			}
 			return fmt.Errorf("no notes found")
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, notes[0].RelPath))
+		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, entries[0].RelPath))
 		return nil
 	},
 }

--- a/note/store.go
+++ b/note/store.go
@@ -214,46 +214,38 @@ func resolveRelPath(root, query string) (string, error) {
 	return rel, nil
 }
 
-// Filter returns all notes whose filename contains the fragment (case-insensitive).
-func Filter(notes []Note, fragment string) []Note {
+// Filter returns entries whose filename contains the fragment (case-insensitive).
+func Filter(entries []Entry, fragment string) []Entry {
 	fragment = strings.ToLower(fragment)
-	var results []Note
-	for _, n := range notes {
-		if strings.Contains(strings.ToLower(filepath.Base(n.RelPath)), fragment) {
-			results = append(results, n)
+	var results []Entry
+	for _, e := range entries {
+		if strings.Contains(strings.ToLower(filepath.Base(e.RelPath)), fragment) {
+			results = append(results, e)
 		}
 	}
 	return results
 }
 
-// FilterByTags returns notes that contain all of the given tags. Tag sources
-// mirror ExtractTags: frontmatter `tags:` fields and body hashtags (#word).
-// Comparison is case-insensitive.
+// FilterByTags returns entries whose merged tags (frontmatter `tags:` plus body
+// hashtags, case-folded) include every tag in tags. The caller supplies the
+// entries — typically from a single Load — so no additional filesystem walk
+// or frontmatter read happens here.
 //
-// Implementation routes through Load so the tag index is built from a single
-// concurrent file-read pass; the []Note signature is preserved as a shim for
-// callers that don't yet hold an Index. A per-note frontmatter parse error is
-// logged to stderr during Load and leaves the note's frontmatter tags empty;
-// body hashtags are still considered.
-func FilterByTags(notes []Note, root string, tags []string) ([]Note, error) {
-	if len(notes) == 0 {
-		return nil, nil
+// An entry whose frontmatter failed to parse during Load still considers its
+// body hashtags (Load logs the parse error and falls back to body-only);
+// entries from Load(WithFrontmatter(false)) have empty MergedTags and match
+// only if tags is also empty.
+func FilterByTags(entries []Entry, tags []string) []Entry {
+	if len(entries) == 0 {
+		return nil
 	}
-	idx, err := Load(root)
-	if err != nil {
-		return nil, err
-	}
-	var results []Note
-	for _, n := range notes {
-		e, ok := idx.ByRel(n.RelPath)
-		if !ok {
-			continue
-		}
+	var results []Entry
+	for _, e := range entries {
 		if hasAllTags(e.MergedTags(), tags) {
-			results = append(results, n)
+			results = append(results, e)
 		}
 	}
-	return results, nil
+	return results
 }
 
 // hasAllTags reports whether every entry in required appears in noteTags,
@@ -272,35 +264,35 @@ func hasAllTags(noteTags []string, required []string) bool {
 	return true
 }
 
-// FilterByDate returns notes whose Date field matches the given YYYYMMDD string.
-func FilterByDate(notes []Note, date string) []Note {
-	var results []Note
-	for _, n := range notes {
-		if n.Date == date {
-			results = append(results, n)
+// FilterByDate returns entries whose Date field matches the given YYYYMMDD string.
+func FilterByDate(entries []Entry, date string) []Entry {
+	var results []Entry
+	for _, e := range entries {
+		if e.Date == date {
+			results = append(results, e)
 		}
 	}
 	return results
 }
 
-// FilterBySlug returns notes with an exact slug match.
-func FilterBySlug(notes []Note, slug string) []Note {
-	var results []Note
-	for _, n := range notes {
-		if n.Slug == slug {
-			results = append(results, n)
+// FilterBySlug returns entries with an exact slug match.
+func FilterBySlug(entries []Entry, slug string) []Entry {
+	var results []Entry
+	for _, e := range entries {
+		if e.Slug == slug {
+			results = append(results, e)
 		}
 	}
 	return results
 }
 
-// FilterByTypes returns notes whose type matches any of the given values.
-func FilterByTypes(notes []Note, types []string) []Note {
+// FilterByTypes returns entries whose type matches any of the given values.
+func FilterByTypes(entries []Entry, types []string) []Entry {
 	set := toSet(types)
-	var results []Note
-	for _, n := range notes {
-		if _, ok := set[n.Type]; ok {
-			results = append(results, n)
+	var results []Entry
+	for _, e := range entries {
+		if _, ok := set[e.Type]; ok {
+			results = append(results, e)
 		}
 	}
 	return results

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -259,10 +259,10 @@ func TestResolveRefWithDateEmptyQueryFiltersByDate(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	notes := []Note{
-		{RelPath: "2026/01/20260106_8823.md", Type: ""},
-		{RelPath: "2026/01/20260102_8814.todo.md", Type: "todo"},
-		{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", Type: ""},
+	entries := []Entry{
+		{Note: Note{RelPath: "2026/01/20260106_8823.md", Type: ""}},
+		{Note: Note{RelPath: "2026/01/20260102_8814.todo.md", Type: "todo"}},
+		{Note: Note{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", Type: ""}},
 	}
 
 	tests := []struct {
@@ -280,7 +280,7 @@ func TestFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Filter(notes, tt.fragment)
+			got := Filter(entries, tt.fragment)
 			if len(got) != tt.wantLen {
 				t.Errorf("Filter(%q) returned %d results, want %d", tt.fragment, len(got), tt.wantLen)
 			}
@@ -290,10 +290,11 @@ func TestFilter(t *testing.T) {
 
 func TestFilterByTags(t *testing.T) {
 	root := testdataPath(t)
-	notes, err := Scan(root)
+	idx, err := Load(root)
 	if err != nil {
-		t.Fatalf("Scan error: %v", err)
+		t.Fatalf("Load error: %v", err)
 	}
+	entries := idx.Entries()
 
 	tests := []struct {
 		name    string
@@ -313,12 +314,9 @@ func TestFilterByTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FilterByTags(notes, root, tt.tags)
-			if err != nil {
-				t.Fatalf("FilterByTags(%v) error: %v", tt.tags, err)
-			}
+			got := FilterByTags(entries, tt.tags)
 			if len(got) != tt.wantLen {
-				t.Fatalf("FilterByTags(%v) returned %d notes, want %d", tt.tags, len(got), tt.wantLen)
+				t.Fatalf("FilterByTags(%v) returned %d entries, want %d", tt.tags, len(got), tt.wantLen)
 			}
 			for i, wantID := range tt.wantIDs {
 				if got[i].ID != wantID {
@@ -338,10 +336,11 @@ func TestFilterByTagsInlineHashtags(t *testing.T) {
 	writeNote(t, root, "2026/01/20260103_1003.md",
 		"---\ntags: [work]\n---\n\nno inline tags here.\n")
 
-	notes, err := Scan(root)
+	idx, err := Load(root)
 	if err != nil {
-		t.Fatalf("Scan error: %v", err)
+		t.Fatalf("Load error: %v", err)
 	}
+	entries := idx.Entries()
 
 	tests := []struct {
 		name    string
@@ -356,12 +355,9 @@ func TestFilterByTagsInlineHashtags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FilterByTags(notes, root, tt.tags)
-			if err != nil {
-				t.Fatalf("FilterByTags(%v) error: %v", tt.tags, err)
-			}
+			got := FilterByTags(entries, tt.tags)
 			if len(got) != len(tt.wantIDs) {
-				t.Fatalf("FilterByTags(%v) returned %d notes, want %d", tt.tags, len(got), len(tt.wantIDs))
+				t.Fatalf("FilterByTags(%v) returned %d entries, want %d", tt.tags, len(got), len(tt.wantIDs))
 			}
 			for i, wantID := range tt.wantIDs {
 				if got[i].ID != wantID {
@@ -373,47 +369,47 @@ func TestFilterByTagsInlineHashtags(t *testing.T) {
 }
 
 func TestFilterBySlug(t *testing.T) {
-	notes := []Note{
-		{Slug: ""},
-		{Slug: "api-redesign"},
-		{Slug: "disable-letter_opener"},
+	entries := []Entry{
+		{Note: Note{Slug: ""}},
+		{Note: Note{Slug: "api-redesign"}},
+		{Note: Note{Slug: "disable-letter_opener"}},
 	}
 
-	got := FilterBySlug(notes, "api-redesign")
+	got := FilterBySlug(entries, "api-redesign")
 	if len(got) != 1 {
 		t.Errorf("FilterBySlug(api-redesign) returned %d, want 1", len(got))
 	}
 
-	got = FilterBySlug(notes, "")
+	got = FilterBySlug(entries, "")
 	if len(got) != 1 {
 		t.Errorf("FilterBySlug('') returned %d, want 1", len(got))
 	}
 
-	got = FilterBySlug(notes, "nope")
+	got = FilterBySlug(entries, "nope")
 	if len(got) != 0 {
 		t.Errorf("FilterBySlug(nope) returned %d, want 0", len(got))
 	}
 }
 
 func TestFilterByDate(t *testing.T) {
-	notes := []Note{
-		{Date: "20260106", ID: "8823"},
-		{Date: "20260104", ID: "8818"},
-		{Date: "20260102", ID: "8814"},
-		{Date: "20241203", ID: "6973"},
+	entries := []Entry{
+		{Note: Note{Date: "20260106", ID: "8823"}},
+		{Note: Note{Date: "20260104", ID: "8818"}},
+		{Note: Note{Date: "20260102", ID: "8814"}},
+		{Note: Note{Date: "20241203", ID: "6973"}},
 	}
 
-	got := FilterByDate(notes, "20260106")
+	got := FilterByDate(entries, "20260106")
 	if len(got) != 1 || got[0].ID != "8823" {
 		t.Errorf("FilterByDate(20260106) = %v, want [{ID:8823}]", got)
 	}
 
-	got = FilterByDate(notes, "20260104")
+	got = FilterByDate(entries, "20260104")
 	if len(got) != 1 || got[0].ID != "8818" {
 		t.Errorf("FilterByDate(20260104) = %v, want [{ID:8818}]", got)
 	}
 
-	got = FilterByDate(notes, "20991231")
+	got = FilterByDate(entries, "20991231")
 	if len(got) != 0 {
 		t.Errorf("FilterByDate(no match) = %v, want []", got)
 	}
@@ -449,11 +445,11 @@ func TestValidateSlug(t *testing.T) {
 }
 
 func TestFilterByTypes(t *testing.T) {
-	notes := []Note{
-		{Type: ""},
-		{Type: "todo"},
-		{Type: "backlog"},
-		{Type: "todo"},
+	entries := []Entry{
+		{Note: Note{Type: ""}},
+		{Note: Note{Type: "todo"}},
+		{Note: Note{Type: "backlog"}},
+		{Note: Note{Type: "todo"}},
 	}
 
 	tests := []struct {
@@ -470,7 +466,7 @@ func TestFilterByTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FilterByTypes(notes, tt.types)
+			got := FilterByTypes(entries, tt.types)
 			if len(got) != tt.wantLen {
 				t.Errorf("FilterByTypes(%v) returned %d, want %d", tt.types, len(got), tt.wantLen)
 			}

--- a/note/todo.go
+++ b/note/todo.go
@@ -131,22 +131,22 @@ func FormatTodoContent(tasks []Task) string {
 	return strings.Join(lines, "\n\n") + "\n"
 }
 
-// FindLatestTodo finds the most recent todo note strictly before the given date.
-func FindLatestTodo(notes []Note, beforeDate string) *Note {
-	// notes are sorted newest-first
-	for i := range notes {
-		if notes[i].Type == "todo" && notes[i].Date < beforeDate {
-			return &notes[i]
+// FindLatestTodo finds the most recent todo entry strictly before the given date.
+func FindLatestTodo(entries []Entry, beforeDate string) *Entry {
+	// entries are sorted newest-first
+	for i := range entries {
+		if entries[i].Type == "todo" && entries[i].Date < beforeDate {
+			return &entries[i]
 		}
 	}
 	return nil
 }
 
-// FindTodayTodo finds a todo note matching today's date.
-func FindTodayTodo(notes []Note, today string) *Note {
-	for i := range notes {
-		if notes[i].Type == "todo" && notes[i].Date == today {
-			return &notes[i]
+// FindTodayTodo finds a todo entry matching today's date.
+func FindTodayTodo(entries []Entry, today string) *Entry {
+	for i := range entries {
+		if entries[i].Type == "todo" && entries[i].Date == today {
+			return &entries[i]
 		}
 	}
 	return nil

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -292,14 +292,14 @@ func TestDirPath(t *testing.T) {
 }
 
 func TestFindLatestTodo(t *testing.T) {
-	notes := []Note{
-		{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"},
-		{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"},
-		{Date: "20260310", Type: "", RelPath: "2026/03/20260310_98.md"},
-		{Date: "20260309", Type: "todo", RelPath: "2026/03/20260309_97.todo.md"},
+	entries := []Entry{
+		{Note: Note{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
+		{Note: Note{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
+		{Note: Note{Date: "20260310", Type: "", RelPath: "2026/03/20260310_98.md"}},
+		{Note: Note{Date: "20260309", Type: "todo", RelPath: "2026/03/20260309_97.todo.md"}},
 	}
 
-	got := FindLatestTodo(notes, "20260312")
+	got := FindLatestTodo(entries, "20260312")
 	if got == nil {
 		t.Fatal("expected to find a todo")
 	}
@@ -309,22 +309,22 @@ func TestFindLatestTodo(t *testing.T) {
 }
 
 func TestFindLatestTodoNone(t *testing.T) {
-	notes := []Note{
-		{Date: "20260312", Type: "todo"},
+	entries := []Entry{
+		{Note: Note{Date: "20260312", Type: "todo"}},
 	}
-	got := FindLatestTodo(notes, "20260312")
+	got := FindLatestTodo(entries, "20260312")
 	if got != nil {
 		t.Error("expected nil when no previous todo exists")
 	}
 }
 
 func TestFindTodayTodo(t *testing.T) {
-	notes := []Note{
-		{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"},
-		{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"},
+	entries := []Entry{
+		{Note: Note{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
+		{Note: Note{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
 	}
 
-	got := FindTodayTodo(notes, "20260312")
+	got := FindTodayTodo(entries, "20260312")
 	if got == nil {
 		t.Fatal("expected to find today's todo")
 	}
@@ -332,7 +332,7 @@ func TestFindTodayTodo(t *testing.T) {
 		t.Errorf("got date %s, want 20260312", got.Date)
 	}
 
-	got = FindTodayTodo(notes, "20260313")
+	got = FindTodayTodo(entries, "20260313")
 	if got != nil {
 		t.Error("expected nil for future date")
 	}


### PR DESCRIPTION
## Summary

- `note.FilterByTags` no longer re-scans the store. It now takes `[]Entry` (and drops the `root` argument and the internal `Load`), matching tags directly from `Entry.MergedTags()` populated by the caller's single `Load`. For `ls --tag foo` this cuts the prior two-walks-plus-second-frontmatter-read down to one walk with frontmatter.
- `note.Filter`, `FilterByDate`, `FilterBySlug`, `FilterByTypes`, `FindTodayTodo`, and `FindLatestTodo` all move to the `[]Entry` shape so the whole pipeline is `Load → []Entry → …`. `Entry` embeds `Note`, so the field-level code inside each helper is unchanged.
- `internal/cli/filter.go`: `applyFilters` now takes and returns `[]note.Entry` and no longer needs `root`. New `loadOptsFor(f) note.LoadOption` picks `WithFrontmatter(true)` when a `--tag` filter is active and `WithFrontmatter(false)` otherwise, so commands that never touch tags do not pay the frontmatter-read cost.
- Each CLI entry point (`ls`, `resolve`, `read`, `append`, `new --upsert`, `new-todo`) now does exactly one `note.Load(root, …)` at the top and feeds `idx.Entries()` through the pipeline. Previously `ls`/`read`/`append`/`resolve` with `--tag` walked the tree twice.
- Tests for the affected helpers (`TestFilter`, `TestFilterByTags`, `TestFilterByTagsInlineHashtags`, `TestFilterBySlug`, `TestFilterByDate`, `TestFilterByTypes`, `TestFindLatestTodo`, `TestFindLatestTodoNone`, `TestFindTodayTodo`) updated to construct `Entry` literals; `TestFilterByTags` and its inline-hashtag twin now build the input set via `Load` (no change to the assertions).

## References

- Closes Q6 of #160
