### PR TITLE
Route new/append stdin through cmd.InOrStdin()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.108] - 2026-04-23
+
+### Changed
+
+- `notes new` and `notes append` now read stdin via `cmd.InOrStdin()` instead of reading `os.Stdin` directly, so tests (or any caller) can inject input by setting `rootCmd.SetIn(...)`. The terminal-detection heuristic is now `stdinIsTerminal(io.Reader)` and only runs the `Stat()` check when the reader is an `*os.File`; any other reader (pipe, `strings.Reader`, `bytes.Buffer`, etc.) is treated as non-terminal. `new_test.go` and `append_test.go` drop the `os.Stdin = r` / `os.Pipe` dance and use `rootCmd.SetIn(strings.NewReader(...))` ([#165])
+
 ## [0.1.107] - 2026-04-23
 
 ### Changed
@@ -710,3 +716,4 @@
 [#162]: https://github.com/dreikanter/notes-cli/pull/162
 [#161]: https://github.com/dreikanter/notes-cli/pull/161
 [#163]: https://github.com/dreikanter/notes-cli/pull/163
+[#165]: https://github.com/dreikanter/notes-cli/pull/165

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -21,13 +21,12 @@ var appendCmd = &cobra.Command{
 			return err
 		}
 
-		// Check stdin is piped
-		if isTerminal(os.Stdin) {
+		in := cmd.InOrStdin()
+		if stdinIsTerminal(in) {
 			return fmt.Errorf("no input: pipe text to stdin (e.g. echo 'text' | notes append <target>)")
 		}
 
-		// Read and trim stdin
-		data, err := io.ReadAll(os.Stdin)
+		data, err := io.ReadAll(in)
 		if err != nil {
 			return fmt.Errorf("cannot read stdin: %w", err)
 		}

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,22 +45,8 @@ func runAppend(t *testing.T, root string, stdin string, args ...string) (string,
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
+	rootCmd.SetIn(strings.NewReader(stdin))
 	rootCmd.SetArgs(append([]string{"append", "--path", root}, args...))
-
-	// Replace stdin
-	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("cannot create pipe: %v", err)
-	}
-	os.Stdin = r
-
-	go func() {
-		_, _ = io.WriteString(w, stdin)
-		w.Close()
-	}()
 
 	execErr := rootCmd.Execute()
 	return strings.TrimSpace(buf.String()), execErr

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -58,8 +58,9 @@ var newCmd = &cobra.Command{
 		}
 
 		var body string
-		if !isTerminal(os.Stdin) {
-			data, err := io.ReadAll(os.Stdin)
+		in := cmd.InOrStdin()
+		if !stdinIsTerminal(in) {
+			data, err := io.ReadAll(in)
 			if err != nil {
 				return fmt.Errorf("cannot read stdin: %w", err)
 			}
@@ -85,7 +86,15 @@ var newCmd = &cobra.Command{
 	},
 }
 
-func isTerminal(f *os.File) bool {
+// stdinIsTerminal reports whether in looks like an interactive terminal. Only
+// *os.File readers are heuristically inspected; any other reader (a pipe,
+// buffer, or other io.Reader injected via cmd.SetIn) is treated as non-terminal
+// so tests and piped invocations read the provided bytes.
+func stdinIsTerminal(in io.Reader) bool {
+	f, ok := in.(*os.File)
+	if !ok {
+		return false
+	}
 	fi, err := f.Stat()
 	if err != nil {
 		return true

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,21 +17,8 @@ func runNew(t *testing.T, root string, stdin string, args ...string) (string, er
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
+	rootCmd.SetIn(strings.NewReader(stdin))
 	rootCmd.SetArgs(append([]string{"new", "--path", root}, args...))
-
-	oldStdin := os.Stdin
-	defer func() { os.Stdin = oldStdin }()
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("cannot create stdin pipe: %v", err)
-	}
-	os.Stdin = r
-
-	go func() {
-		_, _ = io.WriteString(w, stdin)
-		w.Close()
-	}()
 
 	execErr := rootCmd.Execute()
 	return strings.TrimSpace(buf.String()), execErr


### PR DESCRIPTION
## Summary

- `notes new` and `notes append` now read stdin via `cmd.InOrStdin()` instead of `os.Stdin`, so tests (and any caller) can inject input via `rootCmd.SetIn(...)` the same way they already use `SetOut`/`SetErr`.
- The terminal-detection heuristic is now `stdinIsTerminal(io.Reader)` and only runs the `Stat()` check when the reader is an `*os.File`; any other reader (pipe, `strings.Reader`, `bytes.Buffer`, etc.) is treated as non-terminal.
- `new_test.go` and `append_test.go` drop the `os.Stdin = r` / `os.Pipe` dance and use `rootCmd.SetIn(strings.NewReader(stdin))`.

## References

- Relates to #160
