### PR TITLE
Fold mergedTagsSorted back into ExtractTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.110] - 2026-04-23
+
+### Changed
+
+- `note/tags.go`: folded `*Index.mergedTagsSorted` back into `ExtractTags`. The helper was a method on `*Index` but declared in a different file from the rest of `Index`'s methods (`note/index.go`), and it had only one caller. Inlining drops the cross-file method and keeps `Index`'s surface in one place. No behavior change: nil on empty index, deduped/lowercased/sorted union of frontmatter tags and body hashtags, same locking discipline ([#167])
+
 ## [0.1.107] - 2026-04-23
 
 ### Changed
@@ -710,3 +716,4 @@
 [#162]: https://github.com/dreikanter/notes-cli/pull/162
 [#161]: https://github.com/dreikanter/notes-cli/pull/161
 [#163]: https://github.com/dreikanter/notes-cli/pull/163
+[#167]: https://github.com/dreikanter/notes-cli/pull/167

--- a/note/tags.go
+++ b/note/tags.go
@@ -19,36 +19,29 @@ func ExtractTags(root string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return idx.mergedTagsSorted(), nil
-}
-
-// mergedTagsSorted returns the sorted, deduplicated, lowercased union of all
-// entries' frontmatter tags and body hashtags. Returns nil on an empty index
-// to match ExtractTags's pre-migration behavior.
-func (i *Index) mergedTagsSorted() []string {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	if len(i.entries) == 0 {
-		return nil
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	if len(idx.entries) == 0 {
+		return nil, nil
 	}
 	set := make(map[string]struct{})
-	for _, t := range i.allTags {
+	for _, t := range idx.allTags {
 		set[t] = struct{}{}
 	}
-	for _, e := range i.entries {
+	for _, e := range idx.entries {
 		for _, t := range e.bodyHashtags {
 			set[t] = struct{}{}
 		}
 	}
 	if len(set) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]string, 0, len(set))
 	for t := range set {
 		out = append(out, t)
 	}
 	sort.Strings(out)
-	return out
+	return out, nil
 }
 
 // ExtractHashtags scans body text and returns hashtag tokens (without the


### PR DESCRIPTION
## Summary

- `*Index.mergedTagsSorted` had only one caller (`ExtractTags`) yet lived in `note/tags.go`, away from the rest of `Index`'s methods in `note/index.go`. Folded the helper back into `ExtractTags` so the method surface stays in one file and there's no orphan `Index` receiver in `tags.go`.
- No behavior change: `ExtractTags` still returns a nil slice on empty index, merges `allTags` with per-entry body hashtags into a deduped lowercase set, and sorts the result. Locking is acquired/released in `ExtractTags` around the same fields the old method touched.

## References

- Relates to #160
