### PR TITLE
Adopt functional options for note.Scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.111] - 2026-04-23
+
+### Changed
+
+- `note.Scan` swaps its `opts ...ScanOptions` variadic (documented as "only the first is honored") for the functional-options pattern already used by `Load` and `ResolveRef`. New `ScanOption func(*ScanOptions)` and `WithStrict(b bool) ScanOption`. `Scan(root)` still defaults to strict; `Scan(root, WithStrict(false))` walks the full tree. The `ScanOptions` struct stays because it's still the argument to `Load`'s `WithScanOptions` and the watcher's `WithScanOptions`. Internal call sites and tests updated to the new form ([#168])
+
 ## [0.1.107] - 2026-04-23
 
 ### Changed
@@ -710,3 +716,4 @@
 [#162]: https://github.com/dreikanter/notes-cli/pull/162
 [#161]: https://github.com/dreikanter/notes-cli/pull/161
 [#163]: https://github.com/dreikanter/notes-cli/pull/163
+[#168]: https://github.com/dreikanter/notes-cli/pull/168

--- a/note/index.go
+++ b/note/index.go
@@ -141,7 +141,7 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 // worker pool, and atomically swaps the new state in under i.mu. Called by
 // Load for the initial population and by runBuild for subsequent reloads.
 func (i *Index) build() error {
-	notes, err := Scan(i.root, i.cfg.scanOpts)
+	notes, err := Scan(i.root, WithStrict(i.cfg.scanOpts.Strict))
 	if err != nil {
 		return err
 	}

--- a/note/store.go
+++ b/note/store.go
@@ -12,35 +12,44 @@ import (
 
 // ScanOptions configures Scan's directory traversal.
 //
-// Strict=true (the default when no options are passed) restricts discovery to
-// the canonical YYYY/MM/*.md layout used by notes-cli: only top-level directories
-// whose name is all digits are considered years, and only their two-digit
-// all-digit subdirectories are considered months. Other entries are ignored.
+// Strict=true (the default) restricts discovery to the canonical YYYY/MM/*.md
+// layout used by notes-cli: only top-level directories whose name is all
+// digits are considered years, and only their two-digit all-digit
+// subdirectories are considered months. Other entries are ignored.
 //
 // Strict=false walks the entire tree under root with filepath.WalkDir and
-// considers every *.md file whose base name parses via ParseFilename, regardless
-// of nesting depth or parent directory naming. This is the layout downstream
-// tools such as notes-view consume; opt in explicitly when you need it.
+// considers every *.md file whose base name parses via ParseFilename,
+// regardless of nesting depth or parent directory naming. This is the layout
+// downstream tools such as notes-view consume; opt in explicitly when you
+// need it.
 type ScanOptions struct {
 	Strict bool
+}
+
+// ScanOption configures Scan. All options are optional; pass zero or more.
+type ScanOption func(*ScanOptions)
+
+// WithStrict sets Scan's strict-layout mode. Default true. Set false to walk
+// every *.md file under root regardless of layout.
+func WithStrict(b bool) ScanOption {
+	return func(o *ScanOptions) { o.Strict = b }
 }
 
 // Scan enumerates notes under root.
 //
 // Called as Scan(root) it preserves the historical strict YYYY/MM/*.md
-// discipline. Pass ScanOptions{Strict: false} to walk every *.md file under
-// root regardless of layout. Only the first option in opts is consulted;
-// additional values are ignored.
+// discipline. Pass WithStrict(false) to walk every *.md file under root
+// regardless of layout.
 //
 // Unreadable subdirectories are logged to stderr and skipped in both modes,
 // matching the per-note parse-error behavior, so a single permission glitch
 // can't break ls/tags/resolve.
-func Scan(root string, opts ...ScanOptions) ([]Note, error) {
-	strict := true
-	if len(opts) > 0 {
-		strict = opts[0].Strict
+func Scan(root string, opts ...ScanOption) ([]Note, error) {
+	cfg := ScanOptions{Strict: true}
+	for _, o := range opts {
+		o(&cfg)
 	}
-	if strict {
+	if cfg.Strict {
 		return scanStrict(root)
 	}
 	return scanLenient(root)

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -102,7 +102,7 @@ func TestScanSkipsUnreadableDir(t *testing.T) {
 	}
 }
 
-// TestScanStrictExplicit verifies passing ScanOptions{Strict: true} matches the
+// TestScanStrictExplicit verifies passing WithStrict(true) matches the
 // no-options default and continues to ignore non-YYYY layouts.
 func TestScanStrictExplicit(t *testing.T) {
 	root := t.TempDir()
@@ -110,7 +110,7 @@ func TestScanStrictExplicit(t *testing.T) {
 	writeNote(t, root, "drafts/20260102_2.md", "body\n")
 	writeNote(t, root, "inbox/2026/01/20260103_3.md", "body\n")
 
-	notes, err := Scan(root, ScanOptions{Strict: true})
+	notes, err := Scan(root, WithStrict(true))
 	if err != nil {
 		t.Fatalf("Scan strict error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestScanLenient(t *testing.T) {
 	writeNote(t, root, "drafts/not-a-note.md", "body\n")
 	writeNote(t, root, "drafts/random_file.txt", "body\n")
 
-	notes, err := Scan(root, ScanOptions{Strict: false})
+	notes, err := Scan(root, WithStrict(false))
 	if err != nil {
 		t.Fatalf("Scan lenient error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestScanLenientSkipsUnreadableDir(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o755) })
 
-	notes, err := Scan(root, ScanOptions{Strict: false})
+	notes, err := Scan(root, WithStrict(false))
 	if err != nil {
 		t.Fatalf("Scan lenient error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `note.Scan` swaps its `opts ...ScanOptions` variadic (documented as "only the first is honored") for the functional-options pattern already used by `Load` / `ResolveRef`: `Scan(root string, opts ...ScanOption) ([]Note, error)`.
- New `ScanOption func(*ScanOptions)` and `WithStrict(b bool) ScanOption`. `Scan(root)` still defaults to `Strict: true`; `Scan(root, WithStrict(false))` walks the full tree. The `ScanOptions` struct stays (it's also the argument to `Load`'s `WithScanOptions` and the watcher's `WithScanOptions`, which are unchanged).
- Callers updated: `Index.build` (`Scan(i.root, WithStrict(i.cfg.scanOpts.Strict))`) and the `store_test.go` cases that previously constructed `ScanOptions{Strict: …}` inline.

## References

- Relates to #160 
