### PR TITLE
Rename Note to Ref to eliminate package/type stutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0] - 2026-04-23
+
+### Changed
+
+- Rename `note.Note` → `note.Ref` to drop the package/type stutter. `Entry` now embeds `Ref` instead of `Note`, and `ResolveRef` / `Scan` / `ParseFilename` now return `Ref`. The `Ref` field name replaces `Note` in `Entry` struct literals. No cross-package changes required — external callers only consume `note.Entry` and never reference `note.Note` by name. ([#164])
+
+[#164]: https://github.com/dreikanter/notes-cli/pull/164
+
 ## [0.1.111] - 2026-04-23
 
 ### Changed

--- a/note/date.go
+++ b/note/date.go
@@ -9,12 +9,12 @@ import (
 // dates. Use with time.Parse / time.Format (and ParseInLocation for UTC).
 const DateFormat = "20060102"
 
-// Time parses Note.Date (the UID-derived YYYYMMDD prefix) to a time.Time at
+// Time parses Ref.Date (the UID-derived YYYYMMDD prefix) to a time.Time at
 // midnight UTC. It returns false when Date is not a valid YYYYMMDD value;
 // values outside the canonical 8-character form (e.g. short or long years)
 // are reported as malformed even though ParseFilename accepts them.
-func (n Note) Time() (time.Time, bool) {
-	t, err := time.ParseInLocation(DateFormat, n.Date, time.UTC)
+func (r Ref) Time() (time.Time, bool) {
+	t, err := time.ParseInLocation(DateFormat, r.Date, time.UTC)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/note/date_test.go
+++ b/note/date_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestNoteTime(t *testing.T) {
+func TestRefTime(t *testing.T) {
 	cases := []struct {
 		name   string
 		date   string
@@ -34,8 +34,8 @@ func TestNoteTime(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			n := Note{Date: tc.date}
-			got, ok := n.Time()
+			r := Ref{Date: tc.date}
+			got, ok := r.Time()
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
 			}
@@ -78,49 +78,49 @@ func TestResolveEntryDate(t *testing.T) {
 	}{
 		{
 			name:       "uid wins over frontmatter and mtime",
-			entry:      Entry{Note: Note{Date: "20260106"}, Frontmatter: Frontmatter{Date: fmTime}},
+			entry:      Entry{Ref: Ref{Date: "20260106"}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   uidTime,
 			wantSource: "uid",
 		},
 		{
 			name:       "frontmatter when uid malformed",
-			entry:      Entry{Note: Note{Date: "bogus"}, Frontmatter: Frontmatter{Date: fmTime}},
+			entry:      Entry{Ref: Ref{Date: "bogus"}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   fmTime,
 			wantSource: "frontmatter",
 		},
 		{
 			name:       "mtime when uid malformed and frontmatter zero",
-			entry:      Entry{Note: Note{Date: ""}},
+			entry:      Entry{Ref: Ref{Date: ""}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   mtime,
 			wantSource: "mtime",
 		},
 		{
 			name:       "nil fi skips mtime fallback",
-			entry:      Entry{Note: Note{Date: "bad"}},
+			entry:      Entry{Ref: Ref{Date: "bad"}},
 			fi:         nil,
 			wantTime:   time.Time{},
 			wantSource: "",
 		},
 		{
 			name:       "nil fi still uses uid when valid",
-			entry:      Entry{Note: Note{Date: "20260106"}},
+			entry:      Entry{Ref: Ref{Date: "20260106"}},
 			fi:         nil,
 			wantTime:   uidTime,
 			wantSource: "uid",
 		},
 		{
 			name:       "nil fi still uses frontmatter when uid malformed",
-			entry:      Entry{Note: Note{Date: ""}, Frontmatter: Frontmatter{Date: fmTime}},
+			entry:      Entry{Ref: Ref{Date: ""}, Frontmatter: Frontmatter{Date: fmTime}},
 			fi:         nil,
 			wantTime:   fmTime,
 			wantSource: "frontmatter",
 		},
 		{
 			name:       "uid wins even when frontmatter is zero",
-			entry:      Entry{Note: Note{Date: "20260106"}},
+			entry:      Entry{Ref: Ref{Date: "20260106"}},
 			fi:         fakeFileInfo{mtime: mtime},
 			wantTime:   uidTime,
 			wantSource: "uid",

--- a/note/index.go
+++ b/note/index.go
@@ -14,12 +14,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Entry is a fully-hydrated note record: the filename-derived Note plus
+// Entry is a fully-hydrated note record: the filename-derived Ref plus
 // frontmatter and file stat metadata. It is the unit Index exposes to
 // downstream consumers (notes-view, notes-pub) that previously maintained
 // their own in-memory indexes.
 type Entry struct {
-	Note
+	Ref
 	Frontmatter Frontmatter
 	ModTime     time.Time
 	Size        int64
@@ -148,7 +148,7 @@ func (i *Index) build() error {
 
 	entries := make([]Entry, len(notes))
 	for j, n := range notes {
-		entries[j] = Entry{Note: n}
+		entries[j] = Entry{Ref: n}
 	}
 
 	if len(entries) > 0 {

--- a/note/note.go
+++ b/note/note.go
@@ -21,8 +21,12 @@ func HasSpecialBehavior(s string) bool {
 	return false
 }
 
-// Note represents a single note file in the store.
-type Note struct {
+// Ref is a filename-derived reference to a single note file in the store: the
+// fields Ref carries are exactly what ParseFilename can recover from the base
+// name plus the walker's RelPath. It is the lightweight half of the two-tier
+// model — pair with Frontmatter and stat metadata to get a fully-hydrated
+// Entry.
+type Ref struct {
 	RelPath string // relative path from store root, e.g. "2026/01/20260106_8823.md"
 	Date    string // date as Y...YMMDD, e.g. "20260106"
 	ID      string // "8823"
@@ -42,7 +46,7 @@ func isFilenameCacheSafeType(noteType string) bool {
 // Expected format: Y...YMMDD_ID[_slug][.TYPE], where MM and DD are zero-padded.
 // The dot-suffix is extracted as the filename-reported Type only when it round-
 // trips cleanly (see isFilenameCacheSafeType). Frontmatter `type` is canonical.
-func ParseFilename(baseName string) (Note, error) {
+func ParseFilename(baseName string) (Ref, error) {
 	noteType := ""
 	remaining := baseName
 
@@ -60,17 +64,17 @@ func ParseFilename(baseName string) (Note, error) {
 
 	parts := strings.SplitN(remaining, "_", 3)
 	if len(parts) < 2 {
-		return Note{}, fmt.Errorf("invalid note filename: %s", baseName)
+		return Ref{}, fmt.Errorf("invalid note filename: %s", baseName)
 	}
 
 	date := parts[0]
 	if len(date) < 5 || !IsDigits(date) {
-		return Note{}, fmt.Errorf("invalid date in filename: %s", baseName)
+		return Ref{}, fmt.Errorf("invalid date in filename: %s", baseName)
 	}
 
 	id := parts[1]
 	if !IsID(id) {
-		return Note{}, fmt.Errorf("invalid id in filename: %s", baseName)
+		return Ref{}, fmt.Errorf("invalid id in filename: %s", baseName)
 	}
 
 	slug := ""
@@ -78,7 +82,7 @@ func ParseFilename(baseName string) (Note, error) {
 		slug = parts[2]
 	}
 
-	return Note{
+	return Ref{
 		Date: date,
 		ID:   id,
 		Slug: slug,

--- a/note/store.go
+++ b/note/store.go
@@ -44,7 +44,7 @@ func WithStrict(b bool) ScanOption {
 // Unreadable subdirectories are logged to stderr and skipped in both modes,
 // matching the per-note parse-error behavior, so a single permission glitch
 // can't break ls/tags/resolve.
-func Scan(root string, opts ...ScanOption) ([]Note, error) {
+func Scan(root string, opts ...ScanOption) ([]Ref, error) {
 	cfg := ScanOptions{Strict: true}
 	for _, o := range opts {
 		o(&cfg)
@@ -55,8 +55,8 @@ func Scan(root string, opts ...ScanOption) ([]Note, error) {
 	return scanLenient(root)
 }
 
-func scanStrict(root string) ([]Note, error) {
-	var notes []Note
+func scanStrict(root string) ([]Ref, error) {
+	var notes []Ref
 
 	years, err := os.ReadDir(root)
 	if err != nil {
@@ -111,8 +111,8 @@ func scanStrict(root string) ([]Note, error) {
 	return notes, nil
 }
 
-func scanLenient(root string) ([]Note, error) {
-	var notes []Note
+func scanLenient(root string) ([]Ref, error) {
+	var notes []Ref
 
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -169,7 +169,7 @@ func WithDate(date string) ResolveOption {
 	return func(c *resolveConfig) { c.date = date }
 }
 
-// ResolveRef resolves a note reference to a Note using the following priority:
+// ResolveRef resolves a note reference to a Ref using the following priority:
 //  1. Numeric ID — exact match; all-digit queries never fall through
 //  2. Type with special behavior (todo, backlog, weekly) — most recent match
 //  3. Path — absolute or relative path with separator, exact match under root
@@ -181,20 +181,20 @@ func WithDate(date string) ResolveOption {
 // Implementation routes through Index.Resolve on a WithFrontmatter(false)
 // load, so CLI commands that already hold an Index can call Index.Resolve
 // directly and skip this wrapper.
-func ResolveRef(root, query string, opts ...ResolveOption) (Note, error) {
+func ResolveRef(root, query string, opts ...ResolveOption) (Ref, error) {
 	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
-		return Note{}, err
+		return Ref{}, err
 	}
 
 	e, ok, err := idx.Resolve(query, opts...)
 	if err != nil {
-		return Note{}, err
+		return Ref{}, err
 	}
 	if !ok {
-		return Note{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
+		return Ref{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
 	}
-	return e.Note, nil
+	return e.Ref, nil
 }
 
 // resolveRelPath converts a path-like query to a note RelPath under root.

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -260,9 +260,9 @@ func TestResolveRefWithDateEmptyQueryFiltersByDate(t *testing.T) {
 
 func TestFilter(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{RelPath: "2026/01/20260106_8823.md", Type: ""}},
-		{Note: Note{RelPath: "2026/01/20260102_8814.todo.md", Type: "todo"}},
-		{Note: Note{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", Type: ""}},
+		{Ref: Ref{RelPath: "2026/01/20260106_8823.md", Type: ""}},
+		{Ref: Ref{RelPath: "2026/01/20260102_8814.todo.md", Type: "todo"}},
+		{Ref: Ref{RelPath: "2024/12/20241203_6973_disable-letter_opener.md", Type: ""}},
 	}
 
 	tests := []struct {
@@ -370,9 +370,9 @@ func TestFilterByTagsInlineHashtags(t *testing.T) {
 
 func TestFilterBySlug(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Slug: ""}},
-		{Note: Note{Slug: "api-redesign"}},
-		{Note: Note{Slug: "disable-letter_opener"}},
+		{Ref: Ref{Slug: ""}},
+		{Ref: Ref{Slug: "api-redesign"}},
+		{Ref: Ref{Slug: "disable-letter_opener"}},
 	}
 
 	got := FilterBySlug(entries, "api-redesign")
@@ -393,10 +393,10 @@ func TestFilterBySlug(t *testing.T) {
 
 func TestFilterByDate(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Date: "20260106", ID: "8823"}},
-		{Note: Note{Date: "20260104", ID: "8818"}},
-		{Note: Note{Date: "20260102", ID: "8814"}},
-		{Note: Note{Date: "20241203", ID: "6973"}},
+		{Ref: Ref{Date: "20260106", ID: "8823"}},
+		{Ref: Ref{Date: "20260104", ID: "8818"}},
+		{Ref: Ref{Date: "20260102", ID: "8814"}},
+		{Ref: Ref{Date: "20241203", ID: "6973"}},
 	}
 
 	got := FilterByDate(entries, "20260106")
@@ -446,10 +446,10 @@ func TestValidateSlug(t *testing.T) {
 
 func TestFilterByTypes(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Type: ""}},
-		{Note: Note{Type: "todo"}},
-		{Note: Note{Type: "backlog"}},
-		{Note: Note{Type: "todo"}},
+		{Ref: Ref{Type: ""}},
+		{Ref: Ref{Type: "todo"}},
+		{Ref: Ref{Type: "backlog"}},
+		{Ref: Ref{Type: "todo"}},
 	}
 
 	tests := []struct {

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -293,10 +293,10 @@ func TestDirPath(t *testing.T) {
 
 func TestFindLatestTodo(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
-		{Note: Note{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
-		{Note: Note{Date: "20260310", Type: "", RelPath: "2026/03/20260310_98.md"}},
-		{Note: Note{Date: "20260309", Type: "todo", RelPath: "2026/03/20260309_97.todo.md"}},
+		{Ref: Ref{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
+		{Ref: Ref{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
+		{Ref: Ref{Date: "20260310", Type: "", RelPath: "2026/03/20260310_98.md"}},
+		{Ref: Ref{Date: "20260309", Type: "todo", RelPath: "2026/03/20260309_97.todo.md"}},
 	}
 
 	got := FindLatestTodo(entries, "20260312")
@@ -310,7 +310,7 @@ func TestFindLatestTodo(t *testing.T) {
 
 func TestFindLatestTodoNone(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Date: "20260312", Type: "todo"}},
+		{Ref: Ref{Date: "20260312", Type: "todo"}},
 	}
 	got := FindLatestTodo(entries, "20260312")
 	if got != nil {
@@ -320,8 +320,8 @@ func TestFindLatestTodoNone(t *testing.T) {
 
 func TestFindTodayTodo(t *testing.T) {
 	entries := []Entry{
-		{Note: Note{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
-		{Note: Note{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
+		{Ref: Ref{Date: "20260312", Type: "todo", RelPath: "2026/03/20260312_100.todo.md"}},
+		{Ref: Ref{Date: "20260311", Type: "todo", RelPath: "2026/03/20260311_99.todo.md"}},
 	}
 
 	got := FindTodayTodo(entries, "20260312")


### PR DESCRIPTION
## Summary

Rename the `note.Note` type to `note.Ref` to eliminate the package/type name stutter. The `Ref` type represents a lightweight, filename-derived reference to a note file—containing only the fields that can be recovered from the filename and directory structure.

This is a pure refactoring with no behavioral changes:
- `Entry` now embeds `Ref` instead of `Note`
- `ResolveRef`, `Scan`, and `ParseFilename` now return `Ref` instead of `Note`
- All test fixtures and internal code updated to use `Ref` field names
- No cross-package API changes—external callers only consume `Entry` and never reference the type by name

## References

- Closes #164
- https://claude.ai/code/session_01DihReotjVCvnCowvpgitQ6
