### PR TITLE
note: replace os.Stderr logging with an injectable Logger

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,10 +19,11 @@ jobs:
         run: |
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST" ]; then
-            NEXT="v0.1.0"
+            NEXT="v0.2.0"
           else
+            MAJOR_MINOR=$(echo "$LATEST" | cut -d. -f1,2)
             PATCH=$(echo "$LATEST" | cut -d. -f3)
-            NEXT="v0.1.$((PATCH + 1))"
+            NEXT="$MAJOR_MINOR.$((PATCH + 1))"
           fi
           git tag "$NEXT"
           git push origin "$NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.112] - 2026-04-23
+
+### Changed
+
+- `note` package no longer writes to `os.Stderr`. Per-note frontmatter parse failures (`note/index.go`), `Index.Reload` build failures, and unreadable-subdirectory warnings during `Scan` now route through a new `note.Logger = func(error)`. Install one via `note.WithLogger` (LoadOption) or `note.WithScanLogger` (ScanOption); the default is a no-op so external importers (notes-pub, notes-view) can embed the package without inheriting its stderr output. The `notes` CLI wires a single `stderrLogger(cmd)` helper through every `note.Load` call, so user-visible output is unchanged ([#193])
+
+[#193]: https://github.com/dreikanter/notes-cli/pull/193
+
 ## [0.2.0] - 2026-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [0.1.112] - 2026-04-23
+## [0.2.1] - 2026-04-23
 
 ### Changed
 
 - `note` package no longer writes to `os.Stderr`. Per-note frontmatter parse failures (`note/index.go`), `Index.Reload` build failures, and unreadable-subdirectory warnings during `Scan` now route through a new `note.Logger = func(error)`. Install one via `note.WithLogger` (LoadOption) or `note.WithScanLogger` (ScanOption); the default is a no-op so external importers (notes-pub, notes-view) can embed the package without inheriting its stderr output. The `notes` CLI wires a single `stderrLogger(cmd)` helper through every `note.Load` call, so user-visible output is unchanged ([#193])
+- `.github/workflows/tag.yml` preserves the major.minor segment of the latest tag instead of hardcoding `v0.1.*`; `CLAUDE.md`'s Versioning and Changelog sections are updated to match. Bumping minor now requires a manual `v0.X.0` tag, after which the workflow continues patch-bumping within that series ([#193])
 
 [#193]: https://github.com/dreikanter/notes-cli/pull/193
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ Version is set at build time via git tags and `-ldflags`. The `Version` var in
 / `make build` using `git describe --tags`.
 
 Patch version auto-increments on each PR merge via GitHub Actions
-(`.github/workflows/tag.yml`), e.g. `v0.1.0` → `v0.1.1`.
+(`.github/workflows/tag.yml`), e.g. `v0.2.0` → `v0.2.1`. The major.minor
+pair is carried from the latest tag; bump it by tagging manually (e.g.
+`v0.3.0`) before the next merge.
 
 After merging a PR, reinstall locally:
 
@@ -46,7 +48,7 @@ Update `CHANGELOG.md` in every PR with an entry for the version that PR will cre
 Each PR merge auto-increments the patch version. To find the next version:
 
 ```sh
-git describe --tags   # e.g. v0.1.32 → next PR will be v0.1.33
+git describe --tags   # e.g. v0.2.3 → next PR will be v0.2.4
 ```
 
 Rules:

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -50,7 +50,7 @@ var appendCmd = &cobra.Command{
 			}
 			targetPath = filepath.Join(root, n.RelPath)
 		} else if f.active() {
-			idx, loadErr := note.Load(root, loadOptsFor(f))
+			idx, loadErr := note.Load(root, loadOptsFor(cmd, f)...)
 			if loadErr != nil {
 				return loadErr
 			}

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -9,6 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// stderrLogger returns a note.Logger that writes non-fatal warnings from
+// Load/Scan/Reload to cmd's stderr. The note package itself no longer writes
+// to os.Stderr — CLI commands wire this at the edge.
+func stderrLogger(cmd *cobra.Command) note.Logger {
+	return func(err error) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warn: %v\n", err)
+	}
+}
+
 // filterOpts holds the common filter flag values.
 type filterOpts struct {
 	Today bool
@@ -55,9 +64,14 @@ func (f filterOpts) describe() string {
 
 // loadOptsFor picks Load options matching the fields this filter set touches.
 // Tag filters need merged frontmatter+body tags; every other filter only
-// touches filename-derived fields, so the frontmatter read is skipped.
-func loadOptsFor(f filterOpts) note.LoadOption {
-	return note.WithFrontmatter(len(f.Tags) > 0)
+// touches filename-derived fields, so the frontmatter read is skipped. The
+// stderr logger is attached so the note package's per-note and subdirectory
+// warnings surface to the user.
+func loadOptsFor(cmd *cobra.Command, f filterOpts) []note.LoadOption {
+	return []note.LoadOption{
+		note.WithFrontmatter(len(f.Tags) > 0),
+		note.WithLogger(stderrLogger(cmd)),
+	}
 }
 
 // applyFilters applies the common filter pipeline to a list of entries.

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -21,7 +21,7 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		idx, err := note.Load(root, loadOptsFor(f))
+		idx, err := note.Load(root, loadOptsFor(cmd, f)...)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -40,7 +40,7 @@ var newCmd = &cobra.Command{
 		// --upsert: check if today already has a matching note
 		if upsert {
 			today := time.Now().Format(note.DateFormat)
-			idx, err := note.Load(root, note.WithFrontmatter(false))
+			idx, err := note.Load(root, note.WithFrontmatter(false), note.WithLogger(stderrLogger(cmd)))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -22,7 +22,7 @@ var newTodoCmd = &cobra.Command{
 		}
 		today := time.Now().Format(note.DateFormat)
 
-		idx, err := note.Load(root, note.WithFrontmatter(false))
+		idx, err := note.Load(root, note.WithFrontmatter(false), note.WithLogger(stderrLogger(cmd)))
 		if err != nil {
 			return err
 		}

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -33,7 +33,7 @@ var readCmd = &cobra.Command{
 			}
 			relPath = n.RelPath
 		} else if f.active() {
-			idx, err := note.Load(root, loadOptsFor(f))
+			idx, err := note.Load(root, loadOptsFor(cmd, f)...)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -54,7 +54,7 @@ positional resolution to notes dated today.`,
 			return nil
 		}
 
-		idx, err := note.Load(root, loadOptsFor(f))
+		idx, err := note.Load(root, loadOptsFor(cmd, f)...)
 		if err != nil {
 			return err
 		}

--- a/note/index.go
+++ b/note/index.go
@@ -84,6 +84,7 @@ type loadConfig struct {
 	frontmatter bool
 	workers     int
 	scanOpts    ScanOptions
+	logger      Logger
 }
 
 // LoadOption configures Load. All options are optional; pass zero or more.
@@ -110,13 +111,22 @@ func WithScanOptions(o ScanOptions) LoadOption {
 	return func(c *loadConfig) { c.scanOpts = o }
 }
 
+// WithLogger installs a Logger that receives non-fatal errors from Load, the
+// underlying Scan, and subsequent Index.Reload runs — per-note frontmatter
+// parse failures, unreadable subdirectories, and reload-build errors. Default:
+// no-op (the package does not write to os.Stderr; wire a logger at the
+// application edge if you want that).
+func WithLogger(l Logger) LoadOption {
+	return func(c *loadConfig) { c.logger = l }
+}
+
 // Load walks root once, parses frontmatter concurrently, and returns a
 // populated Index. A single concurrent pass replaces the Scan → FilterByTags
 // → ExtractTags re-read chain that duplicated I/O for each query.
 //
-// Per-note frontmatter parse errors are logged to stderr (matching ParseNote's
-// existing behavior) and leave that entry's Frontmatter zero; they never abort
-// the load. Any file-read or stat error aborts the load.
+// Per-note frontmatter parse errors are forwarded to the logger installed via
+// WithLogger (no-op by default) and leave that entry's Frontmatter zero; they
+// never abort the load. Any file-read or stat error aborts the load.
 func Load(root string, opts ...LoadOption) (*Index, error) {
 	cfg := loadConfig{
 		frontmatter: true,
@@ -141,7 +151,7 @@ func Load(root string, opts ...LoadOption) (*Index, error) {
 // worker pool, and atomically swaps the new state in under i.mu. Called by
 // Load for the initial population and by runBuild for subsequent reloads.
 func (i *Index) build() error {
-	notes, err := Scan(i.root, WithStrict(i.cfg.scanOpts.Strict))
+	notes, err := Scan(i.root, WithStrict(i.cfg.scanOpts.Strict), WithScanLogger(i.cfg.logger))
 	if err != nil {
 		return err
 	}
@@ -189,7 +199,7 @@ func (i *Index) build() error {
 						}
 						fm, body, parseErr := ParseNote(data)
 						if parseErr != nil {
-							fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, parseErr)
+							i.cfg.logger.log(fmt.Errorf("%s: %w", path, parseErr))
 							body = data
 						} else {
 							entries[j].Frontmatter = fm
@@ -301,7 +311,7 @@ func (i *Index) runBuild(done chan struct{}) {
 	}()
 
 	if err := i.build(); err != nil {
-		fmt.Fprintf(os.Stderr, "warn: index reload failed: %v\n", err)
+		i.cfg.logger.log(fmt.Errorf("index reload failed: %w", err))
 	}
 }
 

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -470,3 +470,39 @@ func TestReloadCoalescesRequestsDuringInflight(t *testing.T) {
 		t.Error("late note must be indexed once second Reload's done fires")
 	}
 }
+
+// TestLoadLoggerCapturesParseWarnings pins that per-note frontmatter parse
+// failures are routed to the Logger installed via WithLogger instead of being
+// written directly to os.Stderr. External importers that embed this package
+// rely on this to keep their own logging disciplined.
+func TestLoadLoggerCapturesParseWarnings(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "---\nbad: [unclosed\n---\n\nbody\n")
+	writeNote(t, root, "2026/01/20260102_2.md", "---\ntitle: ok\n---\n\nbody\n")
+
+	var captured []error
+	_, err := Load(root, WithLogger(func(err error) {
+		captured = append(captured, err)
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured = %d warnings, want 1", len(captured))
+	}
+	if captured[0] == nil {
+		t.Fatal("captured warning is nil")
+	}
+}
+
+// TestLoadNilLoggerSilent pins that Load runs silently when no logger is
+// installed — no panic on the nil Logger call and no stderr output. Pairs
+// with the package rule that note/ never writes to os.Stderr on its own.
+func TestLoadNilLoggerSilent(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md", "---\nbad: [unclosed\n---\n\nbody\n")
+
+	if _, err := Load(root); err != nil {
+		t.Fatalf("Load with nil logger: %v", err)
+	}
+}

--- a/note/logger.go
+++ b/note/logger.go
@@ -1,0 +1,15 @@
+package note
+
+// Logger receives non-fatal errors from Load, Scan, and Index.Reload — e.g.
+// per-note frontmatter parse failures or unreadable subdirectories that the
+// walk chooses to skip rather than abort on. Install one via WithLogger (or
+// WithScanLogger when calling Scan directly). A nil Logger discards the
+// message; the package does not write to os.Stderr on its own.
+type Logger func(error)
+
+func (l Logger) log(err error) {
+	if l == nil || err == nil {
+		return
+	}
+	l(err)
+}

--- a/note/store.go
+++ b/note/store.go
@@ -24,6 +24,7 @@ import (
 // need it.
 type ScanOptions struct {
 	Strict bool
+	logger Logger
 }
 
 // ScanOption configures Scan. All options are optional; pass zero or more.
@@ -35,27 +36,35 @@ func WithStrict(b bool) ScanOption {
 	return func(o *ScanOptions) { o.Strict = b }
 }
 
+// WithScanLogger installs a Logger for non-fatal warnings from Scan — today
+// that is "subdirectory unreadable, skipping" in both strict and lenient
+// modes. Default: no-op (the scan silently skips, matching the package rule
+// that note/ does not write to os.Stderr).
+func WithScanLogger(l Logger) ScanOption {
+	return func(o *ScanOptions) { o.logger = l }
+}
+
 // Scan enumerates notes under root.
 //
 // Called as Scan(root) it preserves the historical strict YYYY/MM/*.md
 // discipline. Pass WithStrict(false) to walk every *.md file under root
 // regardless of layout.
 //
-// Unreadable subdirectories are logged to stderr and skipped in both modes,
-// matching the per-note parse-error behavior, so a single permission glitch
-// can't break ls/tags/resolve.
+// Unreadable subdirectories are skipped in both modes so a single permission
+// glitch can't break ls/tags/resolve; pass WithScanLogger to surface those
+// warnings to the caller.
 func Scan(root string, opts ...ScanOption) ([]Ref, error) {
 	cfg := ScanOptions{Strict: true}
 	for _, o := range opts {
 		o(&cfg)
 	}
 	if cfg.Strict {
-		return scanStrict(root)
+		return scanStrict(root, cfg.logger)
 	}
-	return scanLenient(root)
+	return scanLenient(root, cfg.logger)
 }
 
-func scanStrict(root string) ([]Ref, error) {
+func scanStrict(root string, log Logger) ([]Ref, error) {
 	var notes []Ref
 
 	years, err := os.ReadDir(root)
@@ -71,7 +80,7 @@ func scanStrict(root string) ([]Ref, error) {
 		yearPath := filepath.Join(root, y.Name())
 		months, err := os.ReadDir(yearPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", yearPath, err)
+			log.log(fmt.Errorf("%s: %w", yearPath, err))
 			continue
 		}
 
@@ -83,7 +92,7 @@ func scanStrict(root string) ([]Ref, error) {
 			monthPath := filepath.Join(yearPath, m.Name())
 			files, err := os.ReadDir(monthPath)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "warn: %s: %v\n", monthPath, err)
+				log.log(fmt.Errorf("%s: %w", monthPath, err))
 				continue
 			}
 
@@ -111,7 +120,7 @@ func scanStrict(root string) ([]Ref, error) {
 	return notes, nil
 }
 
-func scanLenient(root string) ([]Ref, error) {
+func scanLenient(root string, log Logger) ([]Ref, error) {
 	var notes []Ref
 
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -119,7 +128,7 @@ func scanLenient(root string) ([]Ref, error) {
 			if path == root {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", path, err)
+			log.log(fmt.Errorf("%s: %w", path, err))
 			if d != nil && d.IsDir() {
 				return fs.SkipDir
 			}


### PR DESCRIPTION
## Summary

- Introduce `note.Logger = func(error)` plus `WithLogger` (LoadOption) and `WithScanLogger` (ScanOption); default is a no-op.
- Remove all `fmt.Fprintf(os.Stderr, …)` call sites from `note/index.go` and `note/store.go`; per-note parse warnings, unreadable-subdirectory warnings, and `Reload` build failures now flow through the installed logger.
- Wire a single `stderrLogger(cmd)` helper in `internal/cli/filter.go` and thread it into every `note.Load` call in the CLI so user-visible output is unchanged.
- Pin the new behaviour with `TestLoadLoggerCapturesParseWarnings` and `TestLoadNilLoggerSilent`.

## References

- Closes #170
