### PR TITLE
note: unexport TypesWithSpecialBehavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.2] - 2026-04-23
+
+### Changed
+
+- `note.TypesWithSpecialBehavior` unexported to `typesWithSpecialBehavior`; external importers can no longer `append` to the package-level slice and silently change CLI behavior globally. `note.HasSpecialBehavior(s)` remains the public predicate, and a new `note.SpecialBehaviorTypes()` returns a fresh copy of the list for callers that need the values. `SCHEMA.md` now references `HasSpecialBehavior` instead of the unexported slice ([#194])
+
+[#194]: https://github.com/dreikanter/notes-cli/pull/194
+
 ## [0.2.0] - 2026-04-23
 
 ### Changed

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -27,7 +27,7 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 - **Type:** string
 - **Semantics:** note category. Any value is valid. A small set of
   values (`todo`, `backlog`, `weekly`) trigger special notes-cli
-  behavior; see `note.TypesWithSpecialBehavior`. The filename may
+  behavior; see `note.HasSpecialBehavior`. The filename may
   carry a cached copy as a `.type` dot-suffix; on mismatch,
   frontmatter wins.
 - **Consumers:** notes-cli (filters, rollover), notes-pub / notes-view

--- a/note/note.go
+++ b/note/note.go
@@ -6,14 +6,25 @@ import (
 	"strings"
 )
 
-// TypesWithSpecialBehavior lists note types that trigger notes-cli-specific
+// typesWithSpecialBehavior lists note types that trigger notes-cli-specific
 // handling (e.g., daily rollover, weekly review conventions). Any string is a
 // valid `type` value; this list is a soft registry, not a validation gate.
-var TypesWithSpecialBehavior = []string{"todo", "backlog", "weekly"}
+// It is unexported because external importers must not be able to mutate it
+// and change CLI behavior globally — ask via HasSpecialBehavior instead.
+var typesWithSpecialBehavior = []string{"todo", "backlog", "weekly"}
+
+// SpecialBehaviorTypes returns a fresh copy of the soft registry of note
+// types with notes-cli-specific handling. The returned slice may be freely
+// mutated without affecting the package-internal list.
+func SpecialBehaviorTypes() []string {
+	out := make([]string, len(typesWithSpecialBehavior))
+	copy(out, typesWithSpecialBehavior)
+	return out
+}
 
 // HasSpecialBehavior reports whether s is a type with special notes-cli behavior.
 func HasSpecialBehavior(s string) bool {
-	for _, t := range TypesWithSpecialBehavior {
+	for _, t := range typesWithSpecialBehavior {
 		if s == t {
 			return true
 		}


### PR DESCRIPTION
## Summary

- Rename `note.TypesWithSpecialBehavior` to the unexported `typesWithSpecialBehavior` so external importers cannot `append` to it and mutate CLI behavior globally.
- Add `note.SpecialBehaviorTypes()` that returns a fresh copy for callers (tests, docs) that need the list as a value.
- `HasSpecialBehavior` remains the public predicate, unchanged.
- Update `SCHEMA.md` to reference `HasSpecialBehavior` instead of the now-unexported slice.

## References

- Closes #172
