### PR TITLE
note: deep-copy Frontmatter.Extra in cloneEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.3] - 2026-04-23
+
+### Changed
+
+- `note.cloneEntry` now deep-copies `Frontmatter.Extra` — the map, each `yaml.Node` value, and the nested `Content` slices — so a web-service consumer that mutates `Extra` after a lookup cannot race other readers of the same `Index` entry. Previously only `Tags`, `Aliases`, and `bodyHashtags` were cloned, and the doc-comment warned that `Extra` was aliased; that footgun is gone ([#195])
+
+[#195]: https://github.com/dreikanter/notes-cli/pull/195
+
 ## [0.2.0] - 2026-04-23
 
 ### Changed

--- a/note/index.go
+++ b/note/index.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
 )
 
 // Entry is a fully-hydrated note record: the filename-derived Ref plus
@@ -492,13 +493,16 @@ func (i *Index) Resolve(query string, opts ...ResolveOption) (Entry, bool, error
 	return Entry{}, false, nil
 }
 
-// cloneEntry returns e with Tags and Aliases deep-copied so callers can
+// cloneEntry returns e with every slice/map field deep-copied so callers can
 // mutate the returned value without racing other readers of the same index
-// entry. Frontmatter.Extra is shared by reference — callers treating Extra
-// as mutable should copy it themselves.
+// entry. Previously Frontmatter.Extra aliased the index-internal map, which
+// a web-service consumer that mutates Extra could turn into a data race; now
+// the map, its yaml.Node values, and their nested Content slices are all
+// copied.
 func cloneEntry(e Entry) Entry {
 	e.Frontmatter.Tags = cloneStrings(e.Frontmatter.Tags)
 	e.Frontmatter.Aliases = cloneStrings(e.Frontmatter.Aliases)
+	e.Frontmatter.Extra = cloneExtra(e.Frontmatter.Extra)
 	e.bodyHashtags = cloneStrings(e.bodyHashtags)
 	return e
 }
@@ -510,6 +514,38 @@ func cloneStrings(s []string) []string {
 	out := make([]string, len(s))
 	copy(out, s)
 	return out
+}
+
+// cloneExtra deep-copies the Frontmatter.Extra map. Each yaml.Node value is
+// copied by value and its recursive Content slice is cloned so mutations on
+// the returned map — including reassignment of a node's children — cannot
+// race the index-internal copy.
+func cloneExtra(m map[string]yaml.Node) map[string]yaml.Node {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]yaml.Node, len(m))
+	for k, v := range m {
+		out[k] = cloneYAMLNode(v)
+	}
+	return out
+}
+
+func cloneYAMLNode(n yaml.Node) yaml.Node {
+	if len(n.Content) == 0 {
+		n.Content = nil
+		return n
+	}
+	children := make([]*yaml.Node, len(n.Content))
+	for i, c := range n.Content {
+		if c == nil {
+			continue
+		}
+		clone := cloneYAMLNode(*c)
+		children[i] = &clone
+	}
+	n.Content = children
+	return n
 }
 
 // normalizeHashtags lowercases and deduplicates a hashtag list from

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadTestdata(t *testing.T) {
@@ -468,5 +470,51 @@ func TestReloadCoalescesRequestsDuringInflight(t *testing.T) {
 
 	if _, ok := idx.ByRel("2026/02/20260201_9999_late.md"); !ok {
 		t.Error("late note must be indexed once second Reload's done fires")
+	}
+}
+
+// TestCloneEntryDeepCopiesExtra pins that cloneEntry returns an Entry whose
+// Frontmatter.Extra map (and each yaml.Node's Content slice) is independent
+// of the index-internal copy. Without this a web-service consumer that
+// mutates Extra after a lookup races every other reader of the same entry.
+func TestCloneEntryDeepCopiesExtra(t *testing.T) {
+	root := t.TempDir()
+	writeNote(t, root, "2026/01/20260101_1.md",
+		"---\ntitle: T\ncustom:\n  - one\n  - two\n---\n\nbody\n")
+
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	first, ok := idx.ByID("1")
+	if !ok {
+		t.Fatalf("ByID(1) missing")
+	}
+	if first.Frontmatter.Extra == nil {
+		t.Fatal("Extra not populated; test note has a custom key")
+	}
+
+	// Mutate the returned clone.
+	first.Frontmatter.Extra["custom"] = yaml.Node{Kind: yaml.ScalarNode, Value: "mutated"}
+	first.Frontmatter.Extra["injected"] = yaml.Node{Kind: yaml.ScalarNode, Value: "new"}
+	if orig, ok := first.Frontmatter.Extra["custom"]; ok && len(orig.Content) > 0 {
+		orig.Content[0] = &yaml.Node{Kind: yaml.ScalarNode, Value: "zapped"}
+	}
+
+	// Fresh lookup must be untouched.
+	second, ok := idx.ByID("1")
+	if !ok {
+		t.Fatalf("second ByID(1) missing")
+	}
+	if _, injected := second.Frontmatter.Extra["injected"]; injected {
+		t.Error("injected key leaked into index-internal Extra")
+	}
+	got := second.Frontmatter.Extra["custom"]
+	if got.Kind != yaml.SequenceNode {
+		t.Fatalf("custom kind = %v, want SequenceNode — clone shared map with index", got.Kind)
+	}
+	if len(got.Content) != 2 || got.Content[0].Value != "one" {
+		t.Errorf("custom[0].Value = %q, want \"one\" — nested Content was aliased", got.Content[0].Value)
 	}
 }


### PR DESCRIPTION
## Summary

- `cloneEntry` now deep-copies `Frontmatter.Extra` — the map, each `yaml.Node` value, and the nested `Content` slices — so a consumer (e.g. a web service holding long-lived clones) that mutates `Extra` cannot race other readers of the same index entry.
- New `cloneExtra` / `cloneYAMLNode` helpers; no other callers.
- Pin with `TestCloneEntryDeepCopiesExtra`: mutates a returned clone's map, nested `Content`, and injects a new key — a fresh `ByID` must return the original values.
- Doc-comment on `cloneEntry` updated to drop the prior "Extra is shared by reference" footgun warning.

## References

- Closes #174
