### PR TITLE
note: add ErrNotFound sentinel and unify Resolve/ResolveRef error shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.4] - 2026-04-23
+
+### Changed
+
+- `note.ErrNotFound = errors.New("note not found")` exported so callers can match misses with `errors.Is` instead of string-comparing. `ResolveRef` now wraps it on the priority-chain miss path (previously `fmt.Errorf("note not found: %s", …)` with no sentinel) and on the `resolveRelPath` EvalSymlinks miss. `Index.Resolve` keeps its `(Entry, bool, error)` shape — `bool=false` is a miss, `error` is reserved for I/O — and the `ErrNotFound` doc-comment spells out the convention so the two APIs stay distinguishable ([#196])
+
+[#196]: https://github.com/dreikanter/notes-cli/pull/196
+
 ## [0.2.0] - 2026-04-23
 
 ### Changed

--- a/note/store.go
+++ b/note/store.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,6 +10,18 @@ import (
 	"sort"
 	"strings"
 )
+
+// ErrNotFound is returned (wrapped) by ResolveRef and resolveRelPath when a
+// note reference has no match in the store. Callers match with errors.Is:
+//
+//	_, err := note.ResolveRef(root, q)
+//	if errors.Is(err, note.ErrNotFound) { … }
+//
+// Index.Resolve and Index.ByID/ByRel/BySlug keep the (value, bool) miss
+// convention — the bool distinguishes "no match" from I/O failure without a
+// sentinel comparison. ResolveRef wraps because its public contract is
+// `(Ref, error)`; callers with an *Index can call Index.Resolve directly.
+var ErrNotFound = errors.New("note not found")
 
 // ScanOptions configures Scan's directory traversal.
 //
@@ -180,7 +193,8 @@ func WithDate(date string) ResolveOption {
 //
 // Implementation routes through Index.Resolve on a WithFrontmatter(false)
 // load, so CLI commands that already hold an Index can call Index.Resolve
-// directly and skip this wrapper.
+// directly and skip this wrapper. A miss returns an error wrapping
+// [ErrNotFound]; callers match with errors.Is.
 func ResolveRef(root, query string, opts ...ResolveOption) (Ref, error) {
 	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
@@ -192,7 +206,7 @@ func ResolveRef(root, query string, opts ...ResolveOption) (Ref, error) {
 		return Ref{}, err
 	}
 	if !ok {
-		return Ref{}, fmt.Errorf("note not found: %s", strings.TrimSpace(query))
+		return Ref{}, fmt.Errorf("%w: %s", ErrNotFound, strings.TrimSpace(query))
 	}
 	return e.Ref, nil
 }
@@ -214,7 +228,7 @@ func resolveRelPath(root, query string) (string, error) {
 	}
 	absQuery, err := filepath.EvalSymlinks(queryPath)
 	if err != nil {
-		return "", fmt.Errorf("note not found: %s", query)
+		return "", fmt.Errorf("%w: %s", ErrNotFound, query)
 	}
 	rel, err := filepath.Rel(absRoot, absQuery)
 	if err != nil || strings.HasPrefix(rel, "..") {

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -1,6 +1,7 @@
 package note
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,6 +256,34 @@ func TestResolveRefWithDateEmptyQueryFiltersByDate(t *testing.T) {
 	}
 	if got.ID != "8818" {
 		t.Errorf("ResolveRef empty + WithDate(20260104) = %q, want 8818", got.ID)
+	}
+}
+
+// TestResolveRefErrNotFound pins that misses from ResolveRef wrap ErrNotFound
+// so callers can match with errors.Is — both the priority-chain miss path
+// (unknown slug / unknown id) and the path-resolution miss (a path that
+// EvalSymlinks cannot follow). Index.Resolve continues to keep the (value,
+// bool) convention for misses, unchanged.
+func TestResolveRefErrNotFound(t *testing.T) {
+	root := testdataPath(t)
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"unknown id", "9999"},
+		{"unknown slug", "no-such-slug-xyz"},
+		{"missing path", filepath.Join(root, "2099/12/20991231_1.md")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveRef(root, tc.query)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !errors.Is(err, ErrNotFound) {
+				t.Errorf("errors.Is(err, ErrNotFound) = false (err=%v)", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Export `note.ErrNotFound = errors.New("note not found")` so callers can match with `errors.Is` instead of string-comparing.
- `ResolveRef` wraps `ErrNotFound` on the priority-chain miss path (`fmt.Errorf("%w: %s", ErrNotFound, query)`); `resolveRelPath` wraps it on an `EvalSymlinks` miss too. Both keep the existing `(Ref, error)` signature, which is the less-invasive option from the ticket.
- `Index.Resolve` is unchanged: `(Entry, bool, error)` with `bool=false` for misses and `error` reserved for I/O failures. The package doc for `ErrNotFound` spells out the convention: `Index.*` uses `(value, bool)`; `ResolveRef` wraps because its public contract is `(Ref, error)`.
- Pin with `TestResolveRefErrNotFound` covering unknown id, unknown slug, and a missing path.

## References

- Closes #171
