### PR TITLE
note: surface Index.Reload errors through the returned channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.5] - 2026-04-23
+
+### Changed
+
+- `note.Index.Reload()` now returns `<-chan error` (was `<-chan struct{}`). A successful rebuild closes the channel with the zero value; a failing rebuild sends the error on the buffered channel before close, so `err := <-ch` returns the build error or nil. The logger installed via `WithLogger` still sees the same error. Long-lived services can now react to a specific reload's outcome instead of only being able to wait for "some build has finished" ([#197])
+
+[#197]: https://github.com/dreikanter/notes-cli/pull/197
+
 ## [0.2.4] - 2026-04-23
 
 ### Changed

--- a/note/index.go
+++ b/note/index.go
@@ -76,9 +76,13 @@ type Index struct {
 	// buildMu guards curDone and queuedDone — the Reload state machine.
 	// Separate from mu so rebuild bookkeeping does not contend with read
 	// lookups. See Reload for the scheduling semantics.
+	//
+	// Each channel is buffered (cap 1) so runBuild can deposit the build error
+	// (or leave the buffer empty on success) before close, independent of
+	// whether any caller is ready to read.
 	buildMu    sync.Mutex
-	curDone    chan struct{} // in-flight build's completion signal; nil when idle
-	queuedDone chan struct{} // follow-up build queued while curDone runs; nil when none
+	curDone    chan error // in-flight build's completion signal; nil when idle
+	queuedDone chan error // follow-up build queued while curDone runs; nil when none
 }
 
 type loadConfig struct {
@@ -262,27 +266,34 @@ func (i *Index) build() error {
 
 // Reload requests an index rebuild and returns a channel that closes when a
 // build has completed that reflects the tree state at or after this call.
+// The channel yields the build error (nil on success); a read after the
+// channel closes returns the zero value — so `err := <-ch` works regardless
+// of the build outcome. The installed WithLogger also receives the error.
 //
 // Scheduling rules:
 //   - Idle: start a new build immediately.
 //   - Build in-flight: coalesce — queue at most one follow-up. Every caller
 //     that arrives while the in-flight build runs receives the same follow-up's
 //     done channel, so they only observe completion after a full walk that
-//     started after their request.
+//     started after their request. With coalescing, only the first reader of
+//     the shared channel observes the build error; subsequent reads are nil
+//     (the channel closes and only one value is buffered). Long-lived
+//     services that need to react to repeated failures should read from the
+//     first call per rebuild or install a logger.
 //
 // Callers that only need "the current build" can read the returned channel;
 // callers that do not care (e.g. warmup on a navigation) may ignore it.
-func (i *Index) Reload() <-chan struct{} {
+func (i *Index) Reload() <-chan error {
 	i.buildMu.Lock()
 	if i.curDone == nil {
-		done := make(chan struct{})
+		done := make(chan error, 1)
 		i.curDone = done
 		i.buildMu.Unlock()
 		go i.runBuild(done)
 		return done
 	}
 	if i.queuedDone == nil {
-		i.queuedDone = make(chan struct{})
+		i.queuedDone = make(chan error, 1)
 	}
 	done := i.queuedDone
 	i.buildMu.Unlock()
@@ -295,8 +306,10 @@ func (i *Index) Reload() <-chan struct{} {
 //
 // The state-machine cleanup runs in a deferred block so that even if build
 // panics, waiters on done are released and any queued follow-up still gets
-// scheduled — without this, waiting callers would block forever.
-func (i *Index) runBuild(done chan struct{}) {
+// scheduled — without this, waiting callers would block forever. A build
+// error is sent to done (buffered cap 1) before close so the first reader
+// sees it; a reader that arrives after close gets the zero value (nil).
+func (i *Index) runBuild(done chan error) {
 	defer func() {
 		i.buildMu.Lock()
 		next := i.queuedDone
@@ -313,6 +326,12 @@ func (i *Index) runBuild(done chan struct{}) {
 
 	if err := i.build(); err != nil {
 		i.cfg.logger.log(fmt.Errorf("index reload failed: %w", err))
+		// Non-blocking send: the channel is buffered cap 1 and this is the
+		// only producer, so the select-default is belt-and-braces.
+		select {
+		case done <- err:
+		default:
+		}
 	}
 }
 

--- a/note/index_test.go
+++ b/note/index_test.go
@@ -2,6 +2,7 @@ package note
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -552,5 +553,47 @@ func TestLoadNilLoggerSilent(t *testing.T) {
 
 	if _, err := Load(root); err != nil {
 		t.Fatalf("Load with nil logger: %v", err)
+	}
+}
+
+// TestReloadSurfacesBuildError pins that a build failure during Reload (here:
+// the root disappeared between Load and Reload) is both forwarded to the
+// installed logger and delivered through the returned channel as a non-nil
+// error. Long-lived services that want to observe repeated reload failures
+// can react to either signal.
+func TestReloadSurfacesBuildError(t *testing.T) {
+	root := t.TempDir()
+
+	var logged []error
+	idx, err := Load(root, WithLogger(func(err error) { logged = append(logged, err) }))
+	if err != nil {
+		t.Fatalf("initial Load: %v", err)
+	}
+
+	// Remove the root so the next build's Scan fails with a hard error.
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("RemoveAll(root): %v", err)
+	}
+
+	reloadErr := <-idx.Reload()
+	if reloadErr == nil {
+		t.Fatal("Reload() returned nil on channel; expected build error")
+	}
+	if len(logged) == 0 {
+		t.Error("build error not forwarded to logger")
+	}
+}
+
+// TestReloadChannelNilOnSuccess pins that a successful reload closes the
+// returned channel with no value, so `err := <-ch` reads the zero value.
+func TestReloadChannelNilOnSuccess(t *testing.T) {
+	root := t.TempDir()
+	idx, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if err := <-idx.Reload(); err != nil {
+		t.Errorf("<-Reload() on empty store = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `Index.Reload()` now returns `<-chan error` (was `<-chan struct{}`). A successful build still closes the channel; a failed build sends the error on the buffered channel (cap 1) before close, so `err := <-ch` returns the build error or nil — the logger installed via `WithLogger` still sees the same error.
- With coalescing the first reader of a shared `queuedDone` observes the error; subsequent reads return nil (the channel closes). Doc-comment on `Reload` spells this out for long-lived services that need to react to repeated failures.
- Pin with two new tests: `TestReloadSurfacesBuildError` (deletes the root between Load and Reload, asserts both logger and channel see the error) and `TestReloadChannelNilOnSuccess`.

Stacked on top of #193 (needs the Logger infrastructure introduced there). Merge #193 first; this branch will rebase cleanly onto main once it does.

## References

- Closes #173
- Depends on #170 / #193
