### PR TITLE
note: drop IsID in favor of IsDigits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.6] - 2026-04-23
+
+### Changed
+
+- Rename `isFilenameCacheSafeType` → `filenameRoundtripSafeType` in `note/note.go`. The predicate has nothing to do with a cache; it reports whether a type round-trips cleanly through `Filename` / `ParseFilename`. Unexported helper, no external callers affected ([#198])
+
+[#198]: https://github.com/dreikanter/notes-cli/pull/198
+
 ## [0.2.5] - 2026-04-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.7] - 2026-04-23
+
+### Changed
+
+- `note.IsID` removed; it was a one-line alias for `note.IsDigits` with no stricter semantics to enforce. Internal callers (`ParseFilename`, `Index.Resolve`) now call `IsDigits` directly. External consumers that imported `note.IsID` for wikilink / CLI argument detection should switch to `note.IsDigits`, which keeps identical behavior (non-empty, ASCII digits only) ([#199])
+
+[#199]: https://github.com/dreikanter/notes-cli/pull/199
+
 ## [0.2.6] - 2026-04-23
 
 ### Changed

--- a/note/index.go
+++ b/note/index.go
@@ -479,7 +479,7 @@ func (i *Index) Resolve(query string, opts ...ResolveOption) (Entry, bool, error
 		return cloneEntry(entries[0]), true, nil
 	}
 
-	if IsID(query) {
+	if IsDigits(query) {
 		e, ok := byID[query]
 		if !ok {
 			return Entry{}, false, nil

--- a/note/note.go
+++ b/note/note.go
@@ -45,18 +45,18 @@ type Ref struct {
 	Type    string // type reported by the filename dot-suffix; any string accepted. Frontmatter type is canonical when available.
 }
 
-// isFilenameCacheSafeType reports whether a note type can round-trip through
-// the filename-suffix cache. Values containing '.', '/', or '\' cannot —
+// filenameRoundtripSafeType reports whether a note type can round-trip through
+// Filename / ParseFilename. Values containing '.', '/', or '\' cannot —
 // ParseFilename would mis-split them — so we omit them from the filename
 // entirely and rely on frontmatter as canonical.
-func isFilenameCacheSafeType(noteType string) bool {
+func filenameRoundtripSafeType(noteType string) bool {
 	return noteType != "" && !strings.ContainsAny(noteType, `./\`)
 }
 
 // ParseFilename parses a note base filename (without .md extension) into its components.
 // Expected format: Y...YMMDD_ID[_slug][.TYPE], where MM and DD are zero-padded.
 // The dot-suffix is extracted as the filename-reported Type only when it round-
-// trips cleanly (see isFilenameCacheSafeType). Frontmatter `type` is canonical.
+// trips cleanly (see filenameRoundtripSafeType). Frontmatter `type` is canonical.
 func ParseFilename(baseName string) (Ref, error) {
 	noteType := ""
 	remaining := baseName
@@ -67,7 +67,7 @@ func ParseFilename(baseName string) (Ref, error) {
 	if idx := strings.LastIndex(baseName, "."); idx >= 0 {
 		suffix := baseName[idx+1:]
 		prefix := baseName[:idx]
-		if isFilenameCacheSafeType(suffix) && !strings.Contains(prefix, ".") {
+		if filenameRoundtripSafeType(suffix) && !strings.Contains(prefix, ".") {
 			noteType = suffix
 			remaining = prefix
 		}
@@ -110,7 +110,7 @@ func Filename(date string, id int, slug, noteType string) string {
 	if slug != "" {
 		base = fmt.Sprintf("%s_%s", base, slug)
 	}
-	if isFilenameCacheSafeType(noteType) {
+	if filenameRoundtripSafeType(noteType) {
 		return base + "." + noteType + ".md"
 	}
 	return base + ".md"

--- a/note/note.go
+++ b/note/note.go
@@ -84,7 +84,7 @@ func ParseFilename(baseName string) (Ref, error) {
 	}
 
 	id := parts[1]
-	if !IsID(id) {
+	if !IsDigits(id) {
 		return Ref{}, fmt.Errorf("invalid id in filename: %s", baseName)
 	}
 
@@ -124,17 +124,10 @@ func DirPath(root, date string) string {
 	return filepath.Join(root, year, month)
 }
 
-// IsID reports whether s is a valid notes-cli note ID: a non-empty string
-// consisting only of ASCII digits. Downstream tools use this to detect
-// numeric ID references (e.g. wikilinks, CLI query arguments) without
-// re-implementing the predicate.
-func IsID(s string) bool {
-	return IsDigits(s)
-}
-
 // IsDigits reports whether s is non-empty and every rune is an ASCII digit.
-// Use this when the caller cares about the digit-only shape of s (e.g.
-// YYYY/MM path segments), not about whether s is a valid note ID.
+// Use it to test numeric-ID references (wikilinks, CLI query arguments) or
+// digit-shaped path segments (YYYY/MM directories) without re-implementing
+// the predicate.
 func IsDigits(s string) bool {
 	if s == "" {
 		return false

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -162,7 +162,7 @@ func TestParseFilename(t *testing.T) {
 	}
 }
 
-func TestIsID(t *testing.T) {
+func TestIsDigits(t *testing.T) {
 	cases := []struct {
 		in   string
 		want bool
@@ -181,8 +181,8 @@ func TestIsID(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
-			if got := IsID(c.in); got != c.want {
-				t.Errorf("IsID(%q) = %v, want %v", c.in, got, c.want)
+			if got := IsDigits(c.in); got != c.want {
+				t.Errorf("IsDigits(%q) = %v, want %v", c.in, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `note.IsID` was a one-line alias for `note.IsDigits` with identical semantics; there are no stricter ID rules (length bounds, leading-zero / non-zero constraints) to encode, so the distinction added only API surface.
- Remove `IsID` and migrate the two internal call sites (`ParseFilename`, `Index.Resolve`) to `IsDigits`. Rename `TestIsID` → `TestIsDigits`. Doc comment on `IsDigits` now covers both use cases (numeric-ID references and digit-shaped path segments).
- Stacked on #198.

## References

- Closes #176
