### PR TITLE
note: drop ResolveRef; route CLI through Index.Resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.10] - 2026-04-23
+
+### Changed
+
+- `note.ResolveRef` removed. It called `Load(root, WithFrontmatter(false))` on every invocation, so external callers using it in a loop paid for a full store walk per call; the docs already steered callers toward `Index.Resolve`. External consumers should `Load` once and call `idx.Resolve(query, opts...)`, wrapping a `false`-bool miss in `note.ErrNotFound` when the caller's contract is `(_, error)`. The CLI now routes all seven call sites (`edit`, `append`, `annotate`, `read`, `resolve`, `update`, `rm`) through an internal `cli.resolveRef` helper that preserves the previous error surface ([#202])
+
+[#202]: https://github.com/dreikanter/notes-cli/pull/202
+
 ## [0.2.9] - 2026-04-23
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -62,7 +62,7 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	n, err := note.ResolveRef(root, args[0])
+	n, err := resolveRef(cmd, root, args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -44,7 +44,7 @@ var appendCmd = &cobra.Command{
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 
-			n, resolveErr := note.ResolveRef(root, args[0])
+			n, resolveErr := resolveRef(cmd, root, args[0])
 			if resolveErr != nil {
 				return resolveErr
 			}

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +56,7 @@ The editor value may include arguments, e.g. EDITOR="subl --wait".`,
 		if err != nil {
 			return err
 		}
-		n, err := note.ResolveRef(root, args[0])
+		n, err := resolveRef(cmd, root, args[0])
 		if err != nil {
 			return err
 		}

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -18,6 +18,25 @@ func stderrLogger(cmd *cobra.Command) note.Logger {
 	}
 }
 
+// resolveRef loads the index with WithFrontmatter(false) and resolves query
+// through Index.Resolve. Misses wrap note.ErrNotFound so callers can match
+// with errors.Is. Commands that already hold an Index should call
+// idx.Resolve directly.
+func resolveRef(cmd *cobra.Command, root, query string, opts ...note.ResolveOption) (note.Ref, error) {
+	idx, err := note.Load(root, note.WithFrontmatter(false), note.WithLogger(stderrLogger(cmd)))
+	if err != nil {
+		return note.Ref{}, err
+	}
+	e, ok, err := idx.Resolve(query, opts...)
+	if err != nil {
+		return note.Ref{}, err
+	}
+	if !ok {
+		return note.Ref{}, fmt.Errorf("%w: %s", note.ErrNotFound, strings.TrimSpace(query))
+	}
+	return e.Ref, nil
+}
+
 // filterOpts holds the common filter flag values.
 type filterOpts struct {
 	Today bool

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -27,7 +27,7 @@ var readCmd = &cobra.Command{
 			if f.active() {
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
-			n, err := note.ResolveRef(root, args[0])
+			n, err := resolveRef(cmd, root, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -45,7 +45,7 @@ positional resolution to notes dated today.`,
 				date = time.Now().Format(note.DateFormat)
 			}
 
-			n, err := note.ResolveRef(root, args[0], note.WithDate(date))
+			n, err := resolveRef(cmd, root, args[0], note.WithDate(date))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -27,7 +27,7 @@ var rmCmd = &cobra.Command{
 			date = time.Now().Format(note.DateFormat)
 		}
 
-		n, err := note.ResolveRef(root, args[0], note.WithDate(date))
+		n, err := resolveRef(cmd, root, args[0], note.WithDate(date))
 		if err != nil {
 			return err
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -47,7 +47,7 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		n, err := note.ResolveRef(root, args[0])
+		n, err := resolveRef(cmd, root, args[0])
 		if err != nil {
 			return err
 		}

--- a/note/index.go
+++ b/note/index.go
@@ -436,8 +436,8 @@ func (i *Index) Tags() []string {
 	return out
 }
 
-// Resolve mirrors ResolveRef's priority chain against the cached index —
-// no rescan, no re-read:
+// Resolve looks up a note reference against the cached index — no rescan,
+// no re-read:
 //  1. empty query → most recent entry
 //  2. numeric ID → exact ByID match (strict; never falls through)
 //  3. type with special behavior → most recent entry with that Type

--- a/note/store.go
+++ b/note/store.go
@@ -11,16 +11,16 @@ import (
 	"strings"
 )
 
-// ErrNotFound is returned (wrapped) by ResolveRef and resolveRelPath when a
-// note reference has no match in the store. Callers match with errors.Is:
+// ErrNotFound is returned (wrapped) from resolveRelPath when a path-like
+// query cannot be followed under the store root. Callers that wrap a miss
+// from Index.Resolve into an error should reuse this sentinel so users can
+// match with errors.Is:
 //
-//	_, err := note.ResolveRef(root, q)
 //	if errors.Is(err, note.ErrNotFound) { … }
 //
 // Index.Resolve and Index.ByID/ByRel/BySlug keep the (value, bool) miss
 // convention — the bool distinguishes "no match" from I/O failure without a
-// sentinel comparison. ResolveRef wraps because its public contract is
-// `(Ref, error)`; callers with an *Index can call Index.Resolve directly.
+// sentinel comparison.
 var ErrNotFound = errors.New("note not found")
 
 // ScanOptions configures Scan's directory traversal.
@@ -177,47 +177,18 @@ func scanLenient(root string, log Logger) ([]Ref, error) {
 	return notes, nil
 }
 
-// ResolveOption configures ResolveRef. All options are optional; pass zero or
-// more.
+// ResolveOption configures Index.Resolve. All options are optional; pass
+// zero or more.
 type ResolveOption func(*resolveConfig)
 
 type resolveConfig struct {
 	date string
 }
 
-// WithDate restricts ResolveRef candidates to notes matching the given
+// WithDate restricts Index.Resolve candidates to notes matching the given
 // YYYYMMDD date string. An empty string disables the filter (the default).
 func WithDate(date string) ResolveOption {
 	return func(c *resolveConfig) { c.date = date }
-}
-
-// ResolveRef resolves a note reference to a Ref using the following priority:
-//  1. Numeric ID — exact match; all-digit queries never fall through
-//  2. Type with special behavior (todo, backlog, weekly) — most recent match
-//  3. Path — absolute or relative path with separator, exact match under root
-//  4. Slug substring — most recent note whose slug contains the query
-//
-// Options narrow the candidate set before the priority chain runs; see
-// WithDate.
-//
-// Implementation routes through Index.Resolve on a WithFrontmatter(false)
-// load, so CLI commands that already hold an Index can call Index.Resolve
-// directly and skip this wrapper. A miss returns an error wrapping
-// [ErrNotFound]; callers match with errors.Is.
-func ResolveRef(root, query string, opts ...ResolveOption) (Ref, error) {
-	idx, err := Load(root, WithFrontmatter(false))
-	if err != nil {
-		return Ref{}, err
-	}
-
-	e, ok, err := idx.Resolve(query, opts...)
-	if err != nil {
-		return Ref{}, err
-	}
-	if !ok {
-		return Ref{}, fmt.Errorf("%w: %s", ErrNotFound, strings.TrimSpace(query))
-	}
-	return e.Ref, nil
 }
 
 // resolveRelPath converts a path-like query to a note RelPath under root.

--- a/note/store_test.go
+++ b/note/store_test.go
@@ -200,90 +200,22 @@ func TestScanLenientSkipsUnreadableDir(t *testing.T) {
 	}
 }
 
-func TestResolveRef(t *testing.T) {
+// TestResolveRelPathErrNotFound pins that Index.Resolve propagates the
+// ErrNotFound wrap from resolveRelPath when a path-like query cannot be
+// followed under the store root. Other miss paths (unknown id, unknown slug)
+// stay on the (value, bool) convention and return ok=false, err=nil.
+func TestResolveRelPathErrNotFound(t *testing.T) {
 	root := testdataPath(t)
-	absPath := filepath.Join(root, "2026/01/20260106_8823_999.md")
-
-	tests := []struct {
-		name    string
-		query   string
-		wantID  string
-		wantErr bool
-	}{
-		{"by id", "8823", "8823", false},
-		{"by id todo", "8814", "8814", false},
-		{"by type todo", "todo", "8814", false},
-		{"by slug exact", "disable-letter_opener", "6973", false},
-		{"by slug fragment", "letter_opener", "6973", false},
-		{"by partial slug", "meeting", "8818", false},
-		{"by absolute path", absPath, "8823", false},
-		{"absolute path with trailing slash errors", absPath + "/", "", true},
-		{"empty query returns most recent", "", "8823", false},
-		{"numeric non-id errors", "999", "", true},
-		{"numeric date fragment errors", "202601", "", true},
-		{"basename query does not substring-match path", "20260106_8823_999", "", true},
-		{"basename with md does not substring-match path", "20260106_8823_999.md", "", true},
-		{"date fragment inside slug query does not match path", "20260106", "", true},
-		{"not found id", "9999", "", true},
-		{"not found query", "nonexistent", "", true},
-		{"path outside root", "/tmp", "", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveRef(root, tt.query)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("ResolveRef(%q) expected error, got nil", tt.query)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("ResolveRef(%q) unexpected error: %v", tt.query, err)
-			}
-			if got.ID != tt.wantID {
-				t.Errorf("ResolveRef(%q).ID = %q, want %q", tt.query, got.ID, tt.wantID)
-			}
-		})
-	}
-}
-
-func TestResolveRefWithDateEmptyQueryFiltersByDate(t *testing.T) {
-	root := testdataPath(t)
-	got, err := ResolveRef(root, "", WithDate("20260104"))
+	idx, err := Load(root, WithFrontmatter(false))
 	if err != nil {
-		t.Fatalf("ResolveRef WithDate empty query error: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
-	if got.ID != "8818" {
-		t.Errorf("ResolveRef empty + WithDate(20260104) = %q, want 8818", got.ID)
+	_, _, err = idx.Resolve(filepath.Join(root, "2099/12/20991231_1.md"))
+	if err == nil {
+		t.Fatal("expected error for missing path")
 	}
-}
-
-// TestResolveRefErrNotFound pins that misses from ResolveRef wrap ErrNotFound
-// so callers can match with errors.Is — both the priority-chain miss path
-// (unknown slug / unknown id) and the path-resolution miss (a path that
-// EvalSymlinks cannot follow). Index.Resolve continues to keep the (value,
-// bool) convention for misses, unchanged.
-func TestResolveRefErrNotFound(t *testing.T) {
-	root := testdataPath(t)
-	cases := []struct {
-		name  string
-		query string
-	}{
-		{"unknown id", "9999"},
-		{"unknown slug", "no-such-slug-xyz"},
-		{"missing path", filepath.Join(root, "2099/12/20991231_1.md")},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := ResolveRef(root, tc.query)
-			if err == nil {
-				t.Fatalf("expected error")
-			}
-			if !errors.Is(err, ErrNotFound) {
-				t.Errorf("errors.Is(err, ErrNotFound) = false (err=%v)", err)
-			}
-		})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("errors.Is(err, ErrNotFound) = false (err=%v)", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `note.ResolveRef(root, query, opts...)` called `Load(root, WithFrontmatter(false))` on every invocation. External callers using it in a loop paid for a full store walk per call; the docs already recommended `Index.Resolve`. Remove it from the public API.
- Add an internal `cli.resolveRef` helper in `internal/cli/filter.go` that loads the index once, calls `Index.Resolve`, and wraps priority-chain misses with `note.ErrNotFound` so the CLI's error surface stays identical. Migrate `edit`, `append`, `annotate`, `read`, `resolve`, `update`, and `rm` to it.
- Drop the now-unused `note` import from `internal/cli/edit.go`. Update the `ErrNotFound` doc comment (no longer lists `ResolveRef`), and reword the `Index.Resolve` doc comment to stand on its own. Replace `TestResolveRef*` tests with `TestResolveRelPathErrNotFound`, which pins the same `ErrNotFound` path-miss contract via `Index.Resolve` directly.

## References

- Closes #179
