### PR TITLE
note: move WriteAtomic / StoreDirMode out of internal/cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.11] - 2026-04-23
+
+### Changed
+
+- `writeAtomic` and `rootDirMode` moved from `internal/cli` to the `note` package as exported `note.WriteAtomic` and `note.StoreDirMode`. These are pure file-I/O primitives with no CLI dependency; exporting them makes them available to downstream consumers such as notes-pub / notes-view without duplication ([#203])
+
+[#203]: https://github.com/dreikanter/notes-cli/pull/203
+
 ## [0.2.10] - 2026-04-23
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -122,7 +122,7 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := writeAtomic(fullPath, newContent); err != nil {
+	if err := note.WriteAtomic(fullPath, newContent); err != nil {
 		return err
 	}
 

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -78,7 +78,7 @@ var appendCmd = &cobra.Command{
 		}
 		result := existingStr + "\n" + content + "\n"
 
-		if err := writeAtomic(targetPath, []byte(result)); err != nil {
+		if err := note.WriteAtomic(targetPath, []byte(result)); err != nil {
 			return err
 		}
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -21,32 +21,6 @@ type createNoteParams struct {
 	Body        string // initial content after frontmatter
 }
 
-// rootDirMode returns the permissions to use when creating subdirectories
-// under root. It inherits root's permissions so MkdirAll doesn't widen a
-// restrictive root (e.g. 0o700), defaulting to 0o700 if root cannot be
-// stat'd.
-func rootDirMode(root string) os.FileMode {
-	info, err := os.Stat(root)
-	if err != nil {
-		return 0o700
-	}
-	return info.Mode().Perm()
-}
-
-// writeAtomic writes data to path via a tmp+rename so partial writes don't
-// leave a corrupted file behind.
-func writeAtomic(path string, data []byte) error {
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
-		return fmt.Errorf("cannot write note: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("cannot replace note: %w", err)
-	}
-	return nil
-}
-
 // createNote creates a new note file with optional frontmatter and body content.
 // Returns the absolute path to the created file.
 func createNote(p createNoteParams) (string, error) {
@@ -60,7 +34,7 @@ func createNote(p createNoteParams) (string, error) {
 	filename := note.Filename(today, id, p.Slug, p.Type)
 	dir := note.DirPath(p.Root, today)
 
-	if err := os.MkdirAll(dir, rootDirMode(p.Root)); err != nil {
+	if err := os.MkdirAll(dir, note.StoreDirMode(p.Root)); err != nil {
 		return "", fmt.Errorf("cannot create directory %s: %w", dir, err)
 	}
 
@@ -79,7 +53,7 @@ func createNote(p createNoteParams) (string, error) {
 		return "", err
 	}
 
-	if err := writeAtomic(fullPath, content); err != nil {
+	if err := note.WriteAtomic(fullPath, content); err != nil {
 		return "", err
 	}
 

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -47,7 +47,7 @@ var newTodoCmd = &cobra.Command{
 			result := note.RolloverTasks(prevLines)
 			carriedTasks = result.CarriedTasks
 
-			if err := writeAtomic(prevPath, []byte(strings.Join(result.UpdatedLines, "\n"))); err != nil {
+			if err := note.WriteAtomic(prevPath, []byte(strings.Join(result.UpdatedLines, "\n"))); err != nil {
 				return fmt.Errorf("cannot update previous todo: %w", err)
 			}
 		}
@@ -60,7 +60,7 @@ var newTodoCmd = &cobra.Command{
 
 		filename := note.Filename(today, id, "", "todo")
 		dir := note.DirPath(root, today)
-		if err := os.MkdirAll(dir, rootDirMode(root)); err != nil {
+		if err := os.MkdirAll(dir, note.StoreDirMode(root)); err != nil {
 			return fmt.Errorf("cannot create directory %s: %w", dir, err)
 		}
 
@@ -71,7 +71,7 @@ var newTodoCmd = &cobra.Command{
 			return err
 		}
 
-		if err := writeAtomic(fullPath, content); err != nil {
+		if err := note.WriteAtomic(fullPath, content); err != nil {
 			return err
 		}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -108,7 +108,7 @@ var updateCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if err := writeAtomic(oldPath, newContent); err != nil {
+			if err := note.WriteAtomic(oldPath, newContent); err != nil {
 				return err
 			}
 		}

--- a/note/fsutil.go
+++ b/note/fsutil.go
@@ -1,0 +1,32 @@
+package note
+
+import (
+	"fmt"
+	"os"
+)
+
+// StoreDirMode returns the permissions to use when creating subdirectories
+// under root. It inherits root's permissions so MkdirAll doesn't widen a
+// restrictive root (e.g. 0o700), defaulting to 0o700 if root cannot be
+// stat'd.
+func StoreDirMode(root string) os.FileMode {
+	info, err := os.Stat(root)
+	if err != nil {
+		return 0o700
+	}
+	return info.Mode().Perm()
+}
+
+// WriteAtomic writes data to path via a tmp+rename so partial writes don't
+// leave a corrupted file behind.
+func WriteAtomic(path string, data []byte) error {
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("cannot write note: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("cannot replace note: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Move `writeAtomic` and `rootDirMode` from `internal/cli/create.go` to `note/fsutil.go` as exported `WriteAtomic` and `StoreDirMode`
- Update all callers in `internal/cli` (`create.go`, `new_todo.go`, `append.go`, `update.go`, `annotate.go`) to use `note.WriteAtomic` / `note.StoreDirMode`

## References

- Closes #180
