### PR TITLE
cli: extract editor helpers to internal/editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.12] - 2026-04-23
+
+### Changed
+
+- `parseEditor` and `isTerminalEditor` moved from `internal/cli/edit.go` to a new `internal/editor` package as exported `editor.Parse` and `editor.IsTerminal`. The new package is independently testable with no Cobra dependency ([#204])
+
+[#204]: https://github.com/dreikanter/notes-cli/pull/204
+
 ## [0.2.11] - 2026-04-23
 
 ### Changed

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -5,42 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
+	"github.com/dreikanter/notes-cli/internal/editor"
 	"github.com/spf13/cobra"
 )
-
-// terminalEditors is the set of editors that need a terminal (stdin/stdout).
-// Everything else is assumed to be a GUI app and launched detached.
-var terminalEditors = map[string]bool{
-	"ed":     true,
-	"emacs":  true,
-	"jed":    true,
-	"joe":    true,
-	"mcedit": true,
-	"micro":  true,
-	"nano":   true,
-	"ne":     true,
-	"nvim":   true,
-	"pico":   true,
-	"vi":     true,
-	"vim":    true,
-}
-
-// parseEditor splits an editor string (e.g. "subl --wait") into the binary
-// name and any extra arguments.
-func parseEditor(raw string) (string, []string) {
-	parts := strings.Fields(raw)
-	if len(parts) == 0 {
-		return "", nil
-	}
-	return parts[0], parts[1:]
-}
-
-// isTerminalEditor returns true if the given binary name is a known terminal editor.
-func isTerminalEditor(bin string) bool {
-	return terminalEditors[filepath.Base(bin)]
-}
 
 var editCmd = &cobra.Command{
 	Use:   "edit <id|type|query>",
@@ -69,14 +37,14 @@ The editor value may include arguments, e.g. EDITOR="subl --wait".`,
 			return fmt.Errorf("no editor configured: set $EDITOR or $VISUAL")
 		}
 
-		bin, extraArgs := parseEditor(raw)
+		bin, extraArgs := editor.Parse(raw)
 		path := filepath.Join(root, n.RelPath)
 		cmdArgs := make([]string, 0, len(extraArgs)+1)
 		cmdArgs = append(cmdArgs, extraArgs...)
 		cmdArgs = append(cmdArgs, path)
 		ec := exec.Command(bin, cmdArgs...)
 
-		if isTerminalEditor(bin) {
+		if editor.IsTerminal(bin) {
 			ec.Stdin = os.Stdin
 			ec.Stdout = os.Stdout
 			ec.Stderr = os.Stderr

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -8,50 +8,6 @@ import (
 	"testing"
 )
 
-func TestParseEditor(t *testing.T) {
-	tests := []struct {
-		input    string
-		wantBin  string
-		wantArgs []string
-	}{
-		{"vim", "vim", nil},
-		{"subl --wait", "subl", []string{"--wait"}},
-		{"/usr/bin/code -w --new-window", "/usr/bin/code", []string{"-w", "--new-window"}},
-		{"", "", nil},
-	}
-	for _, tt := range tests {
-		bin, args := parseEditor(tt.input)
-		if bin != tt.wantBin {
-			t.Errorf("parseEditor(%q) bin = %q, want %q", tt.input, bin, tt.wantBin)
-		}
-		if len(args) != len(tt.wantArgs) {
-			t.Errorf("parseEditor(%q) args = %v, want %v", tt.input, args, tt.wantArgs)
-			continue
-		}
-		for i := range args {
-			if args[i] != tt.wantArgs[i] {
-				t.Errorf("parseEditor(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
-			}
-		}
-	}
-}
-
-func TestIsTerminalEditor(t *testing.T) {
-	for _, name := range []string{"vim", "nvim", "nano", "emacs", "vi", "micro"} {
-		if !isTerminalEditor(name) {
-			t.Errorf("expected %q to be a terminal editor", name)
-		}
-	}
-	if !isTerminalEditor("/usr/bin/vim") {
-		t.Error("expected /usr/bin/vim to be a terminal editor")
-	}
-	for _, name := range []string{"code", "subl", "zed", "gedit"} {
-		if isTerminalEditor(name) {
-			t.Errorf("expected %q to NOT be a terminal editor", name)
-		}
-	}
-}
-
 // writeFakeEditor creates a shell script named after a known terminal editor
 // so the edit command runs it in foreground mode.
 func writeFakeEditor(t *testing.T, body string) string {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,0 +1,38 @@
+package editor
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// terminalEditors is the set of editors that need a terminal (stdin/stdout).
+// Everything else is assumed to be a GUI app and launched detached.
+var terminalEditors = map[string]bool{
+	"ed":     true,
+	"emacs":  true,
+	"jed":    true,
+	"joe":    true,
+	"mcedit": true,
+	"micro":  true,
+	"nano":   true,
+	"ne":     true,
+	"nvim":   true,
+	"pico":   true,
+	"vi":     true,
+	"vim":    true,
+}
+
+// Parse splits an editor string (e.g. "subl --wait") into the binary name
+// and any extra arguments.
+func Parse(raw string) (string, []string) {
+	parts := strings.Fields(raw)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return parts[0], parts[1:]
+}
+
+// IsTerminal returns true if the given binary name is a known terminal editor.
+func IsTerminal(bin string) bool {
+	return terminalEditors[filepath.Base(bin)]
+}

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1,0 +1,51 @@
+package editor_test
+
+import (
+	"testing"
+
+	"github.com/dreikanter/notes-cli/internal/editor"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantBin  string
+		wantArgs []string
+	}{
+		{"vim", "vim", nil},
+		{"subl --wait", "subl", []string{"--wait"}},
+		{"/usr/bin/code -w --new-window", "/usr/bin/code", []string{"-w", "--new-window"}},
+		{"", "", nil},
+	}
+	for _, tt := range tests {
+		bin, args := editor.Parse(tt.input)
+		if bin != tt.wantBin {
+			t.Errorf("Parse(%q) bin = %q, want %q", tt.input, bin, tt.wantBin)
+		}
+		if len(args) != len(tt.wantArgs) {
+			t.Errorf("Parse(%q) args = %v, want %v", tt.input, args, tt.wantArgs)
+			continue
+		}
+		for i := range args {
+			if args[i] != tt.wantArgs[i] {
+				t.Errorf("Parse(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
+			}
+		}
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	for _, name := range []string{"vim", "nvim", "nano", "emacs", "vi", "micro"} {
+		if !editor.IsTerminal(name) {
+			t.Errorf("expected %q to be a terminal editor", name)
+		}
+	}
+	if !editor.IsTerminal("/usr/bin/vim") {
+		t.Error("expected /usr/bin/vim to be a terminal editor")
+	}
+	for _, name := range []string{"code", "subl", "zed", "gedit"} {
+		if editor.IsTerminal(name) {
+			t.Errorf("expected %q to NOT be a terminal editor", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Move `parseEditor` and `isTerminalEditor` from `internal/cli/edit.go` to a new `internal/editor` package as exported `Parse` and `IsTerminal`
- Move the corresponding unit tests to `internal/editor/editor_test.go`
- `edit.go` retains only the Cobra command wiring

## References

- closes #181