### PR TITLE
note: reshape Task to hide regex-piece fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.14] - 2026-04-23
+
+### Changed
+
+- `note.Task` fields `Prefix`, `Marker`, and `Suffix` are now unexported — they were regex capture intermediates that leaked parse details to external consumers. Replaced with exported `State TaskState` (values: `TaskPending`, `TaskDone`, `TaskOther`) and `Text string` (trimmed task text after the bracket). `Reassembled` and `WithTag` continue to work; internal `RolloverTasks` uses the unexported captures ([#206])
+
+[#206]: https://github.com/dreikanter/notes-cli/pull/206
+
 ## [0.2.13] - 2026-04-23
 
 ### Changed

--- a/note/todo.go
+++ b/note/todo.go
@@ -5,18 +5,45 @@ import (
 	"strings"
 )
 
+// TaskState describes the completion state of a task line.
+type TaskState string
+
+const (
+	// TaskPending is an incomplete task (marker " ").
+	TaskPending TaskState = "pending"
+	// TaskDone is a completed task (marker "+" or "x").
+	TaskDone TaskState = "done"
+	// TaskOther covers any marker character not mapped above.
+	TaskOther TaskState = "other"
+)
+
 // taskRe matches lines like "  - [ ] some task" or "[ ] some task".
 var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.)(\].*)$`)
 
 // Task represents a parsed task line from a todo note.
 type Task struct {
-	Line       string // original full line
-	Prefix     string // everything before the marker character: e.g. "  - ["
-	Marker     string // single char marker: " ", "x", "+", etc.
-	Suffix     string // everything after marker: e.g. "] some task"
-	IsDaily    bool   // whether line contains #daily
-	IsMoved    bool   // whether line contains (moved)
-	LineNumber int    // 0-based index in the source file lines
+	Line       string    // original full line
+	State      TaskState // completion state derived from the marker
+	Text       string    // trimmed task text, e.g. "Buy milk #daily"
+	IsDaily    bool      // whether line contains #daily
+	IsMoved    bool      // whether line contains (moved)
+	LineNumber int       // 0-based index in the source file lines
+
+	// regex capture groups kept unexported; use Reassembled / WithTag to rebuild lines.
+	prefix string
+	marker string
+	suffix string
+}
+
+func markerToState(m string) TaskState {
+	switch m {
+	case " ":
+		return TaskPending
+	case "+", "x":
+		return TaskDone
+	default:
+		return TaskOther
+	}
 }
 
 // ParseTask attempts to parse a line as a task. Returns nil if not a task line.
@@ -25,20 +52,29 @@ func ParseTask(line string, lineNumber int) *Task {
 	if m == nil {
 		return nil
 	}
+	suffix := m[3]
+	text := ""
+	if len(suffix) >= 2 && suffix[:2] == "] " {
+		text = strings.TrimSpace(suffix[2:])
+	} else if len(suffix) > 1 {
+		text = strings.TrimSpace(suffix[1:])
+	}
 	return &Task{
 		Line:       line,
-		Prefix:     m[1],
-		Marker:     m[2],
-		Suffix:     m[3],
+		State:      markerToState(m[2]),
+		Text:       text,
 		IsDaily:    strings.Contains(line, "#daily"),
 		IsMoved:    strings.Contains(line, "(moved)"),
 		LineNumber: lineNumber,
+		prefix:     m[1],
+		marker:     m[2],
+		suffix:     suffix,
 	}
 }
 
 // Reassembled returns the task line with a new marker.
 func (t *Task) Reassembled(marker string) string {
-	return t.Prefix + marker + t.Suffix
+	return t.prefix + marker + t.suffix
 }
 
 // WithTag returns the task line with a tag inserted after the marker bracket.
@@ -46,15 +82,15 @@ func (t *Task) Reassembled(marker string) string {
 // Returns the line unchanged if the tag is already present.
 func (t *Task) WithTag(tag string) string {
 	tagStr := "(" + tag + ")"
-	if strings.Contains(t.Suffix, tagStr) {
+	if strings.Contains(t.suffix, tagStr) {
 		return t.Line
 	}
-	// Suffix starts with "] ", insert tag after the "] "
-	if len(t.Suffix) >= 2 && t.Suffix[:2] == "] " {
-		return t.Prefix + t.Marker + "] " + tagStr + " " + t.Suffix[2:]
+	// suffix starts with "] ", insert tag after the "] "
+	if len(t.suffix) >= 2 && t.suffix[:2] == "] " {
+		return t.prefix + t.marker + "] " + tagStr + " " + t.suffix[2:]
 	}
-	// Suffix is just "]" with no text
-	return t.Prefix + t.Marker + "] " + tagStr + t.Suffix[1:]
+	// suffix is just "]" with no text
+	return t.prefix + t.marker + "] " + tagStr + t.suffix[1:]
 }
 
 // ExtractTasks parses all task lines from a todo file's content lines.
@@ -85,9 +121,9 @@ func RolloverTasks(prevLines []string) RolloverResult {
 
 	addTask := func(t Task) {
 		// Strip (moved) from suffix so carried tasks are clean
-		t.Suffix = strings.Replace(t.Suffix, "(moved) ", "", 1)
+		t.suffix = strings.Replace(t.suffix, "(moved) ", "", 1)
 		// Normalize: strip leading whitespace, bullet, and marker for dedup
-		key := strings.TrimSpace(t.Suffix)
+		key := strings.TrimSpace(t.suffix)
 		if seen[key] {
 			return
 		}
@@ -100,10 +136,10 @@ func RolloverTasks(prevLines []string) RolloverResult {
 		case t.IsDaily:
 			// Daily tasks are always carried over regardless of marker
 			addTask(t)
-			if t.Marker == " " && !t.IsMoved {
+			if t.marker == " " && !t.IsMoved {
 				updated[t.LineNumber] = t.WithTag("moved")
 			}
-		case t.Marker == " " && !t.IsMoved:
+		case t.marker == " " && !t.IsMoved:
 			// Pending tasks: carry over and tag as moved in previous
 			addTask(t)
 			updated[t.LineNumber] = t.WithTag("moved")

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -7,22 +7,23 @@ import (
 
 func TestParseTask(t *testing.T) {
 	tests := []struct {
-		name    string
-		line    string
-		wantNil bool
-		marker  string
-		isDaily bool
-		isMoved bool
+		name      string
+		line      string
+		wantNil   bool
+		wantState TaskState
+		isDaily   bool
+		isMoved   bool
 	}{
-		{"pending", "[ ] Buy milk", false, " ", false, false},
-		{"pending with bullet", "- [ ] Buy milk", false, " ", false, false},
-		{"pending indented", "  [ ] Buy milk", false, " ", false, false},
-		{"pending indented bullet", "  - [ ] Buy milk", false, " ", false, false},
-		{"completed", "[+] Done task", false, "+", false, false},
-		{"daily", "[ ] Standup #daily", false, " ", true, false},
-		{"daily completed", "[+] Standup #daily", false, "+", true, false},
-		{"moved", "- [ ] (moved) Buy milk", false, " ", false, true},
-		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, " ", false, true},
+		{"pending", "[ ] Buy milk", false, TaskPending, false, false},
+		{"pending with bullet", "- [ ] Buy milk", false, TaskPending, false, false},
+		{"pending indented", "  [ ] Buy milk", false, TaskPending, false, false},
+		{"pending indented bullet", "  - [ ] Buy milk", false, TaskPending, false, false},
+		{"completed plus", "[+] Done task", false, TaskDone, false, false},
+		{"completed x", "[x] Done task", false, TaskDone, false, false},
+		{"daily", "[ ] Standup #daily", false, TaskPending, true, false},
+		{"daily completed", "[+] Standup #daily", false, TaskDone, true, false},
+		{"moved", "- [ ] (moved) Buy milk", false, TaskPending, false, true},
+		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, TaskPending, false, true},
 		{"not a task", "Just a regular line", true, "", false, false},
 		{"empty", "", true, "", false, false},
 		{"header", "# Todo", true, "", false, false},
@@ -41,8 +42,8 @@ func TestParseTask(t *testing.T) {
 			if task == nil {
 				t.Fatalf("expected non-nil for %q", tt.line)
 			}
-			if task.Marker != tt.marker {
-				t.Errorf("marker: got %q, want %q", task.Marker, tt.marker)
+			if task.State != tt.wantState {
+				t.Errorf("state: got %q, want %q", task.State, tt.wantState)
 			}
 			if task.IsDaily != tt.isDaily {
 				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)
@@ -51,6 +52,27 @@ func TestParseTask(t *testing.T) {
 				t.Errorf("isMoved: got %v, want %v", task.IsMoved, tt.isMoved)
 			}
 		})
+	}
+}
+
+func TestParseTaskText(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"[ ] Buy milk", "Buy milk"},
+		{"- [ ] Buy milk #daily", "Buy milk #daily"},
+		{"  - [ ] (moved) Do thing", "(moved) Do thing"},
+		{"[+] Done", "Done"},
+	}
+	for _, tt := range tests {
+		task := ParseTask(tt.line, 0)
+		if task == nil {
+			t.Fatalf("expected task for %q", tt.line)
+		}
+		if task.Text != tt.want {
+			t.Errorf("Text for %q: got %q, want %q", tt.line, task.Text, tt.want)
+		}
 	}
 }
 
@@ -174,8 +196,8 @@ func TestRolloverTasksSkipsMoved(t *testing.T) {
 	if len(result.CarriedTasks) != 1 {
 		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
 	}
-	if !strings.Contains(result.CarriedTasks[0].Suffix, "Fresh task") {
-		t.Errorf("expected Fresh task, got: %s", result.CarriedTasks[0].Suffix)
+	if !strings.Contains(result.CarriedTasks[0].Text, "Fresh task") {
+		t.Errorf("expected Fresh task, got: %s", result.CarriedTasks[0].Text)
 	}
 
 	// Already-moved task should not be re-tagged
@@ -196,7 +218,7 @@ func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
 	if len(result.CarriedTasks) != 1 {
 		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
 	}
-	if !strings.Contains(result.CarriedTasks[0].Suffix, "Standup") {
+	if !strings.Contains(result.CarriedTasks[0].Text, "Standup") {
 		t.Error("expected daily task to be carried over")
 	}
 }
@@ -227,12 +249,13 @@ slug: todo
 }
 
 func TestFormatTodoContent(t *testing.T) {
-	tasks := []Task{
-		{Prefix: "[", Marker: " ", Suffix: "] Task one"},
-		{Prefix: "[", Marker: " ", Suffix: "] Task two"},
+	task1 := ParseTask("[ ] Task one", 0)
+	task2 := ParseTask("[ ] Task two", 1)
+	if task1 == nil || task2 == nil {
+		t.Fatal("expected tasks")
 	}
 
-	content := FormatTodoContent(tasks)
+	content := FormatTodoContent([]Task{*task1, *task2})
 
 	if strings.HasPrefix(content, "---") {
 		t.Errorf("unexpected frontmatter, got:\n%s", content)


### PR DESCRIPTION
## Summary

- Make `Prefix`, `Marker`, `Suffix` unexported on `Task` — they are regex capture intermediates, not a stable data shape
- Add exported `State TaskState` (pending / done / other) and `Text string` (trimmed task text after the bracket) so external consumers get a data-oriented API
- Add `TaskState` type with constants `TaskPending`, `TaskDone`, `TaskOther`
- `Reassembled` and `WithTag` continue to work via the unexported captures
- Update tests: replace direct struct literal construction (`{Prefix: "[", Marker: " ", Suffix: "]..."}`) with `ParseTask`; switch `Suffix` field reads to `Text`

## References

- closes #183
- depends on #205