### PR TITLE
note: add Index.Snapshot for zero-copy reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.15] - 2026-04-23
+
+### Changed
+
+- `Index.Snapshot()` added: returns a lightweight `Snapshot` value (slice-header copy, no deep copy) under a short read-lock. `Snapshot` exposes `Entries() []Entry` and `Len() int` and is safe to hold after the lock is released. Callers that need a stable view of the index after `Load` can use `Snapshot()` instead of `Entries()` ([#207])
+
+[#207]: https://github.com/dreikanter/notes-cli/pull/207
+
 ## [0.2.14] - 2026-04-23
 
 ### Changed

--- a/note/index.go
+++ b/note/index.go
@@ -367,6 +367,34 @@ func (i *Index) Entries() []Entry {
 	return out
 }
 
+// Snapshot returns a zero-copy, read-only view of the current index state.
+// The caller must not mutate the returned slice or any Entry within it;
+// doing so races concurrent Reload calls. Use Entries for a safe mutable
+// copy. The snapshot reflects the index at the moment of the call and does
+// not update if Reload runs afterwards.
+func (i *Index) Snapshot() Snapshot {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return Snapshot{entries: i.entries}
+}
+
+// Snapshot is a zero-copy, read-only view of an Index's entry list.
+// Obtain one via Index.Snapshot; do not construct directly.
+type Snapshot struct {
+	entries []Entry
+}
+
+// Entries returns the snapshot's entry slice directly, without copying.
+// The caller must not mutate the slice or any Entry within it.
+func (s Snapshot) Entries() []Entry {
+	return s.entries
+}
+
+// Len returns the number of entries in the snapshot.
+func (s Snapshot) Len() int {
+	return len(s.entries)
+}
+
 // ByID returns the entry with the given numeric ID, or false. When multiple
 // entries share an ID the newest wins.
 func (i *Index) ByID(id string) (Entry, bool) {


### PR DESCRIPTION
## Summary

- Add `Index.Snapshot()` method that returns a read-only `Snapshot` value under a short read-lock
- `Snapshot` holds a copy of the entries slice header (no deep copy) with `Entries()` and `Len()` accessors
- Callers that need a stable view after `Load` can use `Snapshot()` instead of `Entries()` to avoid holding the index lock

## References

- closes #184