### PR TITLE
note: guard flock in NextID behind unix build tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.17] - 2026-04-23
+
+### Changed
+
+- `lockStoreRoot` (the `syscall.Flock` helper used by `NextID`) moved from `note/id.go` into two build-tag files: `note/id_unix.go` (`//go:build unix`) and a no-op stub `note/id_other.go` (`//go:build !unix`). The package now compiles on non-Unix targets without a `syscall` dependency; behavior on Unix is unchanged ([#209])
+
+[#209]: https://github.com/dreikanter/notes-cli/pull/209
+
 ## [0.2.16] - 2026-04-23
 
 ### Changed

--- a/note/id.go
+++ b/note/id.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 // idFile represents the id.json file that tracks the last allocated note ID.
@@ -75,24 +74,4 @@ func writeID(root string, idf idFile) error {
 		return fmt.Errorf("cannot rename temp id.json: %w", err)
 	}
 	return nil
-}
-
-// lockStoreRoot acquires an exclusive flock on the store root directory, blocking
-// until it is available. Locking the directory (rather than a sibling lockfile)
-// avoids leaving artifacts behind and sidesteps the unlink-race that cleanable
-// lockfiles suffer from. The returned function releases the lock and closes
-// the file descriptor.
-func lockStoreRoot(root string) (func(), error) {
-	f, err := os.Open(root)
-	if err != nil {
-		return nil, fmt.Errorf("cannot open notes root for locking: %w", err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
-		return nil, fmt.Errorf("cannot lock notes root: %w", err)
-	}
-	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
-	}, nil
 }

--- a/note/id_other.go
+++ b/note/id_other.go
@@ -1,0 +1,11 @@
+//go:build !unix
+
+package note
+
+// lockStoreRoot is a no-op on non-Unix platforms where syscall.Flock is not
+// available. Concurrent NextID calls are not serialized on these platforms;
+// the notes CLI is primarily used interactively on a single machine, so
+// races are unlikely in practice.
+func lockStoreRoot(_ string) (func(), error) {
+	return func() {}, nil
+}

--- a/note/id_unix.go
+++ b/note/id_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package note
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lockStoreRoot acquires an exclusive flock on the store root directory,
+// blocking until it is available. Locking the directory (rather than a
+// sibling lockfile) avoids leaving artifacts behind and sidesteps the
+// unlink-race that cleanable lockfiles suffer from. The returned function
+// releases the lock and closes the file descriptor.
+func lockStoreRoot(root string) (func(), error) {
+	f, err := os.Open(root)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open notes root for locking: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("cannot lock notes root: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}


### PR DESCRIPTION
## Summary

- Move `lockStoreRoot` out of `note/id.go` into two build-tag files: `note/id_unix.go` (`//go:build unix`) with the real `syscall.Flock` implementation and `note/id_other.go` (`//go:build !unix`) with a no-op
- `note/id.go` no longer imports `syscall`, so the package compiles on non-Unix targets (Windows, plan9) without modification
- Behavior on Unix is unchanged; on non-Unix platforms concurrent `NextID` callers are not serialized, which is acceptable for an interactive single-user CLI

## References

- closes #186