### PR TITLE
cli: extract resolveOrFilter helper for positional-vs-filter dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.18] - 2026-04-23
+
+### Changed
+
+- `resolveOrFilter(cmd, root, args, f, resolveOpts...)` added to `internal/cli/filter.go`. It handles the repeated "positional ref → `resolveRef`; filter flags → load+filter; neither → caller decides" pattern. `append` and `read` now delegate to it; `resolve` uses it for the filter-only path and keeps its positional-arg path inline since it allows `--today` alongside a positional argument ([#210])
+
+[#210]: https://github.com/dreikanter/notes-cli/pull/210
+
 ## [0.2.17] - 2026-04-23
 
 ### Changed

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -37,33 +37,14 @@ var appendCmd = &cobra.Command{
 
 		f := readFilterFlags(cmd)
 
-		var targetPath string
-
-		if len(args) == 1 {
-			if f.active() {
-				return fmt.Errorf("cannot combine positional argument with filter flags")
-			}
-
-			n, resolveErr := resolveRef(cmd, root, args[0])
-			if resolveErr != nil {
-				return resolveErr
-			}
-			targetPath = filepath.Join(root, n.RelPath)
-		} else if f.active() {
-			idx, loadErr := note.Load(root, loadOptsFor(cmd, f)...)
-			if loadErr != nil {
-				return loadErr
-			}
-
-			entries := applyFilters(idx.Entries(), f)
-
-			if len(entries) == 0 {
-				return fmt.Errorf("no notes found matching filters: %s", f.describe())
-			}
-			targetPath = filepath.Join(root, entries[0].RelPath)
-		} else {
+		entry, ok, err := resolveOrFilter(cmd, root, args, f)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}
+		targetPath := filepath.Join(root, entry.RelPath)
 
 		// Read existing file
 		existing, err := os.ReadFile(targetPath)

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -112,6 +112,42 @@ func applyFilters(entries []note.Entry, f filterOpts) []note.Entry {
 	return entries
 }
 
+// resolveOrFilter returns the first note matching a positional ref or filter
+// flags. When a positional arg and active filter flags are both present it
+// returns an error. When filters are active but nothing matches it returns a
+// "no notes found" error. When neither args nor filters are given it returns
+// (Entry{}, false, nil); callers decide how to handle that case.
+func resolveOrFilter(
+	cmd *cobra.Command,
+	root string,
+	args []string,
+	f filterOpts,
+	resolveOpts ...note.ResolveOption,
+) (note.Entry, bool, error) {
+	if len(args) == 1 {
+		if f.active() {
+			return note.Entry{}, false, fmt.Errorf("cannot combine positional argument with filter flags")
+		}
+		n, err := resolveRef(cmd, root, args[0], resolveOpts...)
+		if err != nil {
+			return note.Entry{}, false, err
+		}
+		return note.Entry{Ref: n}, true, nil
+	}
+	if f.active() {
+		idx, err := note.Load(root, loadOptsFor(cmd, f)...)
+		if err != nil {
+			return note.Entry{}, false, err
+		}
+		entries := applyFilters(idx.Entries(), f)
+		if len(entries) == 0 {
+			return note.Entry{}, false, fmt.Errorf("no notes found matching filters: %s", f.describe())
+		}
+		return entries[0], true, nil
+	}
+	return note.Entry{}, false, nil
+}
+
 // addFilterFlags registers the common filter flags on a command.
 func addFilterFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("today", false, "only match notes created today")

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -21,32 +21,14 @@ var readCmd = &cobra.Command{
 		f := readFilterFlags(cmd)
 		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
 
-		var relPath string
-
-		if len(args) == 1 {
-			if f.active() {
-				return fmt.Errorf("cannot combine positional argument with filter flags")
-			}
-			n, err := resolveRef(cmd, root, args[0])
-			if err != nil {
-				return err
-			}
-			relPath = n.RelPath
-		} else if f.active() {
-			idx, err := note.Load(root, loadOptsFor(cmd, f)...)
-			if err != nil {
-				return err
-			}
-
-			entries := applyFilters(idx.Entries(), f)
-
-			if len(entries) == 0 {
-				return fmt.Errorf("no notes found matching filters: %s", f.describe())
-			}
-			relPath = entries[0].RelPath
-		} else {
+		entry, ok, err := resolveOrFilter(cmd, root, args, f)
+		if err != nil {
+			return err
+		}
+		if !ok {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}
+		relPath := entry.RelPath
 
 		data, err := os.ReadFile(filepath.Join(root, relPath))
 		if err != nil {

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -40,12 +40,12 @@ positional resolution to notes dated today.`,
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 
-			var date string
+			var ropts []note.ResolveOption
 			if f.Today {
-				date = time.Now().Format(note.DateFormat)
+				ropts = []note.ResolveOption{note.WithDate(time.Now().Format(note.DateFormat))}
 			}
 
-			n, err := resolveRef(cmd, root, args[0], note.WithDate(date))
+			n, err := resolveRef(cmd, root, args[0], ropts...)
 			if err != nil {
 				return err
 			}
@@ -54,21 +54,24 @@ positional resolution to notes dated today.`,
 			return nil
 		}
 
-		idx, err := note.Load(root, loadOptsFor(cmd, f)...)
+		entry, ok, err := resolveOrFilter(cmd, root, nil, f)
 		if err != nil {
 			return err
 		}
-
-		entries := applyFilters(idx.Entries(), f)
-
-		if len(entries) == 0 {
-			if f.active() {
-				return fmt.Errorf("no notes found matching filters: %s", f.describe())
+		if !ok {
+			// No filters active: return the most recent note.
+			idx, loadErr := note.Load(root, loadOptsFor(cmd, f)...)
+			if loadErr != nil {
+				return loadErr
 			}
-			return fmt.Errorf("no notes found")
+			all := idx.Entries()
+			if len(all) == 0 {
+				return fmt.Errorf("no notes found")
+			}
+			entry = all[0]
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, entries[0].RelPath))
+		fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, entry.RelPath))
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary

- Add `resolveOrFilter(cmd, root, args, f, resolveOpts...)` to `internal/cli/filter.go`; returns `(note.Entry, bool, error)` where `bool=false` and `err=nil` signals "no args and no active filters" for the caller to handle
- `append.go` and `read.go` replace 20+ lines of branching with three lines; the "neither arg nor filter" case returns "specify a note" error
- `resolve.go` keeps its positional-arg path inline (it allows `--today` alongside a positional arg, unlike the other two commands) and uses `resolveOrFilter` for the filter-only path; the `!ok` fallback loads all entries and returns the most recent

## References

- closes #188