### PR TITLE
cli: unify grep/rg external-search dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.19] - 2026-04-23
+
+### Changed
+
+- `runExternalSearch(cmd, args, tool, notInstalled, buildArgs)` extracted to `internal/cli/search.go`. Both `grep` and `rg` delegate to it; each command's `RunE` now only provides the tool-specific `buildArgs` closure. The `notInstalled` string triggers a `exec.LookPath` pre-check when non-empty ([#211])
+
+[#211]: https://github.com/dreikanter/notes-cli/pull/211
+
 ## [0.2.18] - 2026-04-23
 
 ### Changed

--- a/internal/cli/grep.go
+++ b/internal/cli/grep.go
@@ -1,11 +1,6 @@
 package cli
 
-import (
-	"os"
-	"os/exec"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var grepCmd = &cobra.Command{
 	Use:   "grep [flags] <pattern>",
@@ -16,24 +11,9 @@ The following flags are injected automatically: -r (recursive), --include=*.md, 
 	DisableFlagParsing: true,
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, arg := range args {
-			if arg == "--help" || arg == "-h" {
-				return cmd.Help()
-			}
-		}
-
-		root, err := notesRoot()
-		if err != nil {
-			return err
-		}
-		grepArgs := append([]string{"-r", "--include=*.md", "--exclude-dir=.git"}, args...)
-		grepArgs = append(grepArgs, root)
-
-		grep := exec.Command("grep", grepArgs...)
-		grep.Stdout = os.Stdout
-		grep.Stderr = os.Stderr
-
-		return grep.Run()
+		return runExternalSearch(cmd, args, "grep", "", func(root string, passThrough []string) []string {
+			return append(append([]string{"-r", "--include=*.md", "--exclude-dir=.git"}, passThrough...), root)
+		})
 	},
 }
 

--- a/internal/cli/rg.go
+++ b/internal/cli/rg.go
@@ -1,12 +1,6 @@
 package cli
 
-import (
-	"fmt"
-	"os"
-	"os/exec"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var rgCmd = &cobra.Command{
 	Use:   "rg [flags] <pattern>",
@@ -17,28 +11,13 @@ The following flag is injected automatically: --glob *.md. The notes path is app
 	DisableFlagParsing: true,
 	SilenceErrors:      true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, arg := range args {
-			if arg == "--help" || arg == "-h" {
-				return cmd.Help()
-			}
-		}
-
-		if _, err := exec.LookPath("rg"); err != nil {
-			return fmt.Errorf("ripgrep (rg) is not installed; install it from https://github.com/BurntSushi/ripgrep")
-		}
-
-		root, err := notesRoot()
-		if err != nil {
-			return err
-		}
-		rgArgs := append([]string{"--glob", "*.md"}, args...)
-		rgArgs = append(rgArgs, root)
-
-		rg := exec.Command("rg", rgArgs...)
-		rg.Stdout = os.Stdout
-		rg.Stderr = os.Stderr
-
-		return rg.Run()
+		return runExternalSearch(
+			cmd, args, "rg",
+			"ripgrep (rg) is not installed; install it from https://github.com/BurntSushi/ripgrep",
+			func(root string, passThrough []string) []string {
+				return append(append([]string{"--glob", "*.md"}, passThrough...), root)
+			},
+		)
 	},
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// runExternalSearch is the shared dispatch skeleton for grep and rg.
+// It handles help detection, optional PATH check, root resolution, and exec.
+// buildArgs constructs the full argument list from the notes root and the
+// pass-through args. When notInstalled is non-empty, a PATH check is performed
+// first; a missing binary returns an error with that message.
+func runExternalSearch(
+	cmd *cobra.Command,
+	args []string,
+	tool, notInstalled string,
+	buildArgs func(root string, args []string) []string,
+) error {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return cmd.Help()
+		}
+	}
+	if notInstalled != "" {
+		if _, err := exec.LookPath(tool); err != nil {
+			return fmt.Errorf("%s", notInstalled)
+		}
+	}
+	root, err := notesRoot()
+	if err != nil {
+		return err
+	}
+	c := exec.Command(tool, buildArgs(root, args)...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}


### PR DESCRIPTION
## Summary

- Extract `runExternalSearch(cmd, args, tool, notInstalled, buildArgs)` into `internal/cli/search.go`; it handles `--help`/`-h` detection, optional `exec.LookPath` check, root resolution, and exec with inherited stdout/stderr
- `grep.go` and `rg.go` each reduce to a `cobra.Command` declaration and a one-call `RunE` — the only tool-specific part is the `buildArgs` function that prepends the fixed flags

## References

- closes #190