### PR TITLE
cli: split RunE closures in new, update, annotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.20] - 2026-04-23
+
+### Changed
+
+- `new.go`: `findUpsertNote` and `readStdinBody` extracted from `RunE`; the upsert lookup and stdin read are now named helpers
+- `update.go`: `syncNoteFilename` extracted from `RunE`; the hard-link rename path is now a standalone function
+- `annotate.go`: `invokeAnnotate` extracted; it wraps schema build, context deadline, `runClaude`, and result parse into one call ([#212])
+
+[#212]: https://github.com/dreikanter/notes-cli/pull/212
+
 ## [0.2.19] - 2026-04-23
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -96,22 +96,7 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	schema, err := buildAnnotateSchema(empty)
-	if err != nil {
-		return err
-	}
-	ctx := cmd.Context()
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
-	out, err := runClaude(ctx, model, schema, prompt)
-	if err != nil {
-		return err
-	}
-
-	gen, err := parseAnnotation(out)
+	gen, err := invokeAnnotate(cmd.Context(), model, timeout, empty, prompt)
 	if err != nil {
 		return err
 	}
@@ -128,6 +113,25 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintln(cmd.OutOrStdout(), fullPath)
 	return nil
+}
+
+// invokeAnnotate builds the JSON Schema for the empty fields, optionally
+// applies a context deadline, calls runClaude, and parses the result.
+func invokeAnnotate(ctx context.Context, model string, timeout time.Duration, empty []string, prompt string) (annotateResult, error) {
+	schema, err := buildAnnotateSchema(empty)
+	if err != nil {
+		return annotateResult{}, err
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	out, err := runClaude(ctx, model, schema, prompt)
+	if err != nil {
+		return annotateResult{}, err
+	}
+	return parseAnnotation(out)
 }
 
 // runClaude executes the Claude Code CLI non-interactively and returns its stdout.

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -37,34 +37,20 @@ var newCmd = &cobra.Command{
 			return err
 		}
 
-		// --upsert: check if today already has a matching note
 		if upsert {
-			today := time.Now().Format(note.DateFormat)
-			idx, err := note.Load(root, note.WithFrontmatter(false), note.WithLogger(stderrLogger(cmd)))
+			path, found, err := findUpsertNote(cmd, root, noteType, slug)
 			if err != nil {
 				return err
 			}
-			entries := note.FilterByDate(idx.Entries(), today)
-			if noteType != "" {
-				entries = note.FilterByTypes(entries, []string{noteType})
-			}
-			if slug != "" {
-				entries = note.FilterBySlug(entries, slug)
-			}
-			if len(entries) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, entries[0].RelPath))
+			if found {
+				fmt.Fprintln(cmd.OutOrStdout(), path)
 				return nil
 			}
 		}
 
-		var body string
-		in := cmd.InOrStdin()
-		if !stdinIsTerminal(in) {
-			data, err := io.ReadAll(in)
-			if err != nil {
-				return fmt.Errorf("cannot read stdin: %w", err)
-			}
-			body = string(data)
+		body, err := readStdinBody(cmd)
+		if err != nil {
+			return err
 		}
 
 		fullPath, err := createNote(createNoteParams{
@@ -100,6 +86,41 @@ func stdinIsTerminal(in io.Reader) bool {
 		return true
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// findUpsertNote returns the absolute path of an existing today's note
+// matching noteType and slug, or ("", false, nil) when none exists.
+func findUpsertNote(cmd *cobra.Command, root, noteType, slug string) (string, bool, error) {
+	today := time.Now().Format(note.DateFormat)
+	idx, err := note.Load(root, note.WithFrontmatter(false), note.WithLogger(stderrLogger(cmd)))
+	if err != nil {
+		return "", false, err
+	}
+	entries := note.FilterByDate(idx.Entries(), today)
+	if noteType != "" {
+		entries = note.FilterByTypes(entries, []string{noteType})
+	}
+	if slug != "" {
+		entries = note.FilterBySlug(entries, slug)
+	}
+	if len(entries) == 0 {
+		return "", false, nil
+	}
+	return filepath.Join(root, entries[0].RelPath), true, nil
+}
+
+// readStdinBody reads stdin when it is not a terminal and returns its content.
+// Returns ("", nil) when stdin is a terminal (no piped input).
+func readStdinBody(cmd *cobra.Command) (string, error) {
+	in := cmd.InOrStdin()
+	if stdinIsTerminal(in) {
+		return "", nil
+	}
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return "", fmt.Errorf("cannot read stdin: %w", err)
+	}
+	return string(data), nil
 }
 
 func registerNewFlags() {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -113,49 +113,61 @@ var updateCmd = &cobra.Command{
 			}
 		}
 
-		// --sync-filename: reconcile filename to match (already-updated) frontmatter.
-		// When frontmatter is silent on slug/type AND the user didn't touch
-		// those flags, fall back to the filename-reported value so the rename
-		// is a no-op instead of stripping a still-valid cache suffix.
 		newPath := oldPath
 		if syncFilename {
-			id, err := strconv.Atoi(n.ID)
-			if err != nil {
-				return fmt.Errorf("invalid note id %q: %w", n.ID, err)
-			}
-			syncSlug := updated.Slug
-			if syncSlug == "" && !cmd.Flags().Changed("slug") && !updateNoSlug {
-				syncSlug = n.Slug
-			}
-			syncType := updated.Type
-			if syncType == "" && !cmd.Flags().Changed("type") && !updateNoType {
-				syncType = n.Type
-			}
-			newFilename := note.Filename(n.Date, id, syncSlug, syncType)
-			dir := filepath.Dir(oldPath)
-			newPath = filepath.Join(dir, newFilename)
-			if newPath != oldPath {
-				// os.Link atomically reserves the target: returns EEXIST if it
-				// already exists, which os.Rename on Unix would silently clobber.
-				if err := os.Link(oldPath, newPath); err != nil {
-					if errors.Is(err, os.ErrExist) {
-						return fmt.Errorf("target note already exists: %s", newPath)
-					}
-					return fmt.Errorf("cannot link note: %w", err)
-				}
-				if err := os.Remove(oldPath); err != nil {
-					// Roll back the link so we don't leave both paths pointing
-					// to the same inode. Best-effort: a cleanup failure here
-					// isn't surfaced because the original error is more useful.
-					_ = os.Remove(newPath)
-					return fmt.Errorf("cannot remove old note: %w", err)
-				}
+			var syncErr error
+			newPath, syncErr = syncNoteFilename(cmd, n, updated, oldPath, updateNoSlug, updateNoType)
+			if syncErr != nil {
+				return syncErr
 			}
 		}
 
 		fmt.Fprintln(cmd.OutOrStdout(), newPath)
 		return nil
 	},
+}
+
+// syncNoteFilename reconciles the on-disk filename with the (already-updated)
+// frontmatter slug and type. When frontmatter is silent on slug/type and the
+// user did not touch those flags, the filename-reported value is used so the
+// rename is a no-op instead of stripping a still-valid cache suffix. The rename
+// uses hard-link + remove to atomically reserve the target and refuse a clobber.
+// Returns newPath, which equals oldPath when no rename is needed.
+func syncNoteFilename(cmd *cobra.Command, n note.Ref, updated note.Frontmatter, oldPath string, noSlug, noType bool) (string, error) {
+	id, err := strconv.Atoi(n.ID)
+	if err != nil {
+		return "", fmt.Errorf("invalid note id %q: %w", n.ID, err)
+	}
+	syncSlug := updated.Slug
+	if syncSlug == "" && !cmd.Flags().Changed("slug") && !noSlug {
+		syncSlug = n.Slug
+	}
+	syncType := updated.Type
+	if syncType == "" && !cmd.Flags().Changed("type") && !noType {
+		syncType = n.Type
+	}
+	newFilename := note.Filename(n.Date, id, syncSlug, syncType)
+	dir := filepath.Dir(oldPath)
+	newPath := filepath.Join(dir, newFilename)
+	if newPath == oldPath {
+		return oldPath, nil
+	}
+	// os.Link atomically reserves the target: returns EEXIST if it already
+	// exists, which os.Rename on Unix would silently clobber.
+	if err := os.Link(oldPath, newPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return "", fmt.Errorf("target note already exists: %s", newPath)
+		}
+		return "", fmt.Errorf("cannot link note: %w", err)
+	}
+	if err := os.Remove(oldPath); err != nil {
+		// Roll back the link so we don't leave both paths pointing to the
+		// same inode. Best-effort: a cleanup failure here isn't surfaced
+		// because the original error is more useful.
+		_ = os.Remove(newPath)
+		return "", fmt.Errorf("cannot remove old note: %w", err)
+	}
+	return newPath, nil
 }
 
 func registerUpdateFlags() {


### PR DESCRIPTION
## Summary

- `new.go`: extract `findUpsertNote(cmd, root, noteType, slug)` for the upsert lookup and `readStdinBody(cmd)` for the stdin read; `RunE` drops from ~70 to ~45 lines
- `update.go`: extract `syncNoteFilename(cmd, n, updated, oldPath, noSlug, noType)` for the hard-link rename path; `RunE` drops from ~140 to ~115 lines
- `annotate.go`: extract `invokeAnnotate(ctx, model, timeout, empty, prompt)` that wraps schema build + context deadline + `runClaude` + parse; `annotateRunE` drops from ~75 to ~55 lines

## References

- depends on #210
- closes #189