### PR TITLE
note: add Store interface, QueryOpt, and domain types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0] - 2026-04-23
+
+### Added
+
+- `note/domain.go`: `StoreEntry` and `StoreMeta` domain types (temporary names; renamed to `Entry` / `Meta` in the cleanup phase).
+- `note/storage.go`: `Store` interface, `QueryOpt` type, and filter constructors `WithType`, `WithSlug`, `WithTag`, `WithExactDate`, `WithBeforeDate`. The new `WithExactDate` coexists with the legacy `WithDate(string) ResolveOption`; it will be renamed to `WithDate` once the legacy Resolve path is removed.
+
+No implementations and no behaviour changes — this PR only establishes the contract the subsequent migration phases build on ([#230]).
+
+[#230]: https://github.com/dreikanter/notes-cli/pull/230
+
 ## [0.2.21] - 2026-04-23
 
 ### Changed

--- a/note/domain.go
+++ b/note/domain.go
@@ -1,0 +1,44 @@
+package note
+
+import "time"
+
+// StoreEntry is the single domain object that Store implementations work with.
+// It replaces the legacy Entry + Ref pair once the migration reaches Phase 14;
+// the temporary Store prefix avoids collision with the existing Entry type
+// during the transition.
+type StoreEntry struct {
+	ID   int
+	Meta StoreMeta
+	Body string
+}
+
+// StoreMeta holds the user-domain metadata for a note. It replaces the public
+// Frontmatter type once the migration reaches Phase 14; YAML serialisation
+// details live inside OSStore.
+//
+// CreatedAt maps to the YAML frontmatter "date" field and is both read from
+// and written to disk.
+//
+// UpdatedAt is derived from the file's ModTime on read and is never written
+// to YAML. OSStore.Put sets it to time.Now on every write — no file re-read
+// needed because the OS updates ModTime when the file is rewritten.
+//
+// Tags is the merged set of frontmatter "tags" and body "#hashtag" tokens;
+// OSStore performs the merge on read and consumers never distinguish between
+// the two sources.
+//
+// Extra replaces the legacy map[string]yaml.Node representation with a
+// plain-Go map[string]any. OSStore handles conversion at the serialisation
+// boundary.
+type StoreMeta struct {
+	Title       string
+	Slug        string
+	Type        string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Tags        []string
+	Aliases     []string
+	Description string
+	Public      bool
+	Extra       map[string]any
+}

--- a/note/storage.go
+++ b/note/storage.go
@@ -1,0 +1,111 @@
+package note
+
+import "time"
+
+// Store is the backend abstraction the note package exposes. Implementations
+// encapsulate the storage substrate (filesystem, in-memory, future cloud/DB)
+// so CLI commands can target a single interface.
+//
+// Error contract for lookups:
+//   - Get, Find, and Delete return a wrapped ErrNotFound when no entry
+//     matches. Callers check with errors.Is(err, note.ErrNotFound).
+//   - All returns an empty slice with a nil error when no entry matches;
+//     zero results are not considered an error.
+type Store interface {
+	// IDs returns the IDs of every entry newest-first by Meta.CreatedAt.
+	// Backends that can answer from a directory scan must not read file
+	// contents. Returns an empty slice (nil error) when the store is empty.
+	IDs() ([]int, error)
+
+	// All returns every entry matching opts, newest-first by Meta.CreatedAt.
+	// Returned entries are fully populated, including Meta.Tags merged from
+	// frontmatter tags and body hashtags. Zero matches returns an empty
+	// slice with a nil error.
+	All(opts ...QueryOpt) ([]StoreEntry, error)
+
+	// Find returns the newest entry matching opts. Returns ErrNotFound when
+	// no entry matches. Backends may terminate the scan after the first
+	// match.
+	Find(opts ...QueryOpt) (StoreEntry, error)
+
+	// Get returns the entry with the given ID, or ErrNotFound if no entry
+	// has that ID.
+	Get(id int) (StoreEntry, error)
+
+	// Put writes entry. When entry.ID is zero the store assigns a fresh ID
+	// and sets Meta.CreatedAt to time.Now if zero; otherwise Put performs a
+	// full replace of the existing entry. Meta.UpdatedAt is always set to
+	// time.Now on write. Returns the stored entry with all store-assigned
+	// fields populated.
+	Put(entry StoreEntry) (StoreEntry, error)
+
+	// Delete removes the entry with the given ID. Returns ErrNotFound when
+	// no entry has that ID.
+	Delete(id int) error
+}
+
+// query captures the filter state built up from QueryOpts. It is unexported
+// so that only Store implementations inside the note package can inspect it;
+// consumers compose filters by passing QueryOpts.
+type query struct {
+	typeSet    bool
+	noteType   string
+	slugSet    bool
+	slug       string
+	tags       []string
+	dateSet    bool
+	date       time.Time
+	beforeSet  bool
+	beforeDate time.Time
+}
+
+// QueryOpt configures Store.All and Store.Find. Opts are combinable; multiple
+// WithTag opts are AND-combined.
+type QueryOpt func(*query)
+
+// WithType matches entries whose Meta.Type equals t.
+func WithType(t string) QueryOpt {
+	return func(q *query) {
+		q.typeSet = true
+		q.noteType = t
+	}
+}
+
+// WithSlug matches entries whose Meta.Slug equals s. When multiple entries
+// share a slug the newest match is returned first.
+func WithSlug(s string) QueryOpt {
+	return func(q *query) {
+		q.slugSet = true
+		q.slug = s
+	}
+}
+
+// WithTag matches entries whose Meta.Tags contains t (case-insensitive).
+// Multiple WithTag opts combine with AND semantics.
+func WithTag(t string) QueryOpt {
+	return func(q *query) {
+		q.tags = append(q.tags, t)
+	}
+}
+
+// WithExactDate matches entries whose Meta.CreatedAt falls on the same
+// calendar day as d (comparison is at day precision, in d's location).
+//
+// The temporary name avoids a collision with the existing ResolveOption
+// WithDate(string) consumed by Index.Resolve. WithExactDate will be renamed
+// to WithDate in Phase 14 once the legacy Resolve path is removed.
+func WithExactDate(d time.Time) QueryOpt {
+	return func(q *query) {
+		q.dateSet = true
+		q.date = d
+	}
+}
+
+// WithBeforeDate matches entries whose Meta.CreatedAt falls on a calendar
+// day strictly before d (day precision, in d's location).
+func WithBeforeDate(d time.Time) QueryOpt {
+	return func(q *query) {
+		q.beforeSet = true
+		q.beforeDate = d
+	}
+}

--- a/note/store.go
+++ b/note/store.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 )
 
-// ErrNotFound is returned (wrapped) from resolveRelPath when a path-like
-// query cannot be followed under the store root. Callers that wrap a miss
-// from Index.Resolve into an error should reuse this sentinel so users can
-// match with errors.Is:
+// ErrNotFound is the package-wide "entry not found" sentinel. It is returned
+// (wrapped) by Store.Get, Store.Find, and Store.Delete when no entry matches,
+// and by resolveRelPath when a path-like query cannot be followed under the
+// store root. Callers match with errors.Is:
 //
 //	if errors.Is(err, note.ErrNotFound) { … }
 //


### PR DESCRIPTION
## Summary

Phase 1 of #215. Introduces the foundational types the rest of the migration builds on — no implementations, no behaviour changes.

- `note/domain.go`: `StoreEntry` and `StoreMeta` (temporary names; renamed to `Entry` / `Meta` in Phase 14 once legacy types are gone).
- `note/storage.go`: the `Store` interface, the internal `query` struct, and the `QueryOpt` constructors (`WithType`, `WithSlug`, `WithTag`, `WithExactDate`, `WithBeforeDate`).
- `note/store.go`: reuses the existing `ErrNotFound` sentinel (message unchanged); docstring broadened to cover the new `Store.Get` / `Store.Find` / `Store.Delete` contract.

`WithDate` collision — Option 1 chosen: the new `QueryOpt` is named `WithExactDate` to coexist with the existing `WithDate(string) ResolveOption` used by `Index.Resolve`. It will be renamed to `WithDate` in Phase 14 when the legacy `ResolveOption` is removed.

## References

- relates to #215
- closes #216
