### PR TITLE
note: implement MemStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1] - 2026-04-23
+
+### Added
+
+- `note/mem_store.go`: `MemStore` — in-memory `Store` backed by `map[int]StoreEntry` with a `sync.RWMutex`. Test-only; validates the `Store` interface shape before `OSStore` is built. `IDs`, `All`, and `Find` sort newest-first by `Meta.CreatedAt` with a deterministic higher-ID tie-break. `Put` assigns IDs as `max(existing) + 1`, sets `Meta.CreatedAt` to now when zero, and always sets `Meta.UpdatedAt`. Includes a compile-time `var _ Store = (*MemStore)(nil)` assertion ([#231]).
+
+[#231]: https://github.com/dreikanter/notes-cli/pull/231
+
 ## [0.3.0] - 2026-04-23
 
 ### Added

--- a/note/mem_store.go
+++ b/note/mem_store.go
@@ -1,0 +1,215 @@
+package note
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// MemStore is an in-memory Store backed by map[int]StoreEntry with an
+// RWMutex. It is never user-facing — it exists to validate the Store
+// interface shape and to serve as the test double for command tests.
+//
+// MemStore skips the YAML and body-hashtag machinery that OSStore performs
+// on read: Meta.Tags is exactly whatever the caller stored. Tag matching is
+// case-insensitive.
+type MemStore struct {
+	mu      sync.RWMutex
+	entries map[int]StoreEntry
+}
+
+var _ Store = (*MemStore)(nil)
+
+// NewMemStore returns an empty MemStore.
+func NewMemStore() *MemStore {
+	return &MemStore{entries: make(map[int]StoreEntry)}
+}
+
+// IDs returns every stored ID newest-first by Meta.CreatedAt. Ties within
+// the same timestamp break by higher ID first so the order is total and
+// deterministic.
+func (s *MemStore) IDs() ([]int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := make([]int, 0, len(s.entries))
+	for id := range s.entries {
+		ids = append(ids, id)
+	}
+	s.sortIDsLocked(ids)
+	return ids, nil
+}
+
+// All returns every entry matching opts, newest-first by Meta.CreatedAt.
+// See Store.All for the error contract: zero matches yield an empty slice
+// and a nil error.
+func (s *MemStore) All(opts ...QueryOpt) ([]StoreEntry, error) {
+	q := buildQuery(opts)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	matches := s.matchLocked(q)
+	s.sortEntriesByRecency(matches)
+	return matches, nil
+}
+
+// Find returns the newest entry matching opts, or ErrNotFound when no entry
+// matches.
+func (s *MemStore) Find(opts ...QueryOpt) (StoreEntry, error) {
+	q := buildQuery(opts)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	matches := s.matchLocked(q)
+	if len(matches) == 0 {
+		return StoreEntry{}, fmt.Errorf("%w", ErrNotFound)
+	}
+	s.sortEntriesByRecency(matches)
+	return matches[0], nil
+}
+
+// Get returns the entry with the given ID, or ErrNotFound.
+func (s *MemStore) Get(id int) (StoreEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	e, ok := s.entries[id]
+	if !ok {
+		return StoreEntry{}, fmt.Errorf("%w: %d", ErrNotFound, id)
+	}
+	return e, nil
+}
+
+// Put stores entry. When entry.ID is zero a new ID is assigned as
+// max(existing IDs) + 1 (1 for an empty store); otherwise the existing
+// entry is replaced. Meta.CreatedAt is set to time.Now when zero, and
+// Meta.UpdatedAt is always set to time.Now.
+func (s *MemStore) Put(entry StoreEntry) (StoreEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry.ID == 0 {
+		entry.ID = s.nextIDLocked()
+	}
+	now := time.Now()
+	if entry.Meta.CreatedAt.IsZero() {
+		entry.Meta.CreatedAt = now
+	}
+	entry.Meta.UpdatedAt = now
+	s.entries[entry.ID] = entry
+	return entry, nil
+}
+
+// Delete removes the entry with the given ID, or returns ErrNotFound.
+func (s *MemStore) Delete(id int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.entries[id]; !ok {
+		return fmt.Errorf("%w: %d", ErrNotFound, id)
+	}
+	delete(s.entries, id)
+	return nil
+}
+
+// matchLocked returns every entry that matches q. Caller holds s.mu for
+// read (RLock or Lock).
+func (s *MemStore) matchLocked(q query) []StoreEntry {
+	out := make([]StoreEntry, 0, len(s.entries))
+	for _, e := range s.entries {
+		if matches(e, q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// nextIDLocked returns max(existing IDs) + 1, or 1 when empty. Caller holds
+// s.mu for write.
+func (s *MemStore) nextIDLocked() int {
+	max := 0
+	for id := range s.entries {
+		if id > max {
+			max = id
+		}
+	}
+	return max + 1
+}
+
+// sortIDsLocked sorts ids newest-first by the entries' CreatedAt, tie-breaking
+// on higher ID first. Caller holds s.mu for read.
+func (s *MemStore) sortIDsLocked(ids []int) {
+	sort.Slice(ids, func(i, j int) bool {
+		ei, ej := s.entries[ids[i]], s.entries[ids[j]]
+		if !ei.Meta.CreatedAt.Equal(ej.Meta.CreatedAt) {
+			return ei.Meta.CreatedAt.After(ej.Meta.CreatedAt)
+		}
+		return ids[i] > ids[j]
+	})
+}
+
+// sortEntriesByRecency sorts entries newest-first by CreatedAt with the same
+// tie-break as sortIDsLocked.
+func (s *MemStore) sortEntriesByRecency(entries []StoreEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if !entries[i].Meta.CreatedAt.Equal(entries[j].Meta.CreatedAt) {
+			return entries[i].Meta.CreatedAt.After(entries[j].Meta.CreatedAt)
+		}
+		return entries[i].ID > entries[j].ID
+	})
+}
+
+// buildQuery applies opts to a fresh query value.
+func buildQuery(opts []QueryOpt) query {
+	var q query
+	for _, opt := range opts {
+		opt(&q)
+	}
+	return q
+}
+
+// matches reports whether entry satisfies every filter in q. Tag comparison
+// is case-insensitive; date comparisons are at day precision in the filter's
+// location.
+func matches(entry StoreEntry, q query) bool {
+	if q.typeSet && entry.Meta.Type != q.noteType {
+		return false
+	}
+	if q.slugSet && entry.Meta.Slug != q.slug {
+		return false
+	}
+	if len(q.tags) > 0 && !hasAllTags(entry.Meta.Tags, q.tags) {
+		return false
+	}
+	if q.dateSet && !sameDay(entry.Meta.CreatedAt, q.date) {
+		return false
+	}
+	if q.beforeSet && !beforeDay(entry.Meta.CreatedAt, q.beforeDate) {
+		return false
+	}
+	return true
+}
+
+// sameDay reports whether a and b fall on the same calendar day, using b's
+// location for the comparison.
+func sameDay(a, b time.Time) bool {
+	ay, am, ad := a.In(b.Location()).Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// beforeDay reports whether a's calendar day is strictly earlier than b's,
+// using b's location.
+func beforeDay(a, b time.Time) bool {
+	aDay := startOfDay(a.In(b.Location()))
+	bDay := startOfDay(b)
+	return aDay.Before(bDay)
+}
+
+func startOfDay(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
+}

--- a/note/mem_store_test.go
+++ b/note/mem_store_test.go
@@ -1,0 +1,337 @@
+package note
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemStore_IDsEmpty(t *testing.T) {
+	s := NewMemStore()
+	ids, err := s.IDs()
+	if err != nil {
+		t.Fatalf("IDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("IDs on empty store = %v, want empty", ids)
+	}
+}
+
+func TestMemStore_IDsOrderNewestFirstThenIDDesc(t *testing.T) {
+	s := NewMemStore()
+	day1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: day1}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{CreatedAt: day1}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{CreatedAt: day2}})
+
+	ids, err := s.IDs()
+	if err != nil {
+		t.Fatalf("IDs: %v", err)
+	}
+	want := []int{3, 2, 1}
+	if !sliceEqual(ids, want) {
+		t.Fatalf("IDs = %v, want %v", ids, want)
+	}
+}
+
+func TestMemStore_AllNoOpts(t *testing.T) {
+	s := NewMemStore()
+	for i := 1; i <= 3; i++ {
+		mustPut(t, s, StoreEntry{ID: i, Meta: StoreMeta{CreatedAt: time.Date(2026, 1, i, 0, 0, 0, 0, time.UTC)}})
+	}
+	entries, err := s.All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("All len = %d, want 3", len(entries))
+	}
+	if entries[0].ID != 3 || entries[2].ID != 1 {
+		t.Fatalf("All order = %v, want [3 2 1]", entryIDs(entries))
+	}
+}
+
+func TestMemStore_AllFilterByType(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Type: "todo", CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{Type: "note", CreatedAt: day(2026, 1, 2)}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{Type: "todo", CreatedAt: day(2026, 1, 3)}})
+
+	got, err := s.All(WithType("todo"))
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 1 {
+		t.Fatalf("All WithType(todo) = %v, want [3 1]", entryIDs(got))
+	}
+}
+
+func TestMemStore_AllMultipleTagsAreAND(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Tags: []string{"a"}, CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{Tags: []string{"a", "b"}, CreatedAt: day(2026, 1, 2)}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{Tags: []string{"a", "b", "c"}, CreatedAt: day(2026, 1, 3)}})
+
+	got, err := s.All(WithTag("a"), WithTag("b"))
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 2 {
+		t.Fatalf("All WithTag(a)+WithTag(b) = %v, want [3 2]", entryIDs(got))
+	}
+}
+
+func TestMemStore_TagMatchCaseInsensitive(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Tags: []string{"Alpha"}, CreatedAt: day(2026, 1, 1)}})
+	got, err := s.All(WithTag("alpha"))
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("All WithTag(alpha) len = %d, want 1", len(got))
+	}
+}
+
+func TestMemStore_AllNoMatchEmptySliceNotError(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Type: "note", CreatedAt: day(2026, 1, 1)}})
+
+	got, err := s.All(WithType("todo"))
+	if err != nil {
+		t.Fatalf("All unexpected err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("All no-match len = %d, want 0", len(got))
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("All no-match should not wrap ErrNotFound")
+	}
+}
+
+func TestMemStore_AllFilterByExactDate(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{CreatedAt: time.Date(2026, 1, 1, 23, 59, 0, 0, time.UTC)}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{CreatedAt: day(2026, 1, 2)}})
+
+	got, err := s.All(WithExactDate(day(2026, 1, 1)))
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("All WithExactDate len = %d, want 2", len(got))
+	}
+}
+
+func TestMemStore_AllFilterByBeforeDate(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{CreatedAt: day(2026, 1, 2)}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{CreatedAt: day(2026, 1, 3)}})
+
+	got, err := s.All(WithBeforeDate(day(2026, 1, 3)))
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != 2 || got[1].ID != 1 {
+		t.Fatalf("All WithBeforeDate = %v, want [2 1]", entryIDs(got))
+	}
+}
+
+func TestMemStore_FindReturnsNewest(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Type: "todo", CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 2, Meta: StoreMeta{Type: "todo", CreatedAt: day(2026, 1, 2)}})
+
+	got, err := s.Find(WithType("todo"))
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.ID != 2 {
+		t.Fatalf("Find ID = %d, want 2", got.ID)
+	}
+}
+
+func TestMemStore_FindNoMatchErrNotFound(t *testing.T) {
+	s := NewMemStore()
+	_, err := s.Find(WithType("todo"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Find no-match err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemStore_Get(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Title: "one", CreatedAt: day(2026, 1, 1)}})
+
+	got, err := s.Get(1)
+	if err != nil {
+		t.Fatalf("Get hit: %v", err)
+	}
+	if got.Meta.Title != "one" {
+		t.Fatalf("Get title = %q, want one", got.Meta.Title)
+	}
+
+	_, err = s.Get(99)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get miss err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemStore_PutAssignsIDStartingAt1(t *testing.T) {
+	s := NewMemStore()
+	e, err := s.Put(StoreEntry{Body: "hello"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if e.ID != 1 {
+		t.Fatalf("first Put ID = %d, want 1", e.ID)
+	}
+}
+
+func TestMemStore_PutAssignsMaxPlusOne(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 5, Meta: StoreMeta{CreatedAt: day(2026, 1, 1)}})
+	mustPut(t, s, StoreEntry{ID: 3, Meta: StoreMeta{CreatedAt: day(2026, 1, 1)}})
+
+	e, err := s.Put(StoreEntry{Body: "new"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if e.ID != 6 {
+		t.Fatalf("Put new ID = %d, want 6", e.ID)
+	}
+}
+
+func TestMemStore_PutExistingIDReplaces(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{Title: "old"}, Body: "old body"})
+
+	e, err := s.Put(StoreEntry{ID: 1, Meta: StoreMeta{Title: "new"}, Body: "new body"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if e.Meta.Title != "new" || e.Body != "new body" {
+		t.Fatalf("Put replace = %+v, want title=new body=new body", e)
+	}
+	got, _ := s.Get(1)
+	if got.Meta.Title != "new" {
+		t.Fatalf("Get after replace title = %q, want new", got.Meta.Title)
+	}
+}
+
+func TestMemStore_PutZeroCreatedAtSetsToNow(t *testing.T) {
+	s := NewMemStore()
+	before := time.Now()
+	e, err := s.Put(StoreEntry{Body: "hi"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	after := time.Now()
+
+	if e.Meta.CreatedAt.Before(before) || e.Meta.CreatedAt.After(after) {
+		t.Fatalf("CreatedAt = %v, want between %v and %v", e.Meta.CreatedAt, before, after)
+	}
+}
+
+func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {
+	s := NewMemStore()
+	originalCreated := day(2026, 1, 1)
+	e, err := s.Put(StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: originalCreated}})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !e.Meta.CreatedAt.Equal(originalCreated) {
+		t.Fatalf("Put changed provided CreatedAt: got %v", e.Meta.CreatedAt)
+	}
+	if e.Meta.UpdatedAt.IsZero() {
+		t.Fatalf("Put did not set UpdatedAt")
+	}
+
+	time.Sleep(time.Millisecond)
+	e2, err := s.Put(StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: originalCreated}})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if !e2.Meta.UpdatedAt.After(e.Meta.UpdatedAt) {
+		t.Fatalf("UpdatedAt did not advance: first=%v second=%v", e.Meta.UpdatedAt, e2.Meta.UpdatedAt)
+	}
+}
+
+func TestMemStore_Delete(t *testing.T) {
+	s := NewMemStore()
+	mustPut(t, s, StoreEntry{ID: 1, Meta: StoreMeta{CreatedAt: day(2026, 1, 1)}})
+
+	if err := s.Delete(1); err != nil {
+		t.Fatalf("Delete hit: %v", err)
+	}
+	if _, err := s.Get(1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after Delete = %v, want ErrNotFound", err)
+	}
+	if err := s.Delete(1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete miss err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemStore_ConcurrentReads(t *testing.T) {
+	s := NewMemStore()
+	for i := 1; i <= 20; i++ {
+		mustPut(t, s, StoreEntry{ID: i, Meta: StoreMeta{CreatedAt: day(2026, 1, i%28+1)}})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if _, err := s.All(); err != nil {
+					t.Errorf("All: %v", err)
+					return
+				}
+				if _, err := s.IDs(); err != nil {
+					t.Errorf("IDs: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func mustPut(t *testing.T, s *MemStore, e StoreEntry) StoreEntry {
+	t.Helper()
+	out, err := s.Put(e)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return out
+}
+
+func day(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func entryIDs(entries []StoreEntry) []int {
+	out := make([]int, len(entries))
+	for i, e := range entries {
+		out[i] = e.ID
+	}
+	return out
+}
+
+func sliceEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Phase 2 of #215. Adds `MemStore`: an in-memory `Store` implementation backed by `map[int]StoreEntry` with a `sync.RWMutex`. Never user-facing — it validates the `Store` interface shape and serves as the test double for subsequent command-migration phases.

- ID generation via `max(existing) + 1`, starting at 1 for an empty store.
- `IDs` / `All` / `Find` sort newest-first by `Meta.CreatedAt`, tie-break higher ID first (deterministic total order).
- Compile-time assertion: `var _ Store = (*MemStore)(nil)`.
- Tag comparison is case-insensitive (reuses the existing `hasAllTags` helper).
- Date filters (`WithExactDate`, `WithBeforeDate`) compare at day precision in the filter's location.
- `Put` sets `Meta.CreatedAt` to `time.Now` when zero and always sets `Meta.UpdatedAt`.

Tests in `note/mem_store_test.go` cover the scenarios enumerated in #217, including a race-safe concurrent-reads check.

## References

- relates to #215
- closes #217
