### PR TITLE
note: implement OSStore and wire store into CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.2] - 2026-04-24
+
+### Added
+
+- `note/os_store.go`: `OSStore` — the filesystem-backed `Store` implementation over the existing `YYYY/MM/YYYYMMDD_id_slug.md` layout. Reuses `ParseFilename`, `Filename`, `DirPath`, `WriteAtomic`, `NextID`, `ExtractHashtags`, `ParseNote`, and `FormatNote`. Filename scan sorts by `(date DESC, id DESC)` using the integer ID so `_11_` sorts newer than `_9_`. `Put` handles atomic rename on slug/date changes.
+- `internal/cli/root.go`: `notesStore()` helper constructs an `*note.OSStore` from the resolved `--path` / `$NOTES_PATH` root. Threaded in now; individual commands adopt it in later phases ([#232]).
+
+[#232]: https://github.com/dreikanter/notes-cli/pull/232
+
 ## [0.3.1] - 2026-04-23
 
 ### Added

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 
+	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
@@ -70,3 +71,23 @@ func notesRoot() (string, error) {
 
 	return p, nil
 }
+
+// notesStore returns the Store instance the CLI uses for note-package
+// operations. It resolves the root path the same way notesRoot does — flag
+// first, then $NOTES_PATH, then error — so commands can replace their
+// direct filesystem calls with Store calls without touching path-resolution
+// code.
+//
+// Phase 3 wires this helper in; individual commands adopt it in later
+// phases.
+func notesStore() (*note.OSStore, error) {
+	root, err := notesRoot()
+	if err != nil {
+		return nil, err
+	}
+	return note.NewOSStore(root), nil
+}
+
+// Keep notesStore in reach of the unused linter until Phase 4 wires the
+// first command through it.
+var _ = notesStore

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -1,0 +1,508 @@
+package note
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
+)
+
+// dateLayout is the filename date format — 8 digits, YYYYMMDD.
+const dateLayout = "20060102"
+
+// OSStore is the filesystem-backed Store. It wraps the existing
+// root/YYYY/MM/YYYYMMDD_id_slug.md layout and reuses the package's existing
+// filename, frontmatter, and atomic-write helpers.
+//
+// The Store interface never exposes filesystem paths. Callers that need the
+// absolute path of an entry (e.g. the resolve command) type-assert to
+// *OSStore and call AbsPath.
+type OSStore struct {
+	root string
+}
+
+var _ Store = (*OSStore)(nil)
+
+// NewOSStore returns an OSStore rooted at root. The directory must already
+// exist; use os.Stat at the caller if validation is required.
+func NewOSStore(root string) *OSStore {
+	return &OSStore{root: root}
+}
+
+// Root returns the absolute path the store is rooted at.
+func (s *OSStore) Root() string { return s.root }
+
+// fileRef is the filename-derived metadata for a single note. It is used
+// internally to avoid re-parsing filenames repeatedly.
+type fileRef struct {
+	id       int
+	date     string // YYYYMMDD
+	slug     string
+	noteType string // from filename dot-suffix; may be overridden by frontmatter
+	relPath  string // path relative to root
+}
+
+// absPath returns the absolute filesystem path of r under root.
+func (r fileRef) absPath(root string) string { return filepath.Join(root, r.relPath) }
+
+// sortByRecency sorts refs newest-first by (date DESC, id DESC). Pure
+// lexicographic ordering on the filename is not reliable because "_9_" sorts
+// after "_10_" while ID 10 is newer.
+func sortByRecency(refs []fileRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].date != refs[j].date {
+			return refs[i].date > refs[j].date
+		}
+		return refs[i].id > refs[j].id
+	})
+}
+
+// scanFileRefs walks the YYYY/MM subtree under root and returns every note
+// filename that parses successfully. Unreadable subdirectories are skipped;
+// they do not abort the scan.
+func (s *OSStore) scanFileRefs() ([]fileRef, error) {
+	var out []fileRef
+
+	years, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, err
+	}
+	for _, y := range years {
+		if !y.IsDir() || !IsDigits(y.Name()) {
+			continue
+		}
+		months, err := os.ReadDir(filepath.Join(s.root, y.Name()))
+		if err != nil {
+			continue
+		}
+		for _, m := range months {
+			if !m.IsDir() || len(m.Name()) != 2 || !IsDigits(m.Name()) {
+				continue
+			}
+			monthDir := filepath.Join(s.root, y.Name(), m.Name())
+			files, err := os.ReadDir(monthDir)
+			if err != nil {
+				continue
+			}
+			for _, f := range files {
+				if f.IsDir() || filepath.Ext(f.Name()) != ".md" {
+					continue
+				}
+				base := strings.TrimSuffix(f.Name(), ".md")
+				ref, err := ParseFilename(base)
+				if err != nil {
+					continue
+				}
+				id, err := strconv.Atoi(ref.ID)
+				if err != nil {
+					continue
+				}
+				out = append(out, fileRef{
+					id:       id,
+					date:     ref.Date,
+					slug:     ref.Slug,
+					noteType: ref.Type,
+					relPath:  filepath.Join(y.Name(), m.Name(), f.Name()),
+				})
+			}
+		}
+	}
+	sortByRecency(out)
+	return out, nil
+}
+
+// IDs returns every stored ID newest-first by (date DESC, id DESC) using
+// only the filename layout — no file reads.
+func (s *OSStore) IDs() ([]int, error) {
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, len(refs))
+	for i, r := range refs {
+		ids[i] = r.id
+	}
+	return ids, nil
+}
+
+// refMatchesFilename evaluates the subset of q that can be answered from the
+// filename alone: WithType, WithSlug, WithExactDate, WithBeforeDate.
+// Body-dependent filters (WithTag) are always passed as matching at this
+// layer; readEntry decides.
+func refMatchesFilename(r fileRef, q query) bool {
+	if q.typeSet && r.noteType != q.noteType {
+		return false
+	}
+	if q.slugSet && r.slug != q.slug {
+		return false
+	}
+	if q.dateSet {
+		if r.date != q.date.Format(dateLayout) {
+			return false
+		}
+	}
+	if q.beforeSet {
+		if !(r.date < q.beforeDate.Format(dateLayout)) {
+			return false
+		}
+	}
+	return true
+}
+
+// entryMatchesTags reports whether entry satisfies the WithTag filters in q.
+// Called after readEntry so Meta.Tags has body hashtags merged in.
+func entryMatchesTags(entry StoreEntry, q query) bool {
+	if len(q.tags) == 0 {
+		return true
+	}
+	return hasAllTags(entry.Meta.Tags, q.tags)
+}
+
+// All returns every entry matching opts, newest-first. Type/slug/date filters
+// are evaluated from filenames; tag filters require reading file bodies.
+func (s *OSStore) All(opts ...QueryOpt) ([]StoreEntry, error) {
+	return s.collect(opts, false)
+}
+
+// Find returns the newest entry matching opts, or ErrNotFound.
+func (s *OSStore) Find(opts ...QueryOpt) (StoreEntry, error) {
+	entries, err := s.collect(opts, true)
+	if err != nil {
+		return StoreEntry{}, err
+	}
+	if len(entries) == 0 {
+		return StoreEntry{}, fmt.Errorf("%w", ErrNotFound)
+	}
+	return entries[0], nil
+}
+
+// collect is the shared read path for All and Find. When firstOnly is true
+// it stops at the first body-matched entry; refs are already sorted newest-
+// first so the first match is also the newest.
+func (s *OSStore) collect(opts []QueryOpt, firstOnly bool) ([]StoreEntry, error) {
+	q := buildQuery(opts)
+
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := refs[:0:0]
+	for _, r := range refs {
+		if refMatchesFilename(r, q) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	if firstOnly {
+		for _, r := range filtered {
+			entry, err := s.readEntry(r)
+			if err != nil {
+				return nil, err
+			}
+			if entryMatchesTags(entry, q) {
+				return []StoreEntry{entry}, nil
+			}
+		}
+		return nil, nil
+	}
+
+	entries, err := s.readConcurrent(filtered)
+	if err != nil {
+		return nil, err
+	}
+
+	out := entries[:0]
+	for _, e := range entries {
+		if entryMatchesTags(e, q) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// readConcurrent reads each fileRef via a worker pool and returns entries
+// in the same order as refs.
+func (s *OSStore) readConcurrent(refs []fileRef) ([]StoreEntry, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	workers := runtime.NumCPU()
+	if workers > len(refs) {
+		workers = len(refs)
+	}
+
+	entries := make([]StoreEntry, len(refs))
+	g, ctx := errgroup.WithContext(context.Background())
+	jobs := make(chan int)
+
+	g.Go(func() error {
+		defer close(jobs)
+		for i := range refs {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case jobs <- i:
+			}
+		}
+		return nil
+	})
+
+	for w := 0; w < workers; w++ {
+		g.Go(func() error {
+			for i := range jobs {
+				entry, err := s.readEntry(refs[i])
+				if err != nil {
+					return err
+				}
+				entries[i] = entry
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// readEntry loads a single file and converts it to a StoreEntry. It populates
+// Meta.Tags with the merged frontmatter+body-hashtag set and Meta.UpdatedAt
+// from the file's ModTime.
+func (s *OSStore) readEntry(r fileRef) (StoreEntry, error) {
+	path := r.absPath(s.root)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return StoreEntry{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return StoreEntry{}, err
+	}
+	fm, body, err := ParseNote(data)
+	if err != nil {
+		return StoreEntry{}, fmt.Errorf("%s: %w", path, err)
+	}
+	meta := frontmatterToMeta(fm, r, info.ModTime(), body)
+	return StoreEntry{
+		ID:   r.id,
+		Meta: meta,
+		Body: string(body),
+	}, nil
+}
+
+// Get returns the entry with the given ID.
+func (s *OSStore) Get(id int) (StoreEntry, error) {
+	r, err := s.findFileRef(id)
+	if err != nil {
+		return StoreEntry{}, err
+	}
+	return s.readEntry(r)
+}
+
+// Delete removes the file for the given ID.
+func (s *OSStore) Delete(id int) error {
+	r, err := s.findFileRef(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(r.absPath(s.root)); err != nil {
+		return fmt.Errorf("cannot remove note: %w", err)
+	}
+	return nil
+}
+
+// findFileRef scans for a file whose parsed ID matches id.
+func (s *OSStore) findFileRef(id int) (fileRef, error) {
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return fileRef{}, err
+	}
+	for _, r := range refs {
+		if r.id == id {
+			return r, nil
+		}
+	}
+	return fileRef{}, fmt.Errorf("%w: %d", ErrNotFound, id)
+}
+
+// Put writes entry. See Store.Put for the full contract. When entry.ID is
+// zero a new ID is allocated via NextID (id.json + flock) and CreatedAt is
+// defaulted to time.Now if zero. On updates with a changed slug or date the
+// file is renamed atomically.
+func (s *OSStore) Put(entry StoreEntry) (StoreEntry, error) {
+	now := time.Now()
+
+	if entry.ID == 0 {
+		id, err := NextID(s.root)
+		if err != nil {
+			return StoreEntry{}, err
+		}
+		entry.ID = id
+		if entry.Meta.CreatedAt.IsZero() {
+			entry.Meta.CreatedAt = now
+		}
+	}
+
+	if entry.Meta.CreatedAt.IsZero() {
+		return StoreEntry{}, fmt.Errorf("note %d: CreatedAt is zero", entry.ID)
+	}
+
+	var oldPath string
+	if prev, err := s.findFileRef(entry.ID); err == nil {
+		oldPath = prev.absPath(s.root)
+	} else if !errors.Is(err, ErrNotFound) {
+		return StoreEntry{}, err
+	}
+
+	newRelPath, newAbsPath := s.pathFor(entry)
+	dirAbs := filepath.Dir(newAbsPath)
+	if err := os.MkdirAll(dirAbs, StoreDirMode(s.root)); err != nil {
+		return StoreEntry{}, fmt.Errorf("cannot create %s: %w", filepath.Dir(newRelPath), err)
+	}
+
+	fm := metaToFrontmatter(entry.Meta)
+	data, err := FormatNote(fm, []byte(entry.Body))
+	if err != nil {
+		return StoreEntry{}, err
+	}
+
+	if oldPath != "" && oldPath != newAbsPath {
+		if err := os.Rename(oldPath, newAbsPath); err != nil {
+			return StoreEntry{}, fmt.Errorf("cannot rename note: %w", err)
+		}
+	}
+
+	if err := WriteAtomic(newAbsPath, data); err != nil {
+		return StoreEntry{}, err
+	}
+
+	entry.Meta.UpdatedAt = now
+	return entry, nil
+}
+
+// AbsPath returns the absolute path the store would use for entry given its
+// current Meta.CreatedAt, ID, and Meta.Slug. It derives the path purely from
+// the entry's fields — no I/O.
+func (s *OSStore) AbsPath(entry StoreEntry) string {
+	_, abs := s.pathFor(entry)
+	return abs
+}
+
+// pathFor returns the rel/abs path the filename layout produces for entry.
+func (s *OSStore) pathFor(entry StoreEntry) (rel, abs string) {
+	date := entry.Meta.CreatedAt.Format(dateLayout)
+	name := Filename(date, entry.ID, entry.Meta.Slug, entry.Meta.Type)
+	dir := DirPath(s.root, date)
+	abs = filepath.Join(dir, name)
+	rel, _ = filepath.Rel(s.root, abs)
+	return rel, abs
+}
+
+// frontmatterToMeta converts the on-disk Frontmatter into the public
+// StoreMeta. Body hashtags are merged into Meta.Tags; Meta.UpdatedAt is set
+// from the file ModTime; Meta.CreatedAt falls back to the filename date when
+// the frontmatter has no date.
+func frontmatterToMeta(fm Frontmatter, r fileRef, modTime time.Time, body []byte) StoreMeta {
+	created := fm.Date
+	if created.IsZero() {
+		if t, err := time.Parse(dateLayout, r.date); err == nil {
+			created = t
+		}
+	}
+	noteType := fm.Type
+	if noteType == "" {
+		noteType = r.noteType
+	}
+	slug := fm.Slug
+	if slug == "" {
+		slug = r.slug
+	}
+
+	return StoreMeta{
+		Title:       fm.Title,
+		Slug:        slug,
+		Type:        noteType,
+		CreatedAt:   created,
+		UpdatedAt:   modTime,
+		Tags:        computeMergedTags(fm.Tags, normalizeHashtags(ExtractHashtags(body))),
+		Aliases:     append([]string(nil), fm.Aliases...),
+		Description: fm.Description,
+		Public:      fm.Public,
+		Extra:       extraFromYAML(fm.Extra),
+	}
+}
+
+// metaToFrontmatter converts StoreMeta into the on-disk Frontmatter. Body
+// hashtags are *not* stripped from Meta.Tags — they round-trip through the
+// frontmatter alongside the originals. UpdatedAt is never written.
+func metaToFrontmatter(m StoreMeta) Frontmatter {
+	var aliases []string
+	if len(m.Aliases) > 0 {
+		aliases = append([]string(nil), m.Aliases...)
+	}
+	var tags []string
+	if len(m.Tags) > 0 {
+		tags = append([]string(nil), m.Tags...)
+	}
+	return Frontmatter{
+		Title:       m.Title,
+		Slug:        m.Slug,
+		Type:        m.Type,
+		Date:        m.CreatedAt,
+		Tags:        tags,
+		Aliases:     aliases,
+		Description: m.Description,
+		Public:      m.Public,
+		Extra:       extraToYAML(m.Extra),
+	}
+}
+
+// extraFromYAML converts the internal yaml.Node map into the public
+// map[string]any used by StoreMeta.
+func extraFromYAML(in map[string]yaml.Node) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, n := range in {
+		var v any
+		if err := n.Decode(&v); err != nil {
+			out[k] = n
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// extraToYAML converts a map[string]any back into the yaml.Node
+// representation the Frontmatter type expects on write.
+func extraToYAML(in map[string]any) map[string]yaml.Node {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]yaml.Node, len(in))
+	for k, v := range in {
+		if n, ok := v.(yaml.Node); ok {
+			out[k] = n
+			continue
+		}
+		var node yaml.Node
+		if err := node.Encode(v); err != nil {
+			continue
+		}
+		out[k] = node
+	}
+	return out
+}

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -1,0 +1,297 @@
+package note
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newOSTestStore returns an OSStore rooted at a fresh t.TempDir with an
+// initialised id.json (last_id: 0, so NextID starts at 1).
+func newOSTestStore(t *testing.T) *OSStore {
+	t.Helper()
+	dir := t.TempDir()
+	data, _ := json.Marshal(map[string]int{"last_id": 0})
+	if err := os.WriteFile(filepath.Join(dir, "id.json"), data, 0o644); err != nil {
+		t.Fatalf("cannot write id.json: %v", err)
+	}
+	return NewOSStore(dir)
+}
+
+func TestOSStore_SatisfiesInterface(t *testing.T) {
+	var _ Store = (*OSStore)(nil)
+}
+
+func TestOSStore_IDsEmpty(t *testing.T) {
+	s := newOSTestStore(t)
+	ids, err := s.IDs()
+	if err != nil {
+		t.Fatalf("IDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("IDs on empty store = %v, want empty", ids)
+	}
+}
+
+func TestOSStore_IDsOrderIntegerIDNotLexicographic(t *testing.T) {
+	s := newOSTestStore(t)
+
+	today := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// 11 entries on the same day → IDs 1..11. Lexicographic order would
+	// sort 9 before 10/11; the integer-ID sort must put 11 first.
+	for i := 0; i < 11; i++ {
+		_, err := s.Put(StoreEntry{Meta: StoreMeta{Title: "", CreatedAt: today}, Body: "x"})
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	ids, err := s.IDs()
+	if err != nil {
+		t.Fatalf("IDs: %v", err)
+	}
+	if len(ids) != 11 {
+		t.Fatalf("IDs len = %d, want 11", len(ids))
+	}
+	if ids[0] != 11 || ids[1] != 10 || ids[2] != 9 {
+		t.Fatalf("IDs order = %v, want [11 10 9 ...]", ids)
+	}
+}
+
+func TestOSStore_PutNewCreatesFile(t *testing.T) {
+	s := newOSTestStore(t)
+
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	entry, err := s.Put(StoreEntry{
+		Meta: StoreMeta{Title: "hello", Slug: "hi", CreatedAt: created},
+		Body: "body text\n",
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if entry.ID != 1 {
+		t.Fatalf("assigned ID = %d, want 1", entry.ID)
+	}
+	if entry.Meta.UpdatedAt.IsZero() {
+		t.Fatal("Put did not set UpdatedAt")
+	}
+
+	expected := filepath.Join(s.Root(), "2026", "01", "20260115_1_hi.md")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected file at %s: %v", expected, err)
+	}
+}
+
+func TestOSStore_PutSlugChangeRenames(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+
+	entry, err := s.Put(StoreEntry{Meta: StoreMeta{Slug: "old", CreatedAt: created}, Body: "b"})
+	if err != nil {
+		t.Fatalf("Put new: %v", err)
+	}
+	oldPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_old.md")
+
+	entry.Meta.Slug = "new"
+	if _, err := s.Put(entry); err != nil {
+		t.Fatalf("Put rename: %v", err)
+	}
+	newPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_new.md")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("new file missing: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old file should be gone, got err=%v", err)
+	}
+}
+
+func TestOSStore_PutDateChangeMovesToNewSubdir(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+
+	entry, err := s.Put(StoreEntry{Meta: StoreMeta{Slug: "x", CreatedAt: created}, Body: "b"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	oldPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_x.md")
+
+	entry.Meta.CreatedAt = time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
+	if _, err := s.Put(entry); err != nil {
+		t.Fatalf("Put move: %v", err)
+	}
+	newPath := filepath.Join(s.Root(), "2026", "03", "20260320_1_x.md")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("new path missing: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old path should be gone, got err=%v", err)
+	}
+}
+
+func TestOSStore_Get(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	_, err := s.Put(StoreEntry{Meta: StoreMeta{Title: "t", CreatedAt: created}, Body: "body"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := s.Get(1)
+	if err != nil {
+		t.Fatalf("Get hit: %v", err)
+	}
+	if got.Meta.Title != "t" || got.Body != "body" {
+		t.Fatalf("Get = %+v, want title=t body=body", got)
+	}
+
+	if _, err := s.Get(99); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get miss err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestOSStore_AllFilterByTagIncludesBodyHashtags(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	// entry 1: frontmatter tag alpha
+	if _, err := s.Put(StoreEntry{Meta: StoreMeta{Tags: []string{"alpha"}, CreatedAt: created}, Body: "x"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	// entry 2: body-hashtag beta
+	if _, err := s.Put(StoreEntry{Meta: StoreMeta{CreatedAt: created}, Body: "#beta is a body hashtag"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	// entry 3: neither tag
+	if _, err := s.Put(StoreEntry{Meta: StoreMeta{CreatedAt: created}, Body: "nothing"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	gotAlpha, err := s.All(WithTag("alpha"))
+	if err != nil {
+		t.Fatalf("All alpha: %v", err)
+	}
+	if len(gotAlpha) != 1 || gotAlpha[0].ID != 1 {
+		t.Fatalf("All alpha = %v, want [1]", entryIDs(gotAlpha))
+	}
+
+	gotBeta, err := s.All(WithTag("beta"))
+	if err != nil {
+		t.Fatalf("All beta: %v", err)
+	}
+	if len(gotBeta) != 1 || gotBeta[0].ID != 2 {
+		t.Fatalf("All beta = %v, want [2]", entryIDs(gotBeta))
+	}
+}
+
+func TestOSStore_FindStopsAtFirstMatch(t *testing.T) {
+	s := newOSTestStore(t)
+	// Three todo entries across different days; newest first.
+	for i := 1; i <= 3; i++ {
+		day := time.Date(2026, 1, i, 0, 0, 0, 0, time.UTC)
+		if _, err := s.Put(StoreEntry{Meta: StoreMeta{Type: "todo", CreatedAt: day}, Body: ""}); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+
+	got, err := s.Find(WithType("todo"))
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.ID != 3 {
+		t.Fatalf("Find newest todo ID = %d, want 3", got.ID)
+	}
+}
+
+func TestOSStore_FindNoMatch(t *testing.T) {
+	s := newOSTestStore(t)
+	_, err := s.Find(WithType("todo"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Find miss err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestOSStore_Delete(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	entry, err := s.Put(StoreEntry{Meta: StoreMeta{Slug: "x", CreatedAt: created}, Body: "b"})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if err := s.Delete(entry.ID); err != nil {
+		t.Fatalf("Delete hit: %v", err)
+	}
+	if _, err := os.Stat(s.AbsPath(entry)); !os.IsNotExist(err) {
+		t.Fatalf("file should be gone, got err=%v", err)
+	}
+	if err := s.Delete(entry.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete miss err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestOSStore_AbsPathNoIO(t *testing.T) {
+	root := t.TempDir()
+	s := NewOSStore(root)
+
+	entry := StoreEntry{
+		ID: 42,
+		Meta: StoreMeta{
+			Slug:      "demo",
+			CreatedAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	want := filepath.Join(root, "2026", "02", "20260201_42_demo.md")
+	if got := s.AbsPath(entry); got != want {
+		t.Fatalf("AbsPath = %s, want %s", got, want)
+	}
+	// no file should have been created as a side effect
+	if _, err := os.Stat(want); !os.IsNotExist(err) {
+		t.Fatalf("AbsPath created a file: err=%v", err)
+	}
+}
+
+func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	entry, err := s.Put(StoreEntry{
+		Meta: StoreMeta{
+			Title:       "Test",
+			Slug:        "test",
+			Type:        "note",
+			CreatedAt:   created,
+			Tags:        []string{"alpha", "beta"},
+			Aliases:     []string{"t"},
+			Description: "d",
+		},
+		Body: "body with #gamma\n",
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := s.Get(entry.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Meta.Title != "Test" || got.Meta.Slug != "test" || got.Meta.Type != "note" {
+		t.Fatalf("round-trip meta = %+v", got.Meta)
+	}
+	if !got.Meta.CreatedAt.Equal(created) {
+		t.Fatalf("round-trip CreatedAt = %v, want %v", got.Meta.CreatedAt, created)
+	}
+	// Tags should include both frontmatter values and the body hashtag.
+	want := map[string]bool{"alpha": true, "beta": true, "gamma": true}
+	for _, tag := range got.Meta.Tags {
+		delete(want, tag)
+	}
+	if len(want) != 0 {
+		t.Fatalf("round-trip Tags missing: %v (got %v)", want, got.Meta.Tags)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of #215. Adds `OSStore` — the filesystem-backed `Store` — and wires its constructor into `internal/cli/root.go`. No command behaviour changes yet; migration of individual commands begins in Phase 4.

- `note/os_store.go`: `OSStore` with `IDs`, `All`, `Find`, `Get`, `Put`, `Delete`, and `AbsPath`. Reuses the existing `ParseFilename`, `Filename`, `DirPath`, `WriteAtomic`, `StoreDirMode`, `NextID`, `ExtractHashtags`, `ParseNote`, and `FormatNote` helpers.
- Filename scan (`scanFileRefs`) sorts by `(date DESC, id DESC)` using the integer ID so `_11_` sorts newer than `_9_` (pure lexicographic order is unsafe).
- `All`/`Find` evaluate `WithType`/`WithSlug`/`WithExactDate`/`WithBeforeDate` from filenames; tag filters require reading file bodies. File reads go through a worker pool mirroring `Index.build()`.
- `Put` assigns IDs via `NextID` (id.json + flock), defaults `Meta.CreatedAt` to now when zero, renames atomically on slug/date changes, writes via `WriteAtomic`, and sets `Meta.UpdatedAt = time.Now()` on the returned entry without re-reading the file.
- Internal conversion uses the existing `Frontmatter` struct as the on-disk serialisation type and converts to/from `StoreMeta` at the boundary, per the issue's YAML note.
- `internal/cli/root.go`: adds `notesStore()` helper alongside `notesRoot()`. Kept referenced by a package-level `var _ = notesStore` so the unused-linter doesn't flag it until Phase 4 consumes it.

Tests in `note/os_store_test.go` cover the scenarios enumerated in #218, including the integer-vs-lexicographic ID ordering and the rename-on-slug/date-change paths.

## References

- relates to #215
- closes #218
