### PR TITLE
cli: migrate tags command to Store.All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.3] - 2026-04-24
+
+### Changed
+
+- `internal/cli/tags.go`: `notes tags` now calls `store.All()` instead of `note.Load` + index walk. `OSStore.All()` already returns entries with `Meta.Tags` populated as the merged frontmatter/body-hashtag union, so the command drops the two-source merge. Output format is unchanged ([#233]).
+
+[#233]: https://github.com/dreikanter/notes-cli/pull/233
+
 ## [0.3.2] - 2026-04-24
 
 ### Added

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -74,12 +74,7 @@ func notesRoot() (string, error) {
 
 // notesStore returns the Store instance the CLI uses for note-package
 // operations. It resolves the root path the same way notesRoot does — flag
-// first, then $NOTES_PATH, then error — so commands can replace their
-// direct filesystem calls with Store calls without touching path-resolution
-// code.
-//
-// Phase 3 wires this helper in; individual commands adopt it in later
-// phases.
+// first, then $NOTES_PATH, then error.
 func notesStore() (*note.OSStore, error) {
 	root, err := notesRoot()
 	if err != nil {
@@ -87,7 +82,3 @@ func notesStore() (*note.OSStore, error) {
 	}
 	return note.NewOSStore(root), nil
 }
-
-// Keep notesStore in reach of the unused linter until Phase 4 wires the
-// first command through it.
-var _ = notesStore

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
@@ -13,20 +12,17 @@ var tagsCmd = &cobra.Command{
 	Short: "List all tags from frontmatter and body hashtags",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := notesRoot()
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		idx, err := note.Load(root, note.WithLogger(stderrLogger(cmd)))
+		entries, err := store.All()
 		if err != nil {
 			return err
 		}
 		set := make(map[string]struct{})
-		for _, t := range idx.Tags() {
-			set[t] = struct{}{}
-		}
-		for _, e := range idx.Entries() {
-			for _, t := range e.BodyHashtags() {
+		for _, e := range entries {
+			for _, t := range e.Meta.Tags {
 				set[t] = struct{}{}
 			}
 		}


### PR DESCRIPTION
## Summary

Phase 4 of #215. First command migrated to the `Store` interface — the `tags` command now calls `store.All()` instead of `note.Load()` + index walk. Output format unchanged.

- `internal/cli/tags.go`: drop `note.Load` / `idx.Tags()` / `idx.Entries().BodyHashtags()` two-source merge. `OSStore.All()` already returns entries with `Meta.Tags` populated as the merged-and-deduplicated union of frontmatter tags and body hashtags, so the command just collects across entries, dedupes, sorts, and prints.
- `internal/cli/root.go`: `notesStore()` is now consumed by a real command — drop the temporary `var _ = notesStore` placeholder.

## References

- relates to #215
- closes #219
