### PR TITLE
cli: migrate read command to Store.Get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.4] - 2026-04-24
+
+### Changed
+
+- `internal/cli/read.go`: `notes read` now takes a single `<id>` integer argument and resolves it via `store.Get(id)`. The filter flags (`--type`, `--slug`, `--tag`, `--today`) are removed — users discover IDs via `notes ls` or `notes resolve`. `--no-frontmatter` is preserved. Raw file bytes still come from disk (via `store.AbsPath`) so on-disk YAML formatting is unchanged ([#234]).
+
+[#234]: https://github.com/dreikanter/notes-cli/pull/234
+
 ## [0.3.3] - 2026-04-24
 
 ### Changed

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -1,40 +1,44 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
+	"strconv"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
 var readCmd = &cobra.Command{
-	Use:   "read [<id|type|query>]",
-	Short: "Read a note by ref or filter flags",
-	Args:  cobra.MaximumNArgs(1),
+	Use:   "read <id>",
+	Short: "Read a note by numeric ID",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := notesRoot()
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("id must be an integer: %s", args[0])
+		}
+
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		f := readFilterFlags(cmd)
+
+		entry, err := store.Get(id)
+		if err != nil {
+			if errors.Is(err, note.ErrNotFound) {
+				return fmt.Errorf("note %d not found", id)
+			}
+			return err
+		}
+
+		data, err := os.ReadFile(store.AbsPath(entry))
+		if err != nil {
+			return err
+		}
+
 		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
-
-		entry, ok, err := resolveOrFilter(cmd, root, args, f)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
-		}
-		relPath := entry.RelPath
-
-		data, err := os.ReadFile(filepath.Join(root, relPath))
-		if err != nil {
-			return err
-		}
-
 		if noFrontmatter {
 			data = note.StripFrontmatter(data)
 		}
@@ -45,7 +49,6 @@ var readCmd = &cobra.Command{
 }
 
 func registerReadFlags() {
-	addFilterFlags(readCmd)
 	readCmd.Flags().Bool("no-frontmatter", false, "exclude YAML frontmatter from output")
 }
 

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/dreikanter/notes-cli/note"
 )
 
 func runRead(t *testing.T, args ...string) (string, error) {
@@ -36,70 +33,32 @@ func TestReadByID(t *testing.T) {
 	}
 }
 
-func TestReadByTagFilter(t *testing.T) {
-	out, err := runRead(t, "--tag", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// 20260104_8818_meeting.md contains "Standup notes"
-	if !strings.Contains(out, "Standup notes") {
-		t.Errorf("expected meeting note content, got: %s", out)
-	}
-}
-
-func TestReadByTypeFilter(t *testing.T) {
-	out, err := runRead(t, "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// 20260102_8814.todo.md contains "Todo"
-	if !strings.Contains(out, "Todo") {
-		t.Errorf("expected todo note content, got: %s", out)
-	}
-}
-
-func TestReadBySlugFilter(t *testing.T) {
-	out, err := runRead(t, "--slug", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out, "Standup notes") {
-		t.Errorf("expected meeting note content, got: %s", out)
-	}
-}
-
-func TestReadByTodayFilter(t *testing.T) {
-	// No notes in testdata match today's date, so this should error.
-	today := time.Now().Format(note.DateFormat)
-	_, err := runRead(t, "--today")
+func TestReadMissingID(t *testing.T) {
+	_, err := runRead(t, "999999")
 	if err == nil {
-		t.Fatalf("expected error for --today with no matching notes (today=%s), got nil", today)
+		t.Fatal("expected error for non-existent id, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error message should mention 'not found', got: %v", err)
 	}
 }
 
-func TestReadPositionalArgWithFilterErrors(t *testing.T) {
-	_, err := runRead(t, "8823", "--type", "todo")
+func TestReadNonIntegerArg(t *testing.T) {
+	_, err := runRead(t, "not-an-id")
 	if err == nil {
-		t.Fatal("expected error when combining positional arg with filter flags, got nil")
+		t.Fatal("expected error for non-integer id, got nil")
 	}
 }
 
-func TestReadNoTargetErrors(t *testing.T) {
+func TestReadNoArgsErrors(t *testing.T) {
 	_, err := runRead(t)
 	if err == nil {
-		t.Fatal("expected error when no positional arg and no filter flags, got nil")
+		t.Fatal("expected error when no positional arg, got nil")
 	}
 }
 
-func TestReadNoMatchErrors(t *testing.T) {
-	_, err := runRead(t, "--slug", "nonexistent-slug-xyz")
-	if err == nil {
-		t.Fatal("expected error when filters match nothing, got nil")
-	}
-}
-
-func TestReadNoFrontmatterWithFilter(t *testing.T) {
-	out, err := runRead(t, "--tag", "meeting", "--no-frontmatter")
+func TestReadNoFrontmatter(t *testing.T) {
+	out, err := runRead(t, "8818", "--no-frontmatter")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -109,12 +68,5 @@ func TestReadNoFrontmatterWithFilter(t *testing.T) {
 	}
 	if !strings.Contains(out, "Standup notes") {
 		t.Errorf("expected note body, got: %s", out)
-	}
-}
-
-func TestReadPositionalArgWithTodayErrors(t *testing.T) {
-	_, err := runRead(t, "8823", "--today")
-	if err == nil {
-		t.Fatal("expected error when combining positional arg with --today, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 5 of #215. `notes read` now takes a plain `<id>` positional argument and resolves it via `store.Get(id)`.

- `internal/cli/read.go`: drop `resolveRef` / `readFilterFlags` / `resolveOrFilter`. The command accepts one integer argument; non-integer input and missing IDs produce clear messages.
- The `--no-frontmatter` flag is preserved.
- File bytes are still read from disk (via `store.AbsPath(entry)`) so the exact on-disk formatting — including field order inside the YAML block — is preserved. Users don't see surprise reformatting from re-serialising.
- Filter flags (`--type`, `--slug`, `--tag`, `--today`) move off `read`; users discover IDs via `notes ls` or `notes resolve`.

Tests updated: the filter-flag cases are gone; new coverage includes non-integer args, missing IDs, and the no-frontmatter path.

## References

- relates to #215
- closes #220
