### PR TITLE
cli: migrate rm command to Store.Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.5] - 2026-04-24
+
+### Changed
+
+- `internal/cli/rm.go`: `notes rm` now takes a single `<id>` integer argument and deletes via `store.Delete(id)`. The `--today` flag is removed — users get today's ID from `notes ls --today` or `notes resolve`. Non-existent IDs surface `note.ErrNotFound` as a clear "not found" message ([#235]).
+
+[#235]: https://github.com/dreikanter/notes-cli/pull/235
+
 ## [0.3.4] - 2026-04-24
 
 ### Changed

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -1,52 +1,47 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
+	"strconv"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
 )
 
 var rmCmd = &cobra.Command{
-	Use:   "rm <id|type|query>",
-	Short: "Delete a note",
+	Use:   "rm <id>",
+	Short: "Delete a note by numeric ID",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		today, _ := cmd.Flags().GetBool("today")
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("id must be an integer: %s", args[0])
+		}
 
-		root, err := notesRoot()
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
 
-		var date string
-		if today {
-			date = time.Now().Format(note.DateFormat)
-		}
-
-		n, err := resolveRef(cmd, root, args[0], note.WithDate(date))
+		entry, err := store.Get(id)
 		if err != nil {
+			if errors.Is(err, note.ErrNotFound) {
+				return fmt.Errorf("note %d not found", id)
+			}
+			return err
+		}
+		path := store.AbsPath(entry)
+
+		if err := store.Delete(id); err != nil {
 			return err
 		}
 
-		absPath := filepath.Join(root, n.RelPath)
-		if err := os.Remove(absPath); err != nil {
-			return err
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), absPath)
+		fmt.Fprintln(cmd.OutOrStdout(), path)
 		return nil
 	},
 }
 
-func registerRmFlags() {
-	rmCmd.Flags().Bool("today", false, "only match notes created today")
-}
-
 func init() {
-	registerRmFlags()
 	rootCmd.AddCommand(rmCmd)
 }

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -6,16 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/dreikanter/notes-cli/note"
 )
 
 func runRm(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
 	rmCmd.ResetFlags()
-	registerRmFlags()
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -44,69 +40,21 @@ func TestRmByID(t *testing.T) {
 	}
 }
 
-func TestRmBySlug(t *testing.T) {
-	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-
-	out, err := runRm(t, root, "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if out != target {
-		t.Errorf("got %q, want %q", out, target)
-	}
-
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
-		t.Error("file should have been deleted")
-	}
-}
-
 func TestRmNonExistentErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runRm(t, root, "9999")
 	if err == nil {
-		t.Fatal("expected error for non-existent ref, got nil")
+		t.Fatal("expected error for non-existent id, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error message should mention 'not found', got: %v", err)
 	}
 }
 
-func TestRmTodayFlag(t *testing.T) {
-	root := t.TempDir()
-	today := time.Now().Format(note.DateFormat)
-	dir := filepath.Join(root, today[:4], today[4:6])
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	fname := today + "_0001_daily.md"
-	target := filepath.Join(dir, fname)
-	if err := os.WriteFile(target, []byte("test"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	out, err := runRm(t, root, "--today", "daily")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if out != target {
-		t.Errorf("got %q, want %q", out, target)
-	}
-
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
-		t.Error("file should have been deleted")
-	}
-}
-
-func TestRmTodayExcludesOldNotes(t *testing.T) {
+func TestRmNonIntegerArgErrors(t *testing.T) {
 	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-
-	_, err := runRm(t, root, "--today", "meeting")
+	_, err := runRm(t, root, "meeting")
 	if err == nil {
-		t.Fatal("expected error when --today excludes matching note")
-	}
-
-	if _, err := os.Stat(target); err != nil {
-		t.Error("file should NOT have been deleted")
+		t.Fatal("expected error for non-integer id, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 6 of #215. `notes rm` now takes a plain `<id>` positional argument and routes through `store.Delete(id)`.

- `internal/cli/rm.go`: drop `resolveRef`, `os.Remove`, and the `--today` flag. The command first calls `store.Get(id)` to derive the absolute path for the status output and to surface `note.ErrNotFound` as a clear user error, then calls `store.Delete(id)`.

## References

- relates to #215
- closes #221
