### PR TITLE
cli: migrate ls command to Store (output changes to IDs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.6] - 2026-04-24
+
+### Changed
+
+- **Breaking**: `notes ls` now prints one integer ID per line (newest first) instead of one absolute path per line. Scripts that piped `notes ls` into `notes read` / `notes rm` should switch to `notes resolve` if they need paths.
+- `internal/cli/ls.go`: replace `note.Load` + filter pipeline with `store.IDs()` (fast directory-scan path) when no filter flags are set, and `store.All(...)` with composed `QueryOpt`s otherwise.
+- Flag mapping: `--type` → `WithType` (now single-valued), `--slug` → `WithSlug`, `--tag` → `WithTag` (repeatable, AND), `--today` → `WithExactDate(time.Now())`.
+- Removed the `--name` filename-fragment flag; it will return as a tag/title-fragment query option in a future phase ([#236]).
+
+[#236]: https://github.com/dreikanter/notes-cli/pull/236
+
 ## [0.3.5] - 2026-04-24
 
 ### Changed

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"path/filepath"
+	"time"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
@@ -10,44 +10,73 @@ import (
 
 var lsCmd = &cobra.Command{
 	Use:   "ls",
-	Short: "List notes",
+	Short: "List note IDs, newest first",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lsLimit, _ := cmd.Flags().GetInt("limit")
-		lsName, _ := cmd.Flags().GetString("name")
-		f := readFilterFlags(cmd)
+		noteType, _ := cmd.Flags().GetString("type")
+		slug, _ := cmd.Flags().GetString("slug")
+		tags, _ := cmd.Flags().GetStringSlice("tag")
+		today, _ := cmd.Flags().GetBool("today")
 
-		root, err := notesRoot()
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		idx, err := note.Load(root, loadOptsFor(cmd, f)...)
+
+		ids, err := lsIDs(store, noteType, slug, tags, today)
 		if err != nil {
 			return err
 		}
-		entries := idx.Entries()
 
-		if lsName != "" {
-			entries = note.FilterByFilename(entries, lsName)
+		if lsLimit > 0 && len(ids) > lsLimit {
+			ids = ids[:lsLimit]
 		}
-
-		entries = applyFilters(entries, f)
-
-		if lsLimit > 0 && len(entries) > lsLimit {
-			entries = entries[:lsLimit]
-		}
-
-		for _, e := range entries {
-			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, e.RelPath))
+		out := cmd.OutOrStdout()
+		for _, id := range ids {
+			fmt.Fprintln(out, id)
 		}
 		return nil
 	},
 }
 
+// lsIDs returns the IDs to print. With no filter flags it takes the fast
+// directory-scan path via Store.IDs; otherwise it builds a QueryOpt list
+// and delegates to Store.All.
+func lsIDs(store note.Store, noteType, slug string, tags []string, today bool) ([]int, error) {
+	if noteType == "" && slug == "" && len(tags) == 0 && !today {
+		return store.IDs()
+	}
+	var opts []note.QueryOpt
+	if noteType != "" {
+		opts = append(opts, note.WithType(noteType))
+	}
+	if slug != "" {
+		opts = append(opts, note.WithSlug(slug))
+	}
+	for _, t := range tags {
+		opts = append(opts, note.WithTag(t))
+	}
+	if today {
+		opts = append(opts, note.WithExactDate(time.Now()))
+	}
+	entries, err := store.All(opts...)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int, len(entries))
+	for i, e := range entries {
+		ids[i] = e.ID
+	}
+	return ids, nil
+}
+
 func registerLsFlags() {
-	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
-	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
-	addFilterFlags(lsCmd)
+	lsCmd.Flags().Int("limit", 0, "maximum number of IDs to list (0 = no limit)")
+	lsCmd.Flags().String("type", "", "filter by note type")
+	lsCmd.Flags().String("slug", "", "filter by exact slug")
+	lsCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+	lsCmd.Flags().Bool("today", false, "only list notes created today")
 }
 
 func init() {

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -32,6 +31,11 @@ func TestLsNoArgs(t *testing.T) {
 	lines := strings.Split(out, "\n")
 	if len(lines) != 4 {
 		t.Fatalf("got %d lines, want 4:\n%s", len(lines), out)
+	}
+	for _, line := range lines {
+		if !allDigits(line) {
+			t.Fatalf("expected integer ID per line, got %q", line)
+		}
 	}
 }
 
@@ -80,8 +84,8 @@ func TestLsTagAndType(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
 	}
-	if !strings.Contains(lines[0], "todo") {
-		t.Errorf("expected todo note, got %q", lines[0])
+	if lines[0] != "8814" {
+		t.Errorf("expected ID 8814, got %q", lines[0])
 	}
 }
 
@@ -97,7 +101,7 @@ func TestLsTagAndLimit(t *testing.T) {
 	}
 }
 
-func TestLsMultipleTags(t *testing.T) {
+func TestLsMultipleTagsAND(t *testing.T) {
 	out, err := runLs(t, "--tag", "work", "--tag", "planning")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -107,8 +111,8 @@ func TestLsMultipleTags(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("got %d lines, want 1 (only todo has both work+planning):\n%s", len(lines), out)
 	}
-	if !strings.Contains(lines[0], "todo") {
-		t.Errorf("expected todo note, got %q", lines[0])
+	if lines[0] != "8814" {
+		t.Errorf("expected ID 8814, got %q", lines[0])
 	}
 }
 
@@ -122,8 +126,8 @@ func TestLsMultipleTagsCommaSeparated(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("got %d lines, want 1 (only meeting note has both work+meeting):\n%s", len(lines), out)
 	}
-	if !strings.Contains(lines[0], "meeting") {
-		t.Errorf("expected meeting note, got %q", lines[0])
+	if lines[0] != "8818" {
+		t.Errorf("expected ID 8818, got %q", lines[0])
 	}
 }
 
@@ -135,32 +139,6 @@ func TestLsTagAndTypeNoOverlap(t *testing.T) {
 
 	if out != "" {
 		t.Errorf("expected empty output (no todo with meeting tag), got %q", out)
-	}
-}
-
-func TestLsWithName(t *testing.T) {
-	out, err := runLs(t, "--name", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-	if !strings.Contains(lines[0], "meeting") {
-		t.Errorf("expected meeting note, got %q", lines[0])
-	}
-}
-
-func TestLsNameNoMatch(t *testing.T) {
-	out, err := runLs(t, "--name", "nonexistent")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if out != "" {
-		t.Errorf("expected empty output, got %q", out)
 	}
 }
 
@@ -187,54 +165,19 @@ func TestLsUnlimitedByDefault(t *testing.T) {
 	}
 }
 
-func TestLsNameAndType(t *testing.T) {
-	out, err := runLs(t, "--name", "8814", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-	if !strings.Contains(lines[0], "8814") {
-		t.Errorf("expected note 8814, got %q", lines[0])
-	}
-}
-
-func TestLsOutputsAbsolutePaths(t *testing.T) {
+func TestLsOutputsIntegerIDs(t *testing.T) {
 	out, err := runLs(t)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	root := testdataPath(t)
 	for _, line := range strings.Split(out, "\n") {
 		if line == "" {
 			continue
 		}
-		if !filepath.IsAbs(line) {
-			t.Errorf("expected absolute path, got %q", line)
+		if !allDigits(line) {
+			t.Errorf("expected integer ID per line, got %q", line)
 		}
-		if !strings.HasPrefix(line, root) {
-			t.Errorf("expected path under %s, got %q", root, line)
-		}
-	}
-}
-
-func TestLsMultipleTypes(t *testing.T) {
-	// "todo" exists; "backlog" does not — union should return the 1 todo note
-	out, err := runLs(t, "--type", "todo", "--type", "backlog")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-	if !strings.Contains(lines[0], "todo") {
-		t.Errorf("expected todo note, got %q", lines[0])
 	}
 }
 
@@ -248,7 +191,19 @@ func TestLsSlug(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
 	}
-	if !strings.Contains(lines[0], "meeting") {
-		t.Errorf("expected meeting note, got %q", lines[0])
+	if lines[0] != "8818" {
+		t.Errorf("expected ID 8818, got %q", lines[0])
 	}
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Phase 7 of #215. **Breaking**: `notes ls` now prints one integer ID per line instead of one absolute path per line. Users who pipe `notes ls` into `notes read`/`rm` should switch to `notes resolve` for paths.

- `internal/cli/ls.go`: replace `note.Load` + `applyFilters` with `store.IDs()` (fast directory-scan path, no file reads) when no filter flags are set, and `store.All(...)` with composed `QueryOpt`s otherwise.
- Flag mapping: `--type` → `WithType`; `--slug` → `WithSlug`; `--tag` → `WithTag` (repeatable, AND); `--today` → `WithExactDate(time.Now())`.
- `--type` goes from `StringSlice` to `String` since `WithType` is single-valued. `--tag` stays `StringSlice`.
- `--name` flag is **removed**; it will return as `WithTitleFragment` in a future phase.
- `--verbose` remains deferred.
- `--limit` is preserved.

Tests updated to assert integer-ID output and the new flag shape.

## References

- relates to #215
- closes #222
