### PR TITLE
cli: migrate append command to Store.Get + Store.Put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.7] - 2026-04-24
+
+### Changed
+
+- `internal/cli/append.go`: `notes append` now takes a single `<id>` integer argument. Load goes through `store.Get`, body is modified in-memory, and save goes through `store.Put`. Filter flags (`--type`, `--slug`, `--tag`, `--today`) are removed — users get IDs from `notes ls` or `notes resolve` ([#237]).
+
+[#237]: https://github.com/dreikanter/notes-cli/pull/237
+
 ## [0.3.6] - 2026-04-24
 
 ### Changed

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/dreikanter/notes-cli/note"
@@ -12,18 +12,18 @@ import (
 )
 
 var appendCmd = &cobra.Command{
-	Use:   "append [<id|type|query>]",
+	Use:   "append <id>",
 	Short: "Append text from stdin to a note",
-	Args:  cobra.MaximumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := notesRoot()
+		id, err := strconv.Atoi(args[0])
 		if err != nil {
-			return err
+			return fmt.Errorf("id must be an integer: %s", args[0])
 		}
 
 		in := cmd.InOrStdin()
 		if stdinIsTerminal(in) {
-			return fmt.Errorf("no input: pipe text to stdin (e.g. echo 'text' | notes append <target>)")
+			return fmt.Errorf("no input: pipe text to stdin (e.g. echo 'text' | notes append <id>)")
 		}
 
 		data, err := io.ReadAll(in)
@@ -35,44 +35,35 @@ var appendCmd = &cobra.Command{
 			return nil
 		}
 
-		f := readFilterFlags(cmd)
-
-		entry, ok, err := resolveOrFilter(cmd, root, args, f)
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		if !ok {
-			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
-		}
-		targetPath := filepath.Join(root, entry.RelPath)
 
-		// Read existing file
-		existing, err := os.ReadFile(targetPath)
+		entry, err := store.Get(id)
 		if err != nil {
-			return fmt.Errorf("cannot read note: %w", err)
-		}
-
-		// Append: ensure existing ends with \n, then \n + content + \n
-		existingStr := string(existing)
-		if len(existingStr) > 0 && !strings.HasSuffix(existingStr, "\n") {
-			existingStr += "\n"
-		}
-		result := existingStr + "\n" + content + "\n"
-
-		if err := note.WriteAtomic(targetPath, []byte(result)); err != nil {
+			if errors.Is(err, note.ErrNotFound) {
+				return fmt.Errorf("note %d not found", id)
+			}
 			return err
 		}
 
-		fmt.Fprintln(cmd.OutOrStdout(), targetPath)
+		body := entry.Body
+		if body != "" && !strings.HasSuffix(body, "\n") {
+			body += "\n"
+		}
+		entry.Body = body + "\n" + content + "\n"
+
+		saved, err := store.Put(entry)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), store.AbsPath(saved))
 		return nil
 	},
 }
 
-func registerAppendFlags() {
-	addFilterFlags(appendCmd)
-}
-
 func init() {
-	registerAppendFlags()
 	rootCmd.AddCommand(appendCmd)
 }

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -40,7 +40,6 @@ func runAppend(t *testing.T, root string, stdin string, args ...string) (string,
 	t.Helper()
 
 	appendCmd.ResetFlags()
-	registerAppendFlags()
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -70,102 +69,11 @@ func TestAppendByID(t *testing.T) {
 	}
 }
 
-func TestAppendByAbsolutePath(t *testing.T) {
+func TestAppendNonIntegerArgErrors(t *testing.T) {
 	root := copyTestdata(t)
-	target := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	out, err := runAppend(t, root, "path append", target)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if out != target {
-		t.Errorf("got output %q, want %q", out, target)
-	}
-
-	data, _ := os.ReadFile(target)
-	if !strings.Contains(string(data), "path append") {
-		t.Error("appended text not found in file")
-	}
-}
-
-func TestAppendByRelativePath(t *testing.T) {
-	root := copyTestdata(t)
-
-	// chdir into the temp root so a relative path containing "/" works
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("cannot get working directory: %v", err)
-	}
-	if err := os.Chdir(root); err != nil {
-		t.Fatalf("cannot chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWd) })
-
-	out, err := runAppend(t, root, "rel append", "2026/01/20260106_8823_999.md")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	if out != want {
-		t.Errorf("got output %q, want %q", out, want)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(root, "2026/01/20260106_8823_999.md"))
-	if !strings.Contains(string(data), "rel append") {
-		t.Error("appended text not found in file")
-	}
-}
-
-func TestAppendByTagFilter(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runAppend(t, root, "tag append", "--tag", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-	if out != want {
-		t.Errorf("got output %q, want %q", out, want)
-	}
-
-	data, _ := os.ReadFile(want)
-	if !strings.Contains(string(data), "tag append") {
-		t.Error("appended text not found in file")
-	}
-}
-
-func TestAppendBySlugFilter(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runAppend(t, root, "slug append", "--slug", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-	if out != want {
-		t.Errorf("got output %q, want %q", out, want)
-	}
-}
-
-func TestAppendByTypeFilter(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runAppend(t, root, "type append", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	want := filepath.Join(root, "2026/01/20260102_8814.todo.md")
-	if out != want {
-		t.Errorf("got output %q, want %q", out, want)
-	}
-}
-
-func TestAppendPathOutsideRoot(t *testing.T) {
-	root := copyTestdata(t)
-	_, err := runAppend(t, root, "escape attempt", "/tmp/evil.md")
+	_, err := runAppend(t, root, "text", "meeting")
 	if err == nil {
-		t.Fatal("expected error for path outside notes directory, got nil")
+		t.Fatal("expected error for non-integer id, got nil")
 	}
 }
 
@@ -174,6 +82,9 @@ func TestAppendNonExistentNote(t *testing.T) {
 	_, err := runAppend(t, root, "text", "9999")
 	if err == nil {
 		t.Fatal("expected error for non-existent note, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found', got: %v", err)
 	}
 }
 
@@ -234,35 +145,10 @@ func TestAppendMultipleProducesSeparation(t *testing.T) {
 	}
 }
 
-func TestAppendPositionalArgWithFilterErrors(t *testing.T) {
-	root := copyTestdata(t)
-	_, err := runAppend(t, root, "text", "8823", "--type", "todo")
-	if err == nil {
-		t.Fatal("expected error when combining positional arg and filter flags, got nil")
-	}
-}
-
-func TestAppendNoTargetErrors(t *testing.T) {
+func TestAppendNoArgErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runAppend(t, root, "text")
 	if err == nil {
 		t.Fatal("expected error when no target specified, got nil")
-	}
-}
-
-func TestAppendFilterNoMatchErrors(t *testing.T) {
-	root := copyTestdata(t)
-	_, err := runAppend(t, root, "text", "--slug", "nonexistent")
-	if err == nil {
-		t.Fatal("expected error when no notes match filter, got nil")
-	}
-}
-
-func TestAppendTodayFilter(t *testing.T) {
-	// testdata notes are all in the past; --today should find nothing
-	root := copyTestdata(t)
-	_, err := runAppend(t, root, "text", "--type", "todo", "--today")
-	if err == nil {
-		t.Fatal("expected error when --today matches no notes, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 8 of #215. `notes append` now takes a plain `<id>` positional argument and writes via `store.Get` → append to `entry.Body` → `store.Put`.

- `internal/cli/append.go`: drop `resolveOrFilter`, `os.ReadFile`, and `note.WriteAtomic`. The command ensures the loaded body ends with a newline, appends a blank line and the piped content, and lets `store.Put` handle serialisation.
- Filter flags (`--type`, `--slug`, `--tag`, `--today`) move off `append`; users look up the ID via `notes ls` / `notes resolve`.
- Blank-line separation between successive appends is preserved.

## References

- relates to #215
- closes #223
