### PR TITLE
cli: migrate annotate command to Store.Get + Store.Put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.8] - 2026-04-24
+
+### Changed
+
+- `internal/cli/annotate.go`: `notes annotate` now takes a single `<id>` integer argument. Load/save go through `store.Get` / `store.Put`; the Claude invocation flow (schema, exec, timeout handling, error mapping) is unchanged. `annotateEmptyFields` and `mergeAnnotation` now operate on `note.StoreMeta` instead of `note.Frontmatter` ([#238]).
+
+[#238]: https://github.com/dreikanter/notes-cli/pull/238
+
 ## [0.3.7] - 2026-04-24
 
 ### Changed

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -23,9 +23,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dreikanter/notes-cli/note"
@@ -47,48 +47,45 @@ Generate concise metadata for the provided note body, returning ONLY the fields 
 - tags: 1-3 lowercase single-word slugs related to the content.`
 
 var annotateCmd = &cobra.Command{
-	Use:   "annotate <id|type|query>",
+	Use:   "annotate <id>",
 	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
 	Args:  cobra.ExactArgs(1),
 	RunE:  annotateRunE,
 }
 
 func annotateRunE(cmd *cobra.Command, args []string) error {
+	id, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("id must be an integer: %s", args[0])
+	}
+
 	model, _ := cmd.Flags().GetString("model")
 	maxChars, _ := cmd.Flags().GetInt("max-chars")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 
-	root, err := notesRoot()
+	store, err := notesStore()
 	if err != nil {
 		return err
 	}
-	n, err := resolveRef(cmd, root, args[0])
+	entry, err := store.Get(id)
 	if err != nil {
+		if errors.Is(err, note.ErrNotFound) {
+			return fmt.Errorf("note %d not found", id)
+		}
 		return err
 	}
 
-	fullPath := filepath.Join(root, n.RelPath)
-	data, err := os.ReadFile(fullPath)
-	if err != nil {
-		return fmt.Errorf("cannot read note: %w", err)
-	}
-
-	existing, body, err := note.ParseNote(data)
-	if err != nil {
-		return fmt.Errorf("%s: %w", fullPath, err)
-	}
-
-	empty := annotateEmptyFields(existing)
+	empty := annotateEmptyFields(entry.Meta)
 	if len(empty) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+		fmt.Fprintln(cmd.OutOrStdout(), store.AbsPath(entry))
 		return nil
 	}
 
-	if len(bytes.TrimSpace(body)) == 0 {
+	if strings.TrimSpace(entry.Body) == "" {
 		return errors.New("note has no body content to annotate")
 	}
 
-	prompt := string(body)
+	prompt := entry.Body
 	if maxChars > 0 {
 		if runes := []rune(prompt); len(runes) > maxChars {
 			prompt = string(runes[:maxChars])
@@ -101,17 +98,13 @@ func annotateRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	merged := mergeAnnotation(existing, gen)
-	newContent, err := note.FormatNote(merged, body)
+	entry.Meta = mergeAnnotation(entry.Meta, gen)
+	saved, err := store.Put(entry)
 	if err != nil {
 		return err
 	}
 
-	if err := note.WriteAtomic(fullPath, newContent); err != nil {
-		return err
-	}
-
-	fmt.Fprintln(cmd.OutOrStdout(), fullPath)
+	fmt.Fprintln(cmd.OutOrStdout(), store.AbsPath(saved))
 	return nil
 }
 
@@ -178,15 +171,15 @@ func runClaude(ctx context.Context, model, schema, prompt string) ([]byte, error
 
 // annotateEmptyFields returns the empty fields among {title, description, tags}
 // in a deterministic order. "tags" counts as empty when the slice is empty.
-func annotateEmptyFields(f note.Frontmatter) []string {
+func annotateEmptyFields(m note.StoreMeta) []string {
 	var empty []string
-	if f.Title == "" {
+	if m.Title == "" {
 		empty = append(empty, "title")
 	}
-	if f.Description == "" {
+	if m.Description == "" {
 		empty = append(empty, "description")
 	}
-	if len(f.Tags) == 0 {
+	if len(m.Tags) == 0 {
 		empty = append(empty, "tags")
 	}
 	return empty
@@ -261,7 +254,7 @@ func snippet(s string, n int) string {
 
 // mergeAnnotation fills empty fields in existing from gen.
 // Non-empty fields in existing are preserved.
-func mergeAnnotation(existing note.Frontmatter, gen annotateResult) note.Frontmatter {
+func mergeAnnotation(existing note.StoreMeta, gen annotateResult) note.StoreMeta {
 	merged := existing
 	if merged.Title == "" {
 		merged.Title = gen.Title

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -28,7 +28,7 @@ func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
 }
 
 func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
-	got := annotateEmptyFields(note.Frontmatter{})
+	got := annotateEmptyFields(note.StoreMeta{})
 	want := []string{"title", "description", "tags"}
 	if !equalStrings(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -36,8 +36,8 @@ func TestAnnotateEmptyFieldsAllEmpty(t *testing.T) {
 }
 
 func TestAnnotateEmptyFieldsPartial(t *testing.T) {
-	f := note.Frontmatter{Title: "Existing"}
-	got := annotateEmptyFields(f)
+	m := note.StoreMeta{Title: "Existing"}
+	got := annotateEmptyFields(m)
 	want := []string{"description", "tags"}
 	if !equalStrings(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -45,8 +45,8 @@ func TestAnnotateEmptyFieldsPartial(t *testing.T) {
 }
 
 func TestAnnotateEmptyFieldsAllFilled(t *testing.T) {
-	f := note.Frontmatter{Title: "T", Description: "D", Tags: []string{"x"}}
-	got := annotateEmptyFields(f)
+	m := note.StoreMeta{Title: "T", Description: "D", Tags: []string{"x"}}
+	got := annotateEmptyFields(m)
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty", got)
 	}
@@ -186,7 +186,7 @@ func TestParseAnnotationErrorFlag(t *testing.T) {
 }
 
 func TestMergeAnnotationFillsEmpty(t *testing.T) {
-	existing := note.Frontmatter{Slug: "meeting", Public: true}
+	existing := note.StoreMeta{Slug: "meeting", Public: true}
 	gen := annotateResult{
 		Title:       "New",
 		Description: "Generated desc",
@@ -212,7 +212,7 @@ func TestMergeAnnotationFillsEmpty(t *testing.T) {
 }
 
 func TestMergeAnnotationPreservesFilledFields(t *testing.T) {
-	existing := note.Frontmatter{
+	existing := note.StoreMeta{
 		Title:       "Existing title",
 		Description: "Existing desc",
 		Tags:        []string{"keep"},


### PR DESCRIPTION
## Summary

Phase 9 of #215. `notes annotate` now takes a plain `<id>` positional argument and routes through `store.Get` → Claude → merge into `Meta` → `store.Put`.

- `internal/cli/annotate.go`: drop `resolveRef`, `os.ReadFile`, `ParseNote`, `FormatNote`, and `WriteAtomic` call sites. `annotateEmptyFields` / `mergeAnnotation` now operate on `note.StoreMeta`.
- The Claude-CLI invocation (schema build, exec, timeout handling, error mapping) is unchanged.
- Output prints `store.AbsPath(entry)` so the trailing path-echo behaviour is preserved.

Tests updated to use `note.StoreMeta` in the `annotateEmptyFields` / `mergeAnnotation` cases; the end-to-end fake-Claude tests pass unchanged.

## References

- relates to #215
- closes #224
