### PR TITLE
cli: migrate update command to Store; drop --sync-filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.9] - 2026-04-24
+
+### Changed
+
+- `internal/cli/update.go`: `notes update` now takes a single `<id>` integer argument and routes through `store.Get` / `store.Put`. The `--sync-filename` flag is removed — `OSStore.Put` detects filename drift from `Meta.Slug`/`Type`/`CreatedAt` and renames atomically. New `--date YYYYMMDD` flag moves the note to the requested year/month directory. `syncNoteFilename` and its associated rename-via-link logic are deleted ([#239]).
+
+[#239]: https://github.com/dreikanter/notes-cli/pull/239
+
 ## [0.3.8] - 2026-04-24
 
 ### Changed

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -3,9 +3,8 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/dreikanter/notes-cli/note"
 	"github.com/spf13/cobra"
@@ -13,10 +12,15 @@ import (
 )
 
 var updateCmd = &cobra.Command{
-	Use:   "update <id|type|query>",
-	Short: "Update frontmatter; use --sync-filename to reconcile the filename",
+	Use:   "update <id>",
+	Short: "Update frontmatter fields on a note (rename is automatic on slug/type/date changes)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("id must be an integer: %s", args[0])
+		}
+
 		tags, _ := cmd.Flags().GetStringSlice("tag")
 		noTags, _ := cmd.Flags().GetBool("no-tags")
 		title, _ := cmd.Flags().GetString("title")
@@ -25,7 +29,7 @@ var updateCmd = &cobra.Command{
 		noSlug, _ := cmd.Flags().GetBool("no-slug")
 		noteType, _ := cmd.Flags().GetString("type")
 		noType, _ := cmd.Flags().GetBool("no-type")
-		syncFilename, _ := cmd.Flags().GetBool("sync-filename")
+		dateStr, _ := cmd.Flags().GetString("date")
 
 		hasFlag := false
 		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
@@ -42,132 +46,67 @@ var updateCmd = &cobra.Command{
 				return err
 			}
 		}
+		var newDate time.Time
+		if cmd.Flags().Changed("date") {
+			parsed, err := time.Parse(note.DateFormat, dateStr)
+			if err != nil {
+				return fmt.Errorf("invalid date %q: expected %s", dateStr, note.DateFormat)
+			}
+			newDate = parsed
+		}
 
-		root, err := notesRoot()
+		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		n, err := resolveRef(cmd, root, args[0])
+		entry, err := store.Get(id)
 		if err != nil {
+			if errors.Is(err, note.ErrNotFound) {
+				return fmt.Errorf("note %d not found", id)
+			}
 			return err
 		}
 
-		oldPath := filepath.Join(root, n.RelPath)
-		data, err := os.ReadFile(oldPath)
-		if err != nil {
-			return fmt.Errorf("cannot read note: %w", err)
-		}
-
-		updated, body, err := note.ParseNote(data)
-		if err != nil {
-			return fmt.Errorf("%s: %w", oldPath, err)
-		}
-
-		contentChanged := false
 		if cmd.Flags().Changed("title") {
-			updated.Title = title
-			contentChanged = true
+			entry.Meta.Title = title
 		}
 		if cmd.Flags().Changed("description") {
-			updated.Description = description
-			contentChanged = true
+			entry.Meta.Description = description
 		}
 		if noTags {
-			updated.Tags = nil
-			contentChanged = true
+			entry.Meta.Tags = nil
 		} else if cmd.Flags().Changed("tag") {
-			updated.Tags = tags
-			contentChanged = true
+			entry.Meta.Tags = tags
 		}
 		if noSlug {
-			updated.Slug = ""
-			contentChanged = true
+			entry.Meta.Slug = ""
 		} else if cmd.Flags().Changed("slug") {
-			updated.Slug = slug
-			contentChanged = true
+			entry.Meta.Slug = slug
+		}
+		if noType {
+			entry.Meta.Type = ""
+		} else if cmd.Flags().Changed("type") {
+			entry.Meta.Type = noteType
 		}
 		if cmd.Flags().Changed("private") {
 			v, _ := cmd.Flags().GetBool("private")
-			updated.Public = !v
-			contentChanged = true
+			entry.Meta.Public = !v
 		} else if cmd.Flags().Changed("public") {
 			v, _ := cmd.Flags().GetBool("public")
-			updated.Public = v
-			contentChanged = true
+			entry.Meta.Public = v
 		}
-		if noType {
-			updated.Type = ""
-			contentChanged = true
-		} else if cmd.Flags().Changed("type") {
-			updated.Type = noteType
-			contentChanged = true
+		if cmd.Flags().Changed("date") {
+			entry.Meta.CreatedAt = newDate
 		}
 
-		if contentChanged {
-			newContent, err := note.FormatNote(updated, body)
-			if err != nil {
-				return err
-			}
-			if err := note.WriteAtomic(oldPath, newContent); err != nil {
-				return err
-			}
+		saved, err := store.Put(entry)
+		if err != nil {
+			return err
 		}
 
-		newPath := oldPath
-		if syncFilename {
-			var syncErr error
-			newPath, syncErr = syncNoteFilename(cmd, n, updated, oldPath, noSlug, noType)
-			if syncErr != nil {
-				return syncErr
-			}
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), newPath)
+		fmt.Fprintln(cmd.OutOrStdout(), store.AbsPath(saved))
 		return nil
 	},
-}
-
-// syncNoteFilename reconciles the on-disk filename with the (already-updated)
-// frontmatter slug and type. When frontmatter is silent on slug/type and the
-// user did not touch those flags, the filename-reported value is used so the
-// rename is a no-op instead of stripping a still-valid cache suffix. The rename
-// uses hard-link + remove to atomically reserve the target and refuse a clobber.
-// Returns newPath, which equals oldPath when no rename is needed.
-func syncNoteFilename(cmd *cobra.Command, n note.Ref, updated note.Frontmatter, oldPath string, noSlug, noType bool) (string, error) {
-	id, err := strconv.Atoi(n.ID)
-	if err != nil {
-		return "", fmt.Errorf("invalid note id %q: %w", n.ID, err)
-	}
-	syncSlug := updated.Slug
-	if syncSlug == "" && !cmd.Flags().Changed("slug") && !noSlug {
-		syncSlug = n.Slug
-	}
-	syncType := updated.Type
-	if syncType == "" && !cmd.Flags().Changed("type") && !noType {
-		syncType = n.Type
-	}
-	newFilename := note.Filename(n.Date, id, syncSlug, syncType)
-	dir := filepath.Dir(oldPath)
-	newPath := filepath.Join(dir, newFilename)
-	if newPath == oldPath {
-		return oldPath, nil
-	}
-	// os.Link atomically reserves the target: returns EEXIST if it already
-	// exists, which os.Rename on Unix would silently clobber.
-	if err := os.Link(oldPath, newPath); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return "", fmt.Errorf("target note already exists: %s", newPath)
-		}
-		return "", fmt.Errorf("cannot link note: %w", err)
-	}
-	if err := os.Remove(oldPath); err != nil {
-		// Roll back the link so we don't leave both paths pointing to the
-		// same inode. Best-effort: a cleanup failure here isn't surfaced
-		// because the original error is more useful.
-		_ = os.Remove(newPath)
-		return "", fmt.Errorf("cannot remove old note: %w", err)
-	}
-	return newPath, nil
 }
 
 func registerUpdateFlags() {
@@ -175,13 +114,13 @@ func registerUpdateFlags() {
 	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
 	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
 	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")
-	updateCmd.Flags().String("slug", "", "update slug in frontmatter; does not rename the file")
-	updateCmd.Flags().Bool("no-slug", false, "remove slug from frontmatter")
-	updateCmd.Flags().String("type", "", "update type in frontmatter; does not rename the file")
-	updateCmd.Flags().Bool("no-type", false, "remove type from frontmatter")
+	updateCmd.Flags().String("slug", "", "slug for frontmatter; file is renamed to match")
+	updateCmd.Flags().Bool("no-slug", false, "remove slug from frontmatter; file is renamed to match")
+	updateCmd.Flags().String("type", "", "note type; file cache suffix is rewritten to match")
+	updateCmd.Flags().Bool("no-type", false, "remove type; file cache suffix is stripped to match")
 	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
 	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter")
-	updateCmd.Flags().Bool("sync-filename", false, "rename the file to match the frontmatter's slug/type cache")
+	updateCmd.Flags().String("date", "", "move the note to this date (YYYYMMDD); affects the year/month directory and filename prefix")
 	updateCmd.MarkFlagsMutuallyExclusive("slug", "no-slug")
 	updateCmd.MarkFlagsMutuallyExclusive("type", "no-type")
 	updateCmd.MarkFlagsMutuallyExclusive("tag", "no-tags")

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -23,7 +23,6 @@ func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 	return strings.TrimSpace(buf.String()), err
 }
 
-// TestUpdateTagsByID replaces tags on a note resolved by numeric ID.
 func TestUpdateTagsByID(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--tag", "new1", "--tag", "new2")
@@ -31,12 +30,7 @@ func TestUpdateTagsByID(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
-
-	data, _ := os.ReadFile(want)
+	data, _ := os.ReadFile(out)
 	content := string(data)
 	if !strings.Contains(content, "tags:\n    - new1\n    - new2\n") {
 		t.Errorf("expected updated tags in frontmatter, got:\n%s", content)
@@ -46,7 +40,6 @@ func TestUpdateTagsByID(t *testing.T) {
 	}
 }
 
-// TestUpdateNoTags clears all tags.
 func TestUpdateNoTags(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--no-tags")
@@ -60,31 +53,12 @@ func TestUpdateNoTags(t *testing.T) {
 	}
 }
 
-// TestUpdateSlugChangesFrontmatterOnly: --slug rewrites frontmatter but leaves filename.
-func TestUpdateSlugChangesFrontmatterOnly(t *testing.T) {
+// TestUpdateSlugRenamesFile: --slug updates frontmatter AND renames the file.
+func TestUpdateSlugRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
 	origPath := filepath.Join(root, "2026/01/20260106_8823_999.md")
 
 	out, err := runUpdate(t, root, "8823", "--slug", "renamed")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != origPath {
-		t.Errorf("got path %q, want %q (should not rename)", out, origPath)
-	}
-	if _, err := os.Stat(origPath); err != nil {
-		t.Errorf("original file missing: %v", err)
-	}
-	data, _ := os.ReadFile(origPath)
-	if !strings.Contains(string(data), "slug: renamed") {
-		t.Errorf("expected updated slug in frontmatter, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateSlugWithSyncFilenameRenames: --slug + --sync-filename renames the file.
-func TestUpdateSlugWithSyncFilenameRenames(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8823", "--slug", "renamed", "--sync-filename")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,33 +69,20 @@ func TestUpdateSlugWithSyncFilenameRenames(t *testing.T) {
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("new file does not exist: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(root, "2026/01/20260106_8823_999.md")); err == nil {
-		t.Error("old file should have been removed")
+	if _, err := os.Stat(origPath); !os.IsNotExist(err) {
+		t.Errorf("old file should have been removed, err=%v", err)
+	}
+
+	data, _ := os.ReadFile(want)
+	if !strings.Contains(string(data), "slug: renamed") {
+		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateNoSlugClearsSlugFromFrontmatter: --no-slug removes slug from frontmatter only.
-func TestUpdateNoSlugClearsSlugFromFrontmatter(t *testing.T) {
+func TestUpdateNoSlugRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
-	origPath := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
 
 	out, err := runUpdate(t, root, "8818", "--no-slug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != origPath {
-		t.Errorf("got path %q, want %q (should not rename)", out, origPath)
-	}
-	data, _ := os.ReadFile(origPath)
-	if strings.Contains(string(data), "slug:") {
-		t.Errorf("expected slug removed, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateNoSlugWithSyncFilenameRenames: --no-slug + --sync-filename renames file.
-func TestUpdateNoSlugWithSyncFilenameRenames(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8818", "--no-slug", "--sync-filename")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,36 +90,16 @@ func TestUpdateNoSlugWithSyncFilenameRenames(t *testing.T) {
 	if out != want {
 		t.Errorf("got path %q, want %q", out, want)
 	}
-	if _, err := os.Stat(filepath.Join(root, "2026/01/20260104_8818_meeting.md")); err == nil {
-		t.Error("old file should have been removed")
+	if _, err := os.Stat(filepath.Join(root, "2026/01/20260104_8818_meeting.md")); !os.IsNotExist(err) {
+		t.Errorf("old slugged file should be gone, err=%v", err)
 	}
 }
 
-// TestUpdateTypeChangesFrontmatterOnly: --type rewrites frontmatter but leaves filename.
-func TestUpdateTypeChangesFrontmatterOnly(t *testing.T) {
+// TestUpdateTypeRenamesFile: --type rewrites frontmatter and cache suffix.
+func TestUpdateTypeRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
-	origPath := filepath.Join(root, "2026/01/20260106_8823_999.md")
 
 	out, err := runUpdate(t, root, "8823", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != origPath {
-		t.Errorf("got path %q, want %q (should not rename)", out, origPath)
-	}
-	if _, err := os.Stat(origPath); err != nil {
-		t.Errorf("original file missing: %v", err)
-	}
-	data, _ := os.ReadFile(origPath)
-	if !strings.Contains(string(data), "type: todo") {
-		t.Errorf("expected updated type in frontmatter, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateTypeWithSyncFilenameRenames: --type + --sync-filename renames the file.
-func TestUpdateTypeWithSyncFilenameRenames(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8823", "--type", "todo", "--sync-filename")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,39 +108,18 @@ func TestUpdateTypeWithSyncFilenameRenames(t *testing.T) {
 		t.Errorf("got path %q, want %q", out, want)
 	}
 	if _, err := os.Stat(want); err != nil {
-		t.Errorf("new file does not exist: %v", err)
+		t.Errorf("new file missing: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(root, "2026/01/20260106_8823_999.md")); err == nil {
-		t.Error("old file should have been removed")
+	data, _ := os.ReadFile(want)
+	if !strings.Contains(string(data), "type: todo") {
+		t.Errorf("expected type in frontmatter, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateNoTypeClearsTypeFromFrontmatter: --no-type clears frontmatter type only.
-func TestUpdateNoTypeClearsTypeFromFrontmatter(t *testing.T) {
+func TestUpdateNoTypeRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
-	// 8814 has type "todo" reported by filename (no fm type).
-	origPath := filepath.Join(root, "2026/01/20260102_8814.todo.md")
 
 	out, err := runUpdate(t, root, "8814", "--no-type")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != origPath {
-		t.Errorf("got path %q, want %q (should not rename)", out, origPath)
-	}
-	if _, err := os.Stat(origPath); err != nil {
-		t.Errorf("original file missing: %v", err)
-	}
-	data, _ := os.ReadFile(origPath)
-	if strings.Contains(string(data), "type:") {
-		t.Errorf("expected type removed, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateNoTypeWithSyncFilenameRenames: --no-type + --sync-filename renames file.
-func TestUpdateNoTypeWithSyncFilenameRenames(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8814", "--no-type", "--sync-filename")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,242 +127,172 @@ func TestUpdateNoTypeWithSyncFilenameRenames(t *testing.T) {
 	if out != want {
 		t.Errorf("got path %q, want %q", out, want)
 	}
-	if _, err := os.Stat(filepath.Join(root, "2026/01/20260102_8814.todo.md")); err == nil {
-		t.Error("old file should have been removed")
+	if _, err := os.Stat(filepath.Join(root, "2026/01/20260102_8814.todo.md")); !os.IsNotExist(err) {
+		t.Errorf("old typed file should be gone, err=%v", err)
 	}
 }
 
-// TestUpdateTitle updates the title field in frontmatter.
+func TestUpdateDateMovesFile(t *testing.T) {
+	root := copyTestdata(t)
+
+	out, err := runUpdate(t, root, "8823", "--date", "20260301")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(root, "2026/03/20260301_8823_999.md")
+	if out != want {
+		t.Errorf("got path %q, want %q", out, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("new file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "2026/01/20260106_8823_999.md")); !os.IsNotExist(err) {
+		t.Errorf("old file should be gone, err=%v", err)
+	}
+}
+
+func TestUpdateDateInvalidFormat(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runUpdate(t, root, "8823", "--date", "2026-03-01")
+	if err == nil {
+		t.Fatal("expected error for invalid date format")
+	}
+}
+
 func TestUpdateTitle(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--title", "My Title")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	data, _ := os.ReadFile(out)
 	if !strings.Contains(string(data), "title: My Title") {
 		t.Errorf("expected title in frontmatter, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateClearTitle removes the title field when set to empty string.
 func TestUpdateClearTitle(t *testing.T) {
 	root := copyTestdata(t)
-	// First set a title
 	if _, err := runUpdate(t, root, "8823", "--title", "To Remove"); err != nil {
-		t.Fatalf("unexpected error setting title: %v", err)
+		t.Fatalf("set: %v", err)
 	}
-	// Then clear it
 	out, err := runUpdate(t, root, "8823", "--title", "")
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("clear: %v", err)
 	}
-
 	data, _ := os.ReadFile(out)
 	if strings.Contains(string(data), "title:") {
-		t.Errorf("expected title removed from frontmatter, got:\n%s", string(data))
+		t.Errorf("title should be cleared, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateDescription updates the description field.
 func TestUpdateDescription(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--description", "Some desc")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	data, _ := os.ReadFile(out)
 	if !strings.Contains(string(data), "description: Some desc") {
 		t.Errorf("expected description in frontmatter, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateNoFlagsErrors verifies that update with no flags returns an error.
 func TestUpdateNoFlagsErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823")
 	if err == nil {
-		t.Fatal("expected error when no update flags provided, got nil")
-	}
-	if !strings.Contains(err.Error(), "at least one update flag is required") {
-		t.Errorf("unexpected error message: %v", err)
+		t.Fatal("expected error when no update flags given")
 	}
 }
 
-// TestUpdateNonExistentNoteErrors returns an error for an unknown ref.
 func TestUpdateNonExistentNoteErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "9999", "--tag", "x")
 	if err == nil {
-		t.Fatal("expected error for non-existent note, got nil")
+		t.Fatal("expected error for non-existent id")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
 	}
 }
 
-// TestUpdateSlugAndNoSlugConflict verifies --slug and --no-slug cannot be used together.
+func TestUpdateNonIntegerArgErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runUpdate(t, root, "meeting", "--tag", "x")
+	if err == nil {
+		t.Fatal("expected error for non-integer id")
+	}
+}
+
 func TestUpdateSlugAndNoSlugConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8818", "--slug", "other", "--no-slug")
 	if err == nil {
-		t.Fatal("expected error for --slug and --no-slug together, got nil")
-	}
-	if !strings.Contains(err.Error(), "slug") || !strings.Contains(err.Error(), "no-slug") {
-		t.Errorf("expected error mentioning both flags, got: %v", err)
+		t.Fatal("expected error when both --slug and --no-slug are set")
 	}
 }
 
-// TestUpdateTagAndNoTagsConflict verifies --tag and --no-tags cannot be used together.
 func TestUpdateTagAndNoTagsConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--tag", "foo", "--no-tags")
 	if err == nil {
-		t.Fatal("expected error for --tag and --no-tags together, got nil")
-	}
-	if !strings.Contains(err.Error(), "tag") || !strings.Contains(err.Error(), "no-tags") {
-		t.Errorf("expected error mentioning both flags, got: %v", err)
+		t.Fatal("expected error when both --tag and --no-tags are set")
 	}
 }
 
-// TestUpdateTypeAndNoTypeConflict verifies --type and --no-type cannot be used together.
 func TestUpdateTypeAndNoTypeConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8814", "--type", "backlog", "--no-type")
 	if err == nil {
-		t.Fatal("expected error for --type and --no-type together, got nil")
-	}
-	if !strings.Contains(err.Error(), "type") || !strings.Contains(err.Error(), "no-type") {
-		t.Errorf("expected error mentioning both flags, got: %v", err)
+		t.Fatal("expected error when both --type and --no-type are set")
 	}
 }
 
-// TestUpdateBodyPreserved ensures note body is preserved after frontmatter update.
 func TestUpdateBodyPreserved(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--tag", "updated")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	data, _ := os.ReadFile(out)
-	content := string(data)
-	if !strings.Contains(content, "# Plain note") {
-		t.Errorf("body content not preserved after update, got:\n%s", content)
+	if !strings.Contains(string(data), "# Plain note") {
+		t.Errorf("body content missing, got:\n%s", string(data))
 	}
 }
 
-// TestUpdateSlugSyncsToFrontmatter verifies that --slug also sets the slug frontmatter field.
-func TestUpdateSlugSyncsToFrontmatter(t *testing.T) {
-	root := copyTestdata(t)
-	out, err := runUpdate(t, root, "8823", "--slug", "new-slug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if !strings.Contains(string(data), "slug: new-slug") {
-		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateNoSlugRemovesSlugFromFrontmatter verifies that --no-slug removes the slug frontmatter field.
-func TestUpdateNoSlugRemovesSlugFromFrontmatter(t *testing.T) {
-	root := copyTestdata(t)
-	// First add a slug to frontmatter on note 8823
-	_, err := runUpdate(t, root, "8823", "--slug", "to-remove")
-	if err != nil {
-		t.Fatalf("unexpected error setting slug: %v", err)
-	}
-	// Then remove it
-	out, err := runUpdate(t, root, "8823", "--no-slug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if strings.Contains(string(data), "slug:") {
-		t.Errorf("expected slug removed from frontmatter, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateNoFlagDoesNotTouchFrontmatterSlug verifies that unrelated updates don't clobber an existing frontmatter slug.
-func TestUpdateNoFlagDoesNotTouchFrontmatterSlug(t *testing.T) {
-	root := copyTestdata(t)
-	// Give note 8823 a slug in frontmatter
-	_, err := runUpdate(t, root, "8823", "--slug", "keep-me")
-	if err != nil {
-		t.Fatalf("unexpected error setting slug: %v", err)
-	}
-	// Update only the title — slug flags are NOT passed
-	out, err := runUpdate(t, root, "8823", "--title", "New Title")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if !strings.Contains(string(data), "slug: keep-me") {
-		t.Errorf("expected slug frontmatter to be preserved, got:\n%s", string(data))
-	}
-}
-
-// TestUpdatePublicSetsPublicField verifies that --public writes public: true to frontmatter.
 func TestUpdatePublicSetsPublicField(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--public")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
+	data, _ := os.ReadFile(out)
 	if !strings.Contains(string(data), "public: true") {
-		t.Errorf("expected public: true in frontmatter, got:\n%s", string(data))
+		t.Errorf("expected public: true, got:\n%s", string(data))
 	}
 }
 
-// TestUpdatePrivateRemovesPublicField verifies that --private removes public: true from frontmatter.
 func TestUpdatePrivateRemovesPublicField(t *testing.T) {
 	root := copyTestdata(t)
-	// First mark as public
-	_, err := runUpdate(t, root, "8823", "--public")
-	if err != nil {
-		t.Fatalf("unexpected error setting public: %v", err)
+	if _, err := runUpdate(t, root, "8823", "--public"); err != nil {
+		t.Fatalf("pre-set: %v", err)
 	}
-	// Then mark as private
 	out, err := runUpdate(t, root, "8823", "--private")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
+	data, _ := os.ReadFile(out)
 	if strings.Contains(string(data), "public:") {
-		t.Errorf("expected public field removed from frontmatter, got:\n%s", string(data))
+		t.Errorf("expected no public field, got:\n%s", string(data))
 	}
 }
 
-// TestUpdatePublicAndPrivateConflict verifies --public and --private cannot be used together.
 func TestUpdatePublicAndPrivateConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--public", "--private")
 	if err == nil {
-		t.Fatal("expected error for --public and --private together, got nil")
-	}
-	if !strings.Contains(err.Error(), "public") || !strings.Contains(err.Error(), "private") {
-		t.Errorf("expected error mentioning both flags, got: %v", err)
+		t.Fatal("expected error when both --public and --private are set")
 	}
 }
 
@@ -450,122 +300,6 @@ func TestUpdateAllDigitSlugErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--slug", "123")
 	if err == nil {
-		t.Fatal("expected error for all-digit slug, got nil")
-	}
-}
-
-// TestUpdateNoPublicFlagPreservesPublicField verifies unrelated updates don't touch the public field.
-func TestUpdateNoPublicFlagPreservesPublicField(t *testing.T) {
-	root := copyTestdata(t)
-	// Mark as public
-	_, err := runUpdate(t, root, "8823", "--public")
-	if err != nil {
-		t.Fatalf("unexpected error setting public: %v", err)
-	}
-	// Update only the title — no public/private flag
-	out, err := runUpdate(t, root, "8823", "--title", "New Title")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	data, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatalf("read note: %v", err)
-	}
-	if !strings.Contains(string(data), "public: true") {
-		t.Errorf("expected public: true preserved after unrelated update, got:\n%s", string(data))
-	}
-}
-
-// TestUpdatePreservesExtraFields ensures unknown frontmatter keys survive an update.
-func TestUpdatePreservesExtraFields(t *testing.T) {
-	root := copyTestdata(t)
-	// Pick an existing fixture note, overwrite its content to include custom keys.
-	notePath := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	seed := "---\ntitle: Original\nfeatured: true\ncustom_rating: 5\n---\n\nbody\n"
-	if err := os.WriteFile(notePath, []byte(seed), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := runUpdate(t, root, "8823", "--title", "New Title"); err != nil {
-		t.Fatalf("update: %v", err)
-	}
-
-	data, _ := os.ReadFile(notePath)
-	if !strings.Contains(string(data), "title: New Title") {
-		t.Errorf("expected new title, got:\n%s", string(data))
-	}
-	if !strings.Contains(string(data), "featured: true") {
-		t.Errorf("featured dropped, got:\n%s", string(data))
-	}
-	if !strings.Contains(string(data), "custom_rating: 5") {
-		t.Errorf("custom_rating dropped, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateDoesNotPromoteFilenameSlugToFrontmatter: an ordinary --title update
-// on a note whose filename carries a slug but whose frontmatter doesn't must
-// leave the frontmatter's absent slug absent. Frontmatter is canonical.
-func TestUpdateDoesNotPromoteFilenameSlugToFrontmatter(t *testing.T) {
-	root := copyTestdata(t)
-	notePath := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	// Seed with no slug/type in frontmatter; filename still has slug "999".
-	seed := "---\ntitle: Original\n---\n\nbody\n"
-	if err := os.WriteFile(notePath, []byte(seed), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := runUpdate(t, root, "8823", "--title", "New"); err != nil {
-		t.Fatalf("update: %v", err)
-	}
-
-	data, _ := os.ReadFile(notePath)
-	if strings.Contains(string(data), "slug:") {
-		t.Errorf("filename slug must not be promoted into frontmatter, got:\n%s", string(data))
-	}
-}
-
-// TestUpdateSyncFilenameOnly reconciles filename without any content flags.
-func TestUpdateSyncFilenameOnly(t *testing.T) {
-	root := copyTestdata(t)
-	// Seed a note whose frontmatter slug disagrees with its filename.
-	dir := filepath.Join(root, "2026", "01")
-	origPath := filepath.Join(dir, "20260106_8823_999.md")
-	seed := "---\ntitle: T\nslug: my-slug\ntype: meeting\n---\n\nbody\n"
-	if err := os.WriteFile(origPath, []byte(seed), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	out, err := runUpdate(t, root, "8823", "--sync-filename")
-	if err != nil {
-		t.Fatalf("--sync-filename: %v", err)
-	}
-	want := filepath.Join(dir, "20260106_8823_my-slug.meeting.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
-	if _, err := os.Stat(want); err != nil {
-		t.Errorf("new file missing: %v", err)
-	}
-	if _, err := os.Stat(origPath); !os.IsNotExist(err) {
-		t.Errorf("old file should be gone: err=%v", err)
-	}
-}
-
-// TestUpdateSyncFilenameNoOp: --sync-filename on an already-in-sync note is a no-op.
-func TestUpdateSyncFilenameNoOp(t *testing.T) {
-	root := copyTestdata(t)
-	origPath := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	// The fixture has empty fm slug; the filename-reported slug is "999" and
-	// fills in as fallback. Running sync should produce the same filename.
-	out, err := runUpdate(t, root, "8823", "--sync-filename")
-	if err != nil {
-		t.Fatalf("--sync-filename: %v", err)
-	}
-	if out != origPath {
-		t.Errorf("expected no rename, got path %q", out)
-	}
-	if _, err := os.Stat(origPath); err != nil {
-		t.Errorf("file moved or lost: %v", err)
+		t.Fatal("expected error for all-digit slug")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 10 of #215. `notes update` takes a plain `<id>` positional argument, applies flag values to `entry.Meta`, and saves via `store.Put`.

- Load/save go through `store.Get` / `store.Put`; `resolveRef`, `os.ReadFile`, `ParseNote`, `FormatNote`, `WriteAtomic`, and `syncNoteFilename` are deleted.
- `OSStore.Put` detects filename drift and renames atomically — the `--sync-filename` flag is removed. Updating `--slug`, `--no-slug`, `--type`, `--no-type`, or `--date` now always reconciles the filename.
- New `--date YYYYMMDD` flag moves the note to the requested date (year/month directory + filename prefix).
- All other flags (`--title`, `--description`, `--tag`/`--no-tags`, `--public`/`--private`) preserve their prior semantics.

Tests rewritten: the `--sync-filename` cases are gone; slug/type/date cases now assert both the frontmatter update and the automatic rename.

## References

- relates to #215
- closes #225
